### PR TITLE
Update Cadence Language Server to v0.13.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/onflow/cadence v0.13.0
-	github.com/onflow/cadence/languageserver v0.13.0
+	github.com/onflow/cadence/languageserver v0.13.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0
 	github.com/onflow/flow-emulator v0.15.0
 	github.com/onflow/flow-go-sdk v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -766,8 +766,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.13.0 h1:rMQpIwbZyqdiKV3f8nwxmyqyJahHcDRHDaZcjNH3sfI=
 github.com/onflow/cadence v0.13.0/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
-github.com/onflow/cadence/languageserver v0.13.0 h1:Geh4atbLi+hqLkb380DKNeArts6/D5r6dlxf0GqJNh4=
-github.com/onflow/cadence/languageserver v0.13.0/go.mod h1:o/GvA3BNLf8D30nmHweIBxH6zb5WWux9y9I8mqL5V1Q=
+github.com/onflow/cadence/languageserver v0.13.1 h1:xJKxgEEXsC0GtiP0KtkWxNafpxpj1IQfa51uOIea6yg=
+github.com/onflow/cadence/languageserver v0.13.1/go.mod h1:o/GvA3BNLf8D30nmHweIBxH6zb5WWux9y9I8mqL5V1Q=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0 h1:2v10ZSCE4e3TyeDQvKplGJ4/d0X/+xgU2NmeXRmFYRw=


### PR DESCRIPTION
## Description

Contains a fix for relative imports by @psiemens: onflow/cadence#616
______


- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
