### PR TITLE
Set default service account key type to hex

### DIFF
--- a/flow/config.go
+++ b/flow/config.go
@@ -185,6 +185,7 @@ func (c *Config) ServiceAccount() *Account {
 
 func (c *Config) SetServiceAccountKey(privateKey crypto.PrivateKey, hashAlgo crypto.HashAlgorithm) {
 	c.Accounts[serviceAccountName] = &Account{
+		KeyType:    KeyTypeHex,
 		Address:    flow.ServiceAddress(flow.Emulator),
 		PrivateKey: privateKey,
 		SigAlgo:    privateKey.Algorithm(),


### PR DESCRIPTION
Closes #16 

## Description

This fixes a bug in `SetServiceAccountKey` that was inserting a `cli.Account` into the `Config` struct without specifying a key type, which was causing the JSON marshaller to fail in the `flow init` command.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
