### PR TITLE
Kan/send tx from partial

### DIFF
--- a/flow/accounts/add-contract/add.go
+++ b/flow/accounts/add-contract/add.go
@@ -62,11 +62,17 @@ var Cmd = &cobra.Command{
 			},
 		)
 
-		cli.SendTransaction(
+		cli.PrepareTransaction(
 			projectConf.HostWithOverride(conf.Host),
 			signerAccount,
 			tx,
 			signerAccount.Address,
+		)
+
+		cli.SendTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
 			conf.Results,
 		)
 	},

--- a/flow/accounts/add-contract/add.go
+++ b/flow/accounts/add-contract/add.go
@@ -62,17 +62,11 @@ var Cmd = &cobra.Command{
 			},
 		)
 
-		cli.PrepareTransaction(
+		cli.PrepareAndSendTransaction(
 			projectConf.HostWithOverride(conf.Host),
 			signerAccount,
 			tx,
 			signerAccount.Address,
-		)
-
-		cli.SendTransaction(
-			projectConf.HostWithOverride(conf.Host),
-			signerAccount,
-			tx,
 			conf.Results,
 		)
 	},

--- a/flow/accounts/create/create.go
+++ b/flow/accounts/create/create.go
@@ -96,7 +96,19 @@ var Cmd = &cobra.Command{
 
 		tx := templates.CreateAccount(accountKeys, contracts, signerAccount.Address)
 
-		cli.SendTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, tx, signerAccount.Address, conf.Results)
+		cli.PrepareTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
+			signerAccount.Address,
+		)
+
+		cli.SendTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
+			conf.Results,
+		)
 	},
 }
 

--- a/flow/accounts/create/create.go
+++ b/flow/accounts/create/create.go
@@ -96,17 +96,11 @@ var Cmd = &cobra.Command{
 
 		tx := templates.CreateAccount(accountKeys, contracts, signerAccount.Address)
 
-		cli.PrepareTransaction(
+		cli.PrepareAndSendTransaction(
 			projectConf.HostWithOverride(conf.Host),
 			signerAccount,
 			tx,
 			signerAccount.Address,
-		)
-
-		cli.SendTransaction(
-			projectConf.HostWithOverride(conf.Host),
-			signerAccount,
-			tx,
 			conf.Results,
 		)
 	},

--- a/flow/accounts/update-contract/update.go
+++ b/flow/accounts/update-contract/update.go
@@ -62,11 +62,17 @@ var Cmd = &cobra.Command{
 			},
 		)
 
-		cli.SendTransaction(
+		cli.PrepareTransaction(
 			projectConf.HostWithOverride(conf.Host),
 			signerAccount,
 			tx,
 			signerAccount.Address,
+		)
+
+		cli.SendTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
 			conf.Results,
 		)
 	},

--- a/flow/accounts/update-contract/update.go
+++ b/flow/accounts/update-contract/update.go
@@ -62,17 +62,11 @@ var Cmd = &cobra.Command{
 			},
 		)
 
-		cli.PrepareTransaction(
+		cli.PrepareAndSendTransaction(
 			projectConf.HostWithOverride(conf.Host),
 			signerAccount,
 			tx,
 			signerAccount.Address,
-		)
-
-		cli.SendTransaction(
-			projectConf.HostWithOverride(conf.Host),
-			signerAccount,
-			tx,
 			conf.Results,
 		)
 	},

--- a/flow/send.go
+++ b/flow/send.go
@@ -94,6 +94,11 @@ func SendTransaction(host string, signerAccount *Account, tx *flow.Transaction, 
 	}
 }
 
+func PrepareAndSendTransaction(host string, signerAccount *Account, tx *flow.Transaction, payer flow.Address, withResults bool) {
+	preparedTx := PrepareTransaction(host, signerAccount, tx, payer)
+	SendTransaction(host, signerAccount, preparedTx, withResults)
+}
+
 func SignTransaction(host string, signerAccount *Account, signerRole SignerRole, tx *flow.Transaction) *flow.Transaction {
 	ctx := context.Background()
 

--- a/flow/transactions/send/send.go
+++ b/flow/transactions/send/send.go
@@ -60,30 +60,37 @@ var Cmd = &cobra.Command{
 		} else if conf.Partial != "" {
 			partialTxHex, err := ioutil.ReadFile(conf.Partial)
 			if err != nil {
-				cli.Exitf(1, "Failed to read partial transaction from %s", conf.Partial)
+				cli.Exitf(1, "Failed to read partial transaction from %s: %v", conf.Partial, err)
 			}
 			partialTxBytes, err := hex.DecodeString(string(partialTxHex))
 			if err != nil {
-				cli.Exitf(1, "Failed to decode partial transaction from %s", conf.Partial)
+				cli.Exitf(1, "Failed to decode partial transaction from %s: %v", conf.Partial, err)
 			}
 			tx, err = flow.DecodeTransaction(partialTxBytes)
 			if err != nil {
-				cli.Exitf(1, "Failed to decode transaction from %s", conf.Partial)
+				cli.Exitf(1, "Failed to decode transaction from %s: %v", conf.Partial, err)
 			}
 		} else {
 			if conf.Code != "" {
 				code, err = ioutil.ReadFile(conf.Code)
 				if err != nil {
-					cli.Exitf(1, "Failed to read transaction script from %s", conf.Code)
+					cli.Exitf(1, "Failed to read transaction script from %s: %v", conf.Code, err)
 				}
 			}
 
 			tx = flow.NewTransaction().
 				SetScript(code).
 				AddAuthorizer(signerAccount.Address)
+
+			tx = cli.PrepareTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, tx, signerAccount.Address)
 		}
 
-		cli.SendTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, tx, signerAccount.Address, conf.Results)
+		cli.SendTransaction(
+			projectConf.HostWithOverride(conf.Host),
+			signerAccount,
+			tx,
+			conf.Results,
+		)
 	},
 }
 

--- a/flow/transactions/sign/sign.go
+++ b/flow/transactions/sign/sign.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/psiemens/sconfig"
@@ -39,7 +40,7 @@ type Config struct {
 	Code                  string   `flag:"code,c" info:"path to Cadence file"`
 	Host                  string   `flag:"host" info:"Flow Access API host address"`
 	Encoding              string   `default:"hexrlp" flag:"encoding" info:"Encoding to use for transactio (rlp)"`
-	Output                string   `default:"transaction.rlp" flag:"output,o" info:"Output location for transaction file"`
+	Output                string   `default:"" flag:"output,o" info:"Output location for transaction file"`
 }
 
 var conf Config
@@ -100,6 +101,10 @@ var Cmd = &cobra.Command{
 		fmt.Printf("%s encoded transaction written to %s\n", conf.Encoding, conf.Output)
 
 		output := fmt.Sprintf("%x", tx.Encode())
+		if len(strings.TrimSpace(conf.Output)) == 0 {
+			fmt.Println(output)
+			return
+		}
 		err = ioutil.WriteFile(conf.Output, []byte(output), os.ModePerm)
 		if err != nil {
 			cli.Exitf(1, "Failed to save encoded transaction to file %s", conf.Output)

--- a/flow/transactions/sign/sign.go
+++ b/flow/transactions/sign/sign.go
@@ -93,11 +93,13 @@ var Cmd = &cobra.Command{
 			tx.AddAuthorizer(authorizerAddress)
 		}
 
-		tx = cli.SignTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, signerRole, tx, payer)
+		cli.PrepareTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, tx, payer)
+
+		tx = cli.SignTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, signerRole, tx)
 
 		fmt.Printf("%s encoded transaction written to %s\n", conf.Encoding, conf.Output)
 
-		output := fmt.Sprintf("%x\n", tx.Encode())
+		output := fmt.Sprintf("%x", tx.Encode())
 		err = ioutil.WriteFile(conf.Output, []byte(output), os.ModePerm)
 		if err != nil {
 			cli.Exitf(1, "Failed to save encoded transaction to file %s", conf.Output)

--- a/flow/transactions/sign/sign.go
+++ b/flow/transactions/sign/sign.go
@@ -35,7 +35,7 @@ import (
 type Config struct {
 	Signer                string   `default:"service" flag:"signer,s"`
 	Role                  string   `default:"authorizer" flag:"role"`
-	AdditionalAuthorizers []string `flag:"Additional authorizer addresses to add to the transaction"`
+	AdditionalAuthorizers []string `flag:"additional-authorizers" info:"Additional authorizer addresses to add to the transaction"`
 	PayerAddress          string   `flag:"payer" info:"Specify payer of the transaction. Defaults to current signer."`
 	Code                  string   `flag:"code,c" info:"path to Cadence file"`
 	Host                  string   `flag:"host" info:"Flow Access API host address"`


### PR DESCRIPTION
Closes #???

## Description

Examples:
```
flow -f flow.devnet.json transactions sign --code transactions/devnet/mint.cdc --output transaction.rlp
flow -f flow.devnet.json transactions send --partial-tx=transaction.rlp    

```
equivalent to
```
flow -f flow.devnet.json transactions send --code=transactions/devnet/mint.cdc
```

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
