### PR TITLE
Rename deployment fix

### DIFF
--- a/flow/project/cli/config/config.go
+++ b/flow/project/cli/config/config.go
@@ -25,17 +25,17 @@ import (
 )
 
 type Config struct {
-	Emulators Emulators
-	Contracts Contracts
-	Networks  Networks
-	Accounts  Accounts
-	Deploys   Deploys
+	Emulators   Emulators
+	Contracts   Contracts
+	Networks    Networks
+	Accounts    Accounts
+	Deployments Deployments
 }
 
 type Contracts []Contract
 type Networks []Network
 type Accounts []Account
-type Deploys []Deploy
+type Deployments []Deploy
 type Emulators []Emulator
 
 // Network config sets host and chain id
@@ -146,15 +146,15 @@ func (a *Accounts) GetByAddress(address string) Account {
 	}).([]Account)[0]
 }
 
-// GetByNetwork get all deploys by network
-func (d *Deploys) GetByNetwork(network string) Deploys {
+// GetByNetwork get all deployments by network
+func (d *Deployments) GetByNetwork(network string) Deployments {
 	return funk.Filter([]Deploy(*d), func(d Deploy) bool {
 		return d.Network == network
 	}).([]Deploy)
 }
 
 // GetByAccountAndNetwork get deploy by account and network
-func (d *Deploys) GetByAccountAndNetwork(account string, network string) []Deploy {
+func (d *Deployments) GetByAccountAndNetwork(account string, network string) []Deploy {
 	return funk.Filter([]Deploy(*d), func(d Deploy) bool {
 		return d.Account == account && d.Network == network
 	}).([]Deploy)

--- a/flow/project/cli/config/config_test.go
+++ b/flow/project/cli/config/config_test.go
@@ -57,7 +57,7 @@ func generateComplexConfig() Config {
 			Source:  "0x123123123",
 			Network: "testnet",
 		}},
-		Deploys: Deploys{{
+		Deployments: Deployments{{
 			Network:   "emulator",
 			Account:   "emulator-account",
 			Contracts: []string{"KittyItems", "KittyItemsMarket"},
@@ -162,11 +162,11 @@ func Test_GetAccountByAddressComplex(t *testing.T) {
 	assert.Equal(t, acc2.Name, "account-2")
 }
 
-func Test_GetDeploysByNetworkComplex(t *testing.T) {
+func Test_GetDeploymentsByNetworkComplex(t *testing.T) {
 	conf := generateComplexConfig()
-	deploys := conf.Deploys.GetByAccountAndNetwork("account-2", "testnet")
+	deployments := conf.Deployments.GetByAccountAndNetwork("account-2", "testnet")
 
-	assert.Equal(t, deploys[0].Contracts, []string{"FungibleToken", "NonFungibleToken", "Kibble", "KittyItems"})
+	assert.Equal(t, deployments[0].Contracts, []string{"FungibleToken", "NonFungibleToken", "Kibble", "KittyItems"})
 }
 
 func Test_GetNetworkByNameComplex(t *testing.T) {

--- a/flow/project/cli/config/json/config.go
+++ b/flow/project/cli/config/json/config.go
@@ -29,30 +29,30 @@ import (
 )
 
 type jsonConfig struct {
-	Emulators jsonEmulators `json:"emulators"`
-	Contracts jsonContracts `json:"contracts"`
-	Networks  jsonNetworks  `json:"networks"`
-	Accounts  jsonAccounts  `json:"accounts"`
-	Deploys   jsonDeploys   `json:"deploys"`
+	Emulators   jsonEmulators   `json:"emulators"`
+	Contracts   jsonContracts   `json:"contracts"`
+	Networks    jsonNetworks    `json:"networks"`
+	Accounts    jsonAccounts    `json:"accounts"`
+	Deployments jsonDeployments `json:"deployments"`
 }
 
 func (j jsonConfig) transformToConfig() *config.Config {
 	return &config.Config{
-		Emulators: j.Emulators.transformToConfig(),
-		Contracts: j.Contracts.transformToConfig(),
-		Networks:  j.Networks.transformToConfig(),
-		Accounts:  j.Accounts.transformToConfig(),
-		Deploys:   j.Deploys.transformToConfig(),
+		Emulators:   j.Emulators.transformToConfig(),
+		Contracts:   j.Contracts.transformToConfig(),
+		Networks:    j.Networks.transformToConfig(),
+		Accounts:    j.Accounts.transformToConfig(),
+		Deployments: j.Deployments.transformToConfig(),
 	}
 }
 
 func transformConfigToJSON(config *config.Config) jsonConfig {
 	return jsonConfig{
-		Emulators: transformEmulatorsToJSON(config.Emulators),
-		Contracts: transformContractsToJSON(config.Contracts),
-		Networks:  transformNetworksToJSON(config.Networks),
-		Accounts:  transformAccountsToJSON(config.Accounts),
-		Deploys:   transformDeploysToJSON(config.Deploys),
+		Emulators:   transformEmulatorsToJSON(config.Emulators),
+		Contracts:   transformContractsToJSON(config.Contracts),
+		Networks:    transformNetworksToJSON(config.Networks),
+		Accounts:    transformAccountsToJSON(config.Accounts),
+		Deployments: transformDeploymentsToJSON(config.Deployments),
 	}
 }
 

--- a/flow/project/cli/config/json/deploy.go
+++ b/flow/project/cli/config/json/deploy.go
@@ -24,11 +24,11 @@ import (
 	"github.com/onflow/flow-cli/flow/project/cli/config"
 )
 
-type jsonDeploys map[string]jsonDeploy
+type jsonDeployments map[string]jsonDeploy
 
 // transformToConfig transforms json structures to config structure
-func (j jsonDeploys) transformToConfig() config.Deploys {
-	deploys := make(config.Deploys, 0)
+func (j jsonDeployments) transformToConfig() config.Deployments {
+	deployments := make(config.Deployments, 0)
 
 	for networkName, d := range j {
 		for accountName, contracts := range d.Simple {
@@ -38,22 +38,22 @@ func (j jsonDeploys) transformToConfig() config.Deploys {
 				Contracts: contracts,
 			}
 
-			deploys = append(deploys, deploy)
+			deployments = append(deployments, deploy)
 		}
 	}
 
-	return deploys
+	return deployments
 }
 
 // transformToJSON transforms config structure to json structures for saving
-func transformDeploysToJSON(deploys config.Deploys) jsonDeploys {
-	jsonDeploys := jsonDeploys{}
+func transformDeploymentsToJSON(deployments config.Deployments) jsonDeployments {
+	jsonDeployments := jsonDeployments{}
 
-	for _, d := range deploys {
-		if _, exists := jsonDeploys[d.Network]; exists {
-			jsonDeploys[d.Network].Simple[d.Account] = d.Contracts
+	for _, d := range deployments {
+		if _, exists := jsonDeployments[d.Network]; exists {
+			jsonDeployments[d.Network].Simple[d.Account] = d.Contracts
 		} else {
-			jsonDeploys[d.Network] = jsonDeploy{
+			jsonDeployments[d.Network] = jsonDeploy{
 				Simple: map[string][]string{
 					d.Account: d.Contracts,
 				},
@@ -61,7 +61,7 @@ func transformDeploysToJSON(deploys config.Deploys) jsonDeploys {
 		}
 	}
 
-	return jsonDeploys
+	return jsonDeployments
 }
 
 type Simple map[string][]string

--- a/flow/project/cli/config/json/deploy_test.go
+++ b/flow/project/cli/config/json/deploy_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ConfigDeploySimple(t *testing.T) {
+func Test_ConfigDeploymentsSimple(t *testing.T) {
 	b := []byte(`{
 		"testnet": {
 			"account-2": ["FungibleToken", "NonFungibleToken", "Kibble", "KittyItems"]
@@ -36,32 +36,33 @@ func Test_ConfigDeploySimple(t *testing.T) {
 		}
 	}`)
 
-	var jsonDeploys jsonDeploys
-	err := json.Unmarshal(b, &jsonDeploys)
+	var jsonDeployments jsonDeployments
+	err := json.Unmarshal(b, &jsonDeployments)
 	require.NoError(t, err)
 
-	deploys := jsonDeploys.transformToConfig()
+	deployments := jsonDeployments.transformToConfig()
 
-	assert.Equal(t, deploys.GetByAccountAndNetwork("account-2", "testnet")[0].Account, "account-2")
-	assert.Equal(t, deploys.GetByAccountAndNetwork("account-2", "testnet")[0].Contracts, []string{"FungibleToken", "NonFungibleToken", "Kibble", "KittyItems"})
+	//TODO: fix test to be sorted since its not necessary correct order
+	assert.Equal(t, "account-2", deployments.GetByNetwork("testnet")[0].Account)
+	assert.Equal(t, []string{"FungibleToken", "NonFungibleToken", "Kibble", "KittyItems"}, deployments.GetByNetwork("testnet")[0].Contracts)
 
-	assert.Len(t, deploys.GetByNetwork("emulator"), 2)
-	assert.Equal(t, deploys.GetByAccountAndNetwork("account-3", "emulator")[0].Account, "account-3")
-	assert.Equal(t, deploys.GetByAccountAndNetwork("account-4", "emulator")[0].Account, "account-4")
-	assert.Equal(t, deploys.GetByAccountAndNetwork("account-3", "emulator")[0].Contracts, []string{"KittyItems", "KittyItemsMarket"})
-	assert.Equal(t, deploys.GetByAccountAndNetwork("account-4", "emulator")[0].Contracts, []string{"FungibleToken", "NonFungibleToken", "Kibble", "KittyItems", "KittyItemsMarket"})
+	assert.Equal(t, 2, len(deployments.GetByNetwork("emulator")))
+	assert.Equal(t, "account-3", deployments.GetByNetwork("emulator")[0].Account)
+	assert.Equal(t, "account-4", deployments.GetByNetwork("emulator")[1].Account)
+	assert.Equal(t, []string{"KittyItems", "KittyItemsMarket"}, deployments.GetByNetwork("emulator")[0].Contracts)
+	assert.Equal(t, []string{"FungibleToken", "NonFungibleToken", "Kibble", "KittyItems", "KittyItemsMarket"}, deployments.GetByNetwork("emulator")[1].Contracts)
 }
 
 func Test_TransformDeployToJSON(t *testing.T) {
 	b := []byte(`{"emulator":{"account-3":["KittyItems","KittyItemsMarket"],"account-4":["FungibleToken","NonFungibleToken","Kibble","KittyItems","KittyItemsMarket"]},"testnet":{"account-2":["FungibleToken","NonFungibleToken","Kibble","KittyItems"]}}`)
 
-	var jsonDeploys jsonDeploys
-	err := json.Unmarshal(b, &jsonDeploys)
+	var jsonDeployments jsonDeployments
+	err := json.Unmarshal(b, &jsonDeployments)
 	require.NoError(t, err)
 
-	deploys := jsonDeploys.transformToConfig()
+	deployments := jsonDeployments.transformToConfig()
 
-	j := transformDeploysToJSON(deploys)
+	j := transformDeploymentsToJSON(deployments)
 	x, _ := json.Marshal(j)
 
 	assert.Equal(t, string(b), string(x))

--- a/flow/project/cli/project.go
+++ b/flow/project/cli/project.go
@@ -165,8 +165,8 @@ func (p *Project) EmulatorServiceAccount() config.Account {
 func (p *Project) GetContractsByNetwork(network string) []Contract {
 	contracts := make([]Contract, 0)
 
-	// get deploys for specific network
-	for _, deploy := range p.conf.Deploys.GetByNetwork(network) {
+	// get deployments for specific network
+	for _, deploy := range p.conf.Deployments.GetByNetwork(network) {
 		account := p.GetAccountByName(deploy.Account)
 
 		// go through each contract for this deploy

--- a/flow/project/cli/project_test.go
+++ b/flow/project/cli/project_test.go
@@ -62,7 +62,7 @@ func generateComplexProject() Project {
 			Source:  "0x123123123",
 			Network: "testnet",
 		}},
-		Deploys: config.Deploys{{
+		Deployments: config.Deployments{{
 			Network:   "emulator",
 			Account:   "emulator-account",
 			Contracts: []string{"KittyItems", "KittyItemsMarket"},
@@ -142,7 +142,7 @@ func generateSimpleProject() Project {
 			Source:  "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
 			Network: "emulator",
 		}},
-		Deploys: config.Deploys{{
+		Deployments: config.Deployments{{
 			Network:   "emulator",
 			Account:   "emulator-account",
 			Contracts: []string{"NonFungibleToken"},
@@ -253,7 +253,7 @@ func generateAliasesComplexProject() Project {
 			Network: "emulator",
 			Alias:   "ee82856bf20e2aa6",
 		}},
-		Deploys: config.Deploys{{
+		Deployments: config.Deployments{{
 			Network:   "emulator",
 			Account:   "emulator-account",
 			Contracts: []string{"NonFungibleToken"},

--- a/flow/project/cli/project_test.go
+++ b/flow/project/cli/project_test.go
@@ -193,7 +193,7 @@ func generateAliasesProject() Project {
 			Network: "emulator",
 			Alias:   "ee82856bf20e2aa6",
 		}},
-		Deploys: config.Deploys{{
+		Deployments: config.Deployments{{
 			Network:   "emulator",
 			Account:   "emulator-account",
 			Contracts: []string{"NonFungibleToken"},

--- a/flow/project/commands/deploy_contracts/deploy.go
+++ b/flow/project/commands/deploy_contracts/deploy.go
@@ -59,7 +59,7 @@ var Cmd = &cobra.Command{
 
 		// check there are not multiple accounts with same contract
 		if project.ContractConflictExists(conf.Network) {
-			fmt.Println("\n❌ Currently it is not possible to deploy same contract with multiple accounts, please check Deploys in config and make sure contract is only present in one account")
+			fmt.Println("\n❌ Currently it is not possible to deploy same contract with multiple accounts, please check Deployments in config and make sure contract is only present in one account")
 			cli.Exit(1, "")
 			return
 		}


### PR DESCRIPTION
Changes `deploy` to `deployments` as it is more clear
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
