### PR TITLE
Add update-contract command

### DIFF
--- a/flow/accounts/accounts.go
+++ b/flow/accounts/accounts.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/flow-cli/flow/accounts/create"
 	"github.com/onflow/flow-cli/flow/accounts/get"
+	"github.com/onflow/flow-cli/flow/accounts/update-contract"
 )
 
 var Cmd = &cobra.Command{
@@ -34,4 +35,5 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(create.Cmd)
 	Cmd.AddCommand(get.Cmd)
+	Cmd.AddCommand(update_contract.Cmd)
 }

--- a/flow/accounts/create/create.go
+++ b/flow/accounts/create/create.go
@@ -32,11 +32,11 @@ import (
 
 type Config struct {
 	Signer   string   `default:"service" flag:"signer,s"`
-	Keys     []string `flag:"key,k" info:"public keys to attach to account"`
-	SigAlgo  string   `default:"ECDSA_P256" flag:"sig-algo" info:"signature algorithm used to generate the keys"`
-	HashAlgo string   `default:"SHA3_256" flag:"hash-algo" info:"hash used for the digest"`
+	Keys     []string `flag:"key,k" info:"Public keys to attach to account"`
+	SigAlgo  string   `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm used to generate the keys"`
+	HashAlgo string   `default:"SHA3_256" flag:"hash-algo" info:"Hash used for the digest"`
 	Host     string   `flag:"host" info:"Flow Access API host address"`
-	Results  bool     `default:"false" flag:"results" info:"whether or not to wait for the results of the transaction"`
+	Results  bool     `default:"false" flag:"results" info:"Display the results of the transaction"`
 }
 
 var conf Config

--- a/flow/accounts/get/get.go
+++ b/flow/accounts/get/get.go
@@ -46,9 +46,14 @@ var Cmd = &cobra.Command{
 			projectConf = cli.LoadConfig()
 		}
 
-		acc := cli.GetAccount(projectConf.HostWithOverride(conf.Host), flow.HexToAddress(args[0]))
+		address := flow.HexToAddress(args[0])
 
-		printAccount(acc, conf.Code)
+		account := cli.GetAccount(
+			projectConf.HostWithOverride(conf.Host),
+			address,
+		)
+
+		printAccount(account, conf.Code)
 	},
 }
 
@@ -71,6 +76,7 @@ func printAccount(account *flow.Account, printCode bool) {
 	fmt.Println("Address: " + account.Address.Hex())
 	fmt.Println("Balance : ", cli.FormatUFix64(account.Balance))
 	fmt.Println("Total Keys: ", len(account.Keys))
+
 	for _, key := range account.Keys {
 		fmt.Println("  ---")
 		fmt.Println("  Key Index: ", key.Index)
@@ -80,12 +86,15 @@ func printAccount(account *flow.Account, printCode bool) {
 		fmt.Println("  Weight: ", key.Weight)
 		fmt.Println("  SequenceNumber: ", key.SequenceNumber)
 	}
+
 	fmt.Println("  ---")
+
 	if printCode {
 		for name, code := range account.Contracts {
 			fmt.Printf("Code '%s':\n", name)
 			fmt.Println(string(code))
 		}
 	}
+
 	fmt.Println()
 }

--- a/flow/accounts/update-contract/update.go
+++ b/flow/accounts/update-contract/update.go
@@ -1,0 +1,86 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package update_contract
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/onflow/flow-go-sdk/templates"
+	"github.com/psiemens/sconfig"
+	"github.com/spf13/cobra"
+
+	cli "github.com/onflow/flow-cli/flow"
+)
+
+type Config struct {
+	Signer   string   `default:"service" flag:"signer,s"`
+	Host     string   `flag:"host" info:"Flow Access API host address"`
+	Results  bool     `default:"false" flag:"results" info:"Display the results of the transaction"`
+}
+
+var conf Config
+
+var Cmd = &cobra.Command{
+	Use:   "update-contract <name> <filename>",
+	Short: "Update a contract deployed to an account",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		projectConf := cli.LoadConfig()
+
+		contractName := args[0]
+		contractFilename := args[1]
+
+		contractSource, err := ioutil.ReadFile(contractFilename)
+		if err != nil {
+			cli.Exitf(1, "Failed to read contract from source file %s", contractFilename)
+		}
+
+		signerAccount := projectConf.Accounts[conf.Signer]
+
+		tx := templates.UpdateAccountContract(
+			signerAccount.Address,
+			templates.Contract{
+				Name: contractName,
+				Source: string(contractSource),
+			},
+		)
+
+		cli.SendTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
+			conf.Results,
+		)
+	},
+}
+
+func init() {
+	initConfig()
+}
+
+func initConfig() {
+	err := sconfig.New(&conf).
+		FromEnvironment(cli.EnvPrefix).
+		BindFlags(Cmd.PersistentFlags()).
+		Parse()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/flow/cadence/languageserver/languageserver.go
+++ b/flow/cadence/languageserver/languageserver.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Config struct {
-	EnableFlowClient bool `default:"true" flag:"enableFlowClient" info:"enable Flow client functionality"`
+	EnableFlowClient bool `default:"true" flag:"enableFlowClient" info:"Enable Flow client functionality"`
 }
 
 var conf Config

--- a/flow/initialize/init.go
+++ b/flow/initialize/init.go
@@ -30,10 +30,10 @@ import (
 )
 
 type Config struct {
-	ServicePrivateKey  string `flag:"service-priv-key" info:"service account private key"`
-	ServiceKeySigAlgo  string `default:"ECDSA_P256" flag:"service-sig-algo" info:"service account key signature algorithm"`
-	ServiceKeyHashAlgo string `default:"SHA3_256" flag:"service-hash-algo" info:"service account key hash algorithm"`
-	Reset              bool   `default:"false" flag:"reset" info:"reset flow.json config file"`
+	ServicePrivateKey  string `flag:"service-priv-key" info:"Service account private key"`
+	ServiceKeySigAlgo  string `default:"ECDSA_P256" flag:"service-sig-algo" info:"Service account key signature algorithm"`
+	ServiceKeyHashAlgo string `default:"SHA3_256" flag:"service-hash-algo" info:"Service account key hash algorithm"`
+	Reset              bool   `default:"false" flag:"reset" info:"Reset flow.json config file"`
 }
 
 var (

--- a/flow/keys/generate/generate.go
+++ b/flow/keys/generate/generate.go
@@ -31,8 +31,8 @@ import (
 )
 
 type Config struct {
-	Seed    string `flag:"seed,s" info:"deterministic seed phrase"`
-	SigAlgo string `default:"ECDSA_P256" flag:"algo,a" info:"signature algorithm"`
+	Seed    string `flag:"seed,s" info:"Deterministic seed phrase"`
+	SigAlgo string `default:"ECDSA_P256" flag:"algo,a" info:"Signature algorithm"`
 }
 
 var conf Config

--- a/flow/transactions/send/send.go
+++ b/flow/transactions/send/send.go
@@ -33,7 +33,7 @@ type Config struct {
 	Signer  string `default:"service" flag:"signer,s"`
 	Code    string `flag:"code,c"`
 	Host    string `flag:"host" info:"Flow Access API host address"`
-	Results bool   `default:"false" flag:"results" info:"Whether or not to wait for the results of the transaction"`
+	Results bool   `default:"false" flag:"results" info:"Display the results of the transaction"`
 }
 
 var conf Config


### PR DESCRIPTION
Closes #3 

## Description

This PR adds the `flow accounts update-contract` command, which allows users to update a contract deployed to an account.

This new command makes use of the `templates.UpdateAccountContract` template from the latest release of the Flow Go SDK.

Misc. changes: 
- Updated flag capitalization to be consistent across all commands.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
