### PR TITLE
Add add-contract command

### DIFF
--- a/flow/accounts/accounts.go
+++ b/flow/accounts/accounts.go
@@ -21,6 +21,7 @@ package accounts
 import (
 	"github.com/spf13/cobra"
 
+	add_contract "github.com/onflow/flow-cli/flow/accounts/add-contract"
 	"github.com/onflow/flow-cli/flow/accounts/create"
 	"github.com/onflow/flow-cli/flow/accounts/get"
 	"github.com/onflow/flow-cli/flow/accounts/update-contract"
@@ -35,5 +36,6 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(create.Cmd)
 	Cmd.AddCommand(get.Cmd)
+	Cmd.AddCommand(add_contract.Cmd)
 	Cmd.AddCommand(update_contract.Cmd)
 }

--- a/flow/accounts/add-contract/add.go
+++ b/flow/accounts/add-contract/add.go
@@ -1,0 +1,86 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package add_contract
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/onflow/flow-go-sdk/templates"
+	"github.com/psiemens/sconfig"
+	"github.com/spf13/cobra"
+
+	cli "github.com/onflow/flow-cli/flow"
+)
+
+type Config struct {
+	Signer   string   `default:"service" flag:"signer,s"`
+	Host     string   `flag:"host" info:"Flow Access API host address"`
+	Results  bool     `default:"false" flag:"results" info:"Display the results of the transaction"`
+}
+
+var conf Config
+
+var Cmd = &cobra.Command{
+	Use:   "add-contract <name> <filename>",
+	Short: "Deploy a new contract to an account",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		projectConf := cli.LoadConfig()
+
+		contractName := args[0]
+		contractFilename := args[1]
+
+		contractSource, err := ioutil.ReadFile(contractFilename)
+		if err != nil {
+			cli.Exitf(1, "Failed to read contract from source file %s", contractFilename)
+		}
+
+		signerAccount := projectConf.Accounts[conf.Signer]
+
+		tx := templates.AddAccountContract(
+			signerAccount.Address,
+			templates.Contract{
+				Name: contractName,
+				Source: string(contractSource),
+			},
+		)
+
+		cli.SendTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
+			conf.Results,
+		)
+	},
+}
+
+func init() {
+	initConfig()
+}
+
+func initConfig() {
+	err := sconfig.New(&conf).
+		FromEnvironment(cli.EnvPrefix).
+		BindFlags(Cmd.PersistentFlags()).
+		Parse()
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds the `flow accounts add-contract` command, which allows users to deploy a new contract to an account.

This new command makes use of the `templates.AddAccountContract` template from the latest release of the Flow Go SDK.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
