### PR TITLE
Print contracts instead of code

### DIFF
--- a/flow/accounts/get/get.go
+++ b/flow/accounts/get/get.go
@@ -83,7 +83,7 @@ func printAccount(account *flow.Account, printCode bool) {
 	fmt.Println("  ---")
 	if printCode {
 		for name, code := range account.Contracts {
-			fmt.Printf("Code '%s':", name)
+			fmt.Printf("Code '%s':\n", name)
 			fmt.Println(string(code))
 		}
 	}

--- a/flow/accounts/get/get.go
+++ b/flow/accounts/get/get.go
@@ -82,8 +82,10 @@ func printAccount(account *flow.Account, printCode bool) {
 	}
 	fmt.Println("  ---")
 	if printCode {
-		fmt.Println("Code:")
-		fmt.Println(string(account.Code))
+		for name, code := range account.Contracts {
+			fmt.Printf("Code '%s':", name)
+			fmt.Println(string(code))
+		}
 	}
 	fmt.Println()
 }


### PR DESCRIPTION
The `Code` field is deprecated and empty now. Show all contracts instead.