### PR TITLE
Build darwin/arm64 binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14.5'
+        go-version: '1.16.2'
     - uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ versioned-binaries:
 	$(MAKE) OS=linux ARCH=amd64 ARCHNAME=x86_64 versioned-binary
 	$(MAKE) OS=linux ARCH=arm64 versioned-binary
 	$(MAKE) OS=darwin ARCH=amd64 ARCHNAME=x86_64 versioned-binary
-	# enable once supported: https://github.com/golang/go/issues/38485
-	# $(MAKE) OS=darwin ARCH=arm64 versioned-binary
+	$(MAKE) OS=darwin ARCH=arm64 versioned-binary
 	$(MAKE) OS=windows ARCH=amd64 ARCHNAME=x86_64 versioned-binary
 
 .PHONY: versioned-binary


### PR DESCRIPTION
## Description

Go 1.16 added support for darwin/arm64. Build binaries for it.

______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
