### PR TITLE
Increase linter timeout to 3 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29.0
+          args: --timeout=3m


### PR DESCRIPTION
## Description

This lint action has been failing with a timeout error lately. This is an attempt to fix it, but not a long-term solution; ideally linting does not take 3 minutes 😓 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
