### PR TITLE
Add tx result code toggle

### DIFF
--- a/flow/accounts/get/get.go
+++ b/flow/accounts/get/get.go
@@ -85,6 +85,7 @@ func printAccount(account *flow.Account, printCode bool) {
 		fmt.Println("  HashAlgo: ", key.HashAlgo)
 		fmt.Println("  Weight: ", key.Weight)
 		fmt.Println("  SequenceNumber: ", key.SequenceNumber)
+		fmt.Println("  Revoked: ", key.Revoked)
 	}
 
 	fmt.Println("  ---")

--- a/flow/result.go
+++ b/flow/result.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func GetTransactionResult(host string, id string, sealed bool) {
+func GetTransactionResult(host string, id string, sealed bool, showTransactionCode bool) {
 	ctx := context.Background()
 
 	flowClient, err := client.New(host, grpc.WithInsecure())
@@ -55,7 +55,7 @@ func GetTransactionResult(host string, id string, sealed bool) {
 	}
 
 	// Print out results of the TX to std out
-	printTxResult(tx, res)
+	printTxResult(tx, res, showTransactionCode)
 }
 
 func waitForSeal(ctx context.Context, c *client.Client, id flow.Identifier) (*flow.TransactionResult, error) {
@@ -80,16 +80,17 @@ func waitForSeal(ctx context.Context, c *client.Client, id flow.Identifier) (*fl
 	return result, nil
 }
 
-func printTxResult(tx *flow.Transaction, res *flow.TransactionResult) {
+func printTxResult(tx *flow.Transaction, res *flow.TransactionResult, showCode bool) {
 	fmt.Println()
 	fmt.Println("Status: " + res.Status.String())
 	if res.Error != nil {
 		fmt.Println("Execution Error: " + res.Error.Error())
-		return
 	}
 
-	fmt.Println("Code: ")
-	fmt.Println(string(tx.Script))
+	if showCode {
+		fmt.Println("Code: ")
+		fmt.Println(string(tx.Script))
+	}
 
 	fmt.Println("Events:")
 	printEvents(res.Events, false)

--- a/flow/send.go
+++ b/flow/send.go
@@ -74,6 +74,6 @@ func SendTransaction(host string, signerAccount *Account, tx *flow.Transaction, 
 		if err != nil {
 			Exitf(1, "Failed to seal transaction: %s", err)
 		}
-		printTxResult(tx, res)
+		printTxResult(tx, res, true)
 	}
 }

--- a/flow/transactions/status/status.go
+++ b/flow/transactions/status/status.go
@@ -30,6 +30,7 @@ import (
 type Config struct {
 	Host   string `flag:"host" info:"Flow Access API host address"`
 	Sealed bool   `default:"true" flag:"sealed" info:"Wait for a sealed result"`
+	Code   bool   `default:"false" flag:"code" info:"Display transaction code"`
 }
 
 var conf Config
@@ -43,7 +44,7 @@ var Cmd = &cobra.Command{
 		if conf.Host == "" {
 			projectConf = cli.LoadConfig()
 		}
-		cli.GetTransactionResult(projectConf.HostWithOverride(conf.Host), args[0], conf.Sealed)
+		cli.GetTransactionResult(projectConf.HostWithOverride(conf.Host), args[0], conf.Sealed, conf.Code)
 	},
 }
 


### PR DESCRIPTION
## Description

Adds a `--code` toggle to the tx result command, to allow toggling whether we want to display the transaction code or now.

Also added a small update to show the `Revoked` field for keys.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
