### PR TITLE
Add back contract deployment

### DIFF
--- a/flow/accounts/create/create.go
+++ b/flow/accounts/create/create.go
@@ -33,13 +33,13 @@ import (
 )
 
 type Config struct {
-	Signer   string   `default:"service" flag:"signer,s"`
-	Keys     []string `flag:"key,k" info:"Public keys to attach to account"`
-	SigAlgo  string   `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm used to generate the keys"`
-	HashAlgo string   `default:"SHA3_256" flag:"hash-algo" info:"Hash used for the digest"`
-	Host     string   `flag:"host" info:"Flow Access API host address"`
-	Results  bool     `default:"false" flag:"results" info:"Display the results of the transaction"`
-	Contract string   `flag:"contract,c" info:"Contract to be deployed during account creation. <name:path>"`
+	Signer    string   `default:"service" flag:"signer,s"`
+	Keys      []string `flag:"key,k" info:"Public keys to attach to account"`
+	SigAlgo   string   `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm used to generate the keys"`
+	HashAlgo  string   `default:"SHA3_256" flag:"hash-algo" info:"Hash used for the digest"`
+	Host      string   `flag:"host" info:"Flow Access API host address"`
+	Results   bool     `default:"false" flag:"results" info:"Display the results of the transaction"`
+	Contracts []string `flag:"contract,c" info:"Contract to be deployed during account creation. <name:path>"`
 }
 
 var conf Config
@@ -73,12 +73,12 @@ var Cmd = &cobra.Command{
 			}
 		}
 
-		var contracts []templates.Contract
+		contracts := []templates.Contract{}
 
-		if len(conf.Contract) > 0 {
-			contractFlagContent := strings.Split(conf.Contract, ":")
+		for _, contract := range conf.Contracts {
+			contractFlagContent := strings.SplitN(contract, ":", 2)
 			if len(contractFlagContent) != 2 {
-				cli.Exitf(1, "Failed to read contract name and path from flag. Ensure you're providing a contract name and a file path. %s", conf.Contract)
+				cli.Exitf(1, "Failed to read contract name and path from flag. Ensure you're providing a contract name and a file path. %s", contract)
 			}
 			contractName := contractFlagContent[0]
 			contractPath := contractFlagContent[1]


### PR DESCRIPTION
Closes #2 

## Description

Adds a `--contract` flag to allow deploying a contract along with account creation.

How do we feel about the requirement for the flag contents to be `name:filepath`?

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
