### PR TITLE
Unify signature for Transactions.Send and Scripts.Execute

### DIFF
--- a/cmd/transactions/send.go
+++ b/cmd/transactions/send.go
@@ -35,7 +35,7 @@ func (a *cmdSend) Run(
 	project *cli.Project,
 	services *services.Services,
 ) (cmd.Result, error) {
-	tx, result, err := services.Transactions.Send(args[0], a.flags.Signer, a.flags.Args)
+	tx, result, err := services.Transactions.Send(args[0], a.flags.Signer, a.flags.Args, a.flags.ArgsJSON)
 	return &TransactionResult{
 		result: result,
 		tx:     tx,

--- a/sharedlib/lib/arguments.go
+++ b/sharedlib/lib/arguments.go
@@ -64,3 +64,15 @@ func ParseArgumentsCommaSplit(input []string) ([]cadence.Value, error) {
 
 	return cadenceArgs, err
 }
+
+func ParseArguments(args []string, argsJSON string) (scriptArgs []cadence.Value, err error) {
+	if argsJSON != "" {
+		scriptArgs, err = ParseArgumentsJSON(argsJSON)
+	} else {
+		scriptArgs, err = ParseArgumentsCommaSplit(args)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return
+}

--- a/sharedlib/services/scripts.go
+++ b/sharedlib/services/scripts.go
@@ -31,17 +31,9 @@ func (s *Scripts) Execute(scriptFilename string, args []string, argsJSON string)
 		return nil, err
 	}
 
-	var scriptArgs []cadence.Value
-	if argsJSON != "" {
-		scriptArgs, err = lib.ParseArgumentsJSON(argsJSON)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		scriptArgs, err = lib.ParseArgumentsCommaSplit(args)
-		if err != nil {
-			return nil, err
-		}
+	scriptArgs, err := lib.ParseArguments(args, argsJSON)
+	if err != nil {
+		return nil, err
 	}
 
 	return s.gateway.ExecuteScript(script, scriptArgs)

--- a/sharedlib/services/transactions.go
+++ b/sharedlib/services/transactions.go
@@ -31,6 +31,7 @@ func (t *Transactions) Send(
 	transactionFilename string,
 	signerName string,
 	args []string,
+	argsJSON string,
 ) (*flow.Transaction, *flow.TransactionResult, error) {
 
 	signer := t.project.GetAccountByName(signerName)
@@ -55,7 +56,7 @@ func (t *Transactions) Send(
 		SetScript(code).
 		AddAuthorizer(signer.Address())
 
-	transactionArguments, err := lib.ParseArgumentsCommaSplit(args)
+	transactionArguments, err := lib.ParseArguments(args, argsJSON)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Add `ParseArguments` function to provide coherent signature for scripts and transactions.

I've run a search for `Send` and `Execute` method from sharedlib if they were used elsewhere. But you know the code better ^__^