### PR TITLE
Kan/add payload signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,8 @@ jobs:
         with:
           version: v1.29.0
           args: --timeout=5m
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          skip-build-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29.0
+          version: v1.38.0
           args: --timeout=5m
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          skip-build-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29.0
-          args: --timeout=3m
+          args: --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ clean:
 
 .PHONY: install-linter
 install-linter:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.29.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.38.0
 
 .PHONY: lint
 lint:

--- a/flow/transactions/send/send.go
+++ b/flow/transactions/send/send.go
@@ -20,7 +20,6 @@ package send
 
 import (
 	"log"
-	"os"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/psiemens/sconfig"
@@ -54,7 +53,7 @@ var Cmd = &cobra.Command{
 			signerAccount = projectConf.Accounts["emulator-account"]
 		}
 
-		validateKeyPreReq(signerAccount)
+		utils.ValidateKeyPreReq(signerAccount)
 		var tx *flow.Transaction
 
 		if conf.Payload != "" && conf.Code != "" {
@@ -89,23 +88,4 @@ func initConfig() {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func validateKeyPreReq(account *cli.Account) {
-	if account.KeyType == cli.KeyTypeHex {
-		// Always Valid
-		return
-	} else if account.KeyType == cli.KeyTypeKMS {
-		// Check GOOGLE_APPLICATION_CREDENTIALS
-		googleAppCreds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-		if len(googleAppCreds) == 0 {
-			if len(account.KeyContext["projectId"]) == 0 {
-				cli.Exitf(1, "Could not get GOOGLE_APPLICATION_CREDENTIALS, no google service account json provided but private key type is KMS", account.Address)
-			}
-			cli.GcloudApplicationSignin(account.KeyContext["projectId"])
-		}
-		return
-	}
-	cli.Exitf(1, "Failed to validate %s key for %s", account.KeyType, account.Address)
-
 }

--- a/flow/transactions/send/send.go
+++ b/flow/transactions/send/send.go
@@ -60,6 +60,8 @@ var Cmd = &cobra.Command{
 		if conf.Payload != "" && conf.Code != "" {
 			cli.Exitf(1, "Both a partial transaction and Cadence code file provided, but cannot use both")
 		} else if conf.Payload != "" {
+			utils.AssertEmptyOnLoadingPayload(conf.Args, "arguments")
+
 			tx = utils.LoadTransactionPayloadFromFile(conf.Payload)
 		} else {
 			tx = utils.NewTransactionWithCodeArgsAuthorizers(conf.Code, conf.Args, []string{signerAccount.Address.String()})

--- a/flow/transactions/sign/sign.go
+++ b/flow/transactions/sign/sign.go
@@ -85,7 +85,7 @@ var Cmd = &cobra.Command{
 				cli.Exitf(1, "Role specified as Payer, but Payer address also provided, and different: %s !=", payer, signerAccount.Address)
 			}
 		case cli.SignerRoleProposer:
-			cli.Exitf(1, "Proposer role not yet supported: %s", conf.Role)
+			// Just sign payload, no special actions needed
 		default:
 			cli.Exitf(1, "unknown role %s", conf.Role)
 		}
@@ -133,6 +133,9 @@ func initConfig() {
 }
 
 func validateKeyPreReq(account *cli.Account) {
+	if account == nil {
+		cli.Exitf(1, "A specified key was not found")
+	}
 	if account.KeyType == cli.KeyTypeHex {
 		// Always Valid
 		return

--- a/flow/transactions/sign/sign.go
+++ b/flow/transactions/sign/sign.go
@@ -56,11 +56,11 @@ var Cmd = &cobra.Command{
 		projectConf := cli.LoadConfig()
 
 		signerAccount := projectConf.Accounts[conf.Signer]
-		validateKeyPreReq(signerAccount)
+		utils.ValidateKeyPreReq(signerAccount)
 		proposerAccount := signerAccount
 		if conf.Proposer != "" {
 			proposerAccount = projectConf.Accounts[conf.Proposer]
-			validateKeyPreReq(proposerAccount)
+			utils.ValidateKeyPreReq(proposerAccount)
 		}
 		var (
 			tx             *flow.Transaction
@@ -138,26 +138,4 @@ func initConfig() {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func validateKeyPreReq(account *cli.Account) {
-	if account == nil {
-		cli.Exitf(1, "A specified key was not found")
-	}
-	if account.KeyType == cli.KeyTypeHex {
-		// Always Valid
-		return
-	} else if account.KeyType == cli.KeyTypeKMS {
-		// Check GOOGLE_APPLICATION_CREDENTIALS
-		googleAppCreds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-		if len(googleAppCreds) == 0 {
-			if len(account.KeyContext["projectId"]) == 0 {
-				cli.Exitf(1, "Could not get GOOGLE_APPLICATION_CREDENTIALS, no google service account json provided but private key type is KMS", account.Address)
-			}
-			cli.GcloudApplicationSignin(account.KeyContext["projectId"])
-		}
-		return
-	}
-	cli.Exitf(1, "Failed to validate %s key for %s", account.KeyType, account.Address)
-
 }

--- a/flow/transactions/utils/utils.go
+++ b/flow/transactions/utils/utils.go
@@ -1,0 +1,84 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"encoding/hex"
+	"io/ioutil"
+
+	cli "github.com/onflow/flow-cli/flow"
+	"github.com/onflow/flow-go-sdk"
+)
+
+func LoadTransactionPayloadFromFile(filename string) *flow.Transaction {
+	partialTxHex, err := ioutil.ReadFile(filename)
+	if err != nil {
+		cli.Exitf(1, "Failed to read partial transaction from %s: %v", filename, err)
+	}
+	partialTxBytes, err := hex.DecodeString(string(partialTxHex))
+	if err != nil {
+		cli.Exitf(1, "Failed to decode partial transaction from %s: %v", filename, err)
+	}
+	tx, err := flow.DecodeTransaction(partialTxBytes)
+	if err != nil {
+		cli.Exitf(1, "Failed to decode transaction from %s: %v", filename, err)
+	}
+
+	return tx
+}
+
+func NewTransactionWithCodeArgsAuthorizers(code string, args string, authorizers []string) *flow.Transaction {
+	tx := flow.NewTransaction()
+	if code != "" {
+		codeBytes, err := ioutil.ReadFile(code)
+		if err != nil {
+			cli.Exitf(1, "Failed to read transaction script from %s: %v", code, err)
+		}
+		tx.SetScript(codeBytes)
+	}
+
+	// Arguments
+	if args != "" {
+		transactionArguments, err := cli.ParseArguments(args)
+		if err != nil {
+			cli.Exitf(1, "Invalid arguments passed: %s", args)
+		}
+
+		for _, arg := range transactionArguments {
+			err := tx.AddArgument(arg)
+
+			if err != nil {
+				cli.Exitf(1, "Failed to add %s argument to a transaction ", args)
+			}
+		}
+	}
+
+	if len(authorizers) > 0 {
+		for _, authorizer := range authorizers {
+			authorizerAddress := flow.HexToAddress(authorizer)
+			if authorizerAddress == flow.EmptyAddress {
+				cli.Exitf(1, "Invalid authorizer address provided %s", authorizer)
+			}
+
+			tx.AddAuthorizer(authorizerAddress)
+		}
+	}
+
+	return tx
+}

--- a/flow/transactions/utils/utils.go
+++ b/flow/transactions/utils/utils.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"encoding/hex"
 	"io/ioutil"
+	"strings"
 
 	cli "github.com/onflow/flow-cli/flow"
 	"github.com/onflow/flow-go-sdk"
@@ -81,4 +82,10 @@ func NewTransactionWithCodeArgsAuthorizers(code string, args string, authorizers
 	}
 
 	return tx
+}
+
+func AssertEmptyOnLoadingPayload(shouldBeEmpty string, paramName string) {
+	if strings.TrimSpace(shouldBeEmpty) != "" {
+		cli.Exitf(1, "Loading transaction payload from file, but %s provided which cannot be used", paramName)
+	}
 }

--- a/flow/txprepare.go
+++ b/flow/txprepare.go
@@ -1,0 +1,60 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/client"
+	"google.golang.org/grpc"
+)
+
+func PrepareTransaction(host string, proposerAccount *Account, tx *flow.Transaction, payer flow.Address) *flow.Transaction {
+	ctx := context.Background()
+
+	flowClient, err := client.New(host, grpc.WithInsecure())
+	if err != nil {
+		Exitf(1, "Failed to connect to host: %s", err)
+	}
+
+	proposerAddress := proposerAccount.Address
+
+	fmt.Printf("Getting information for account with address 0x%s ...\n", proposerAddress.Hex())
+
+	account, err := flowClient.GetAccount(ctx, proposerAddress)
+	if err != nil {
+		Exitf(1, "Failed to get account with address %s: 0x%s", proposerAddress.Hex(), err)
+	}
+
+	// Default 0, i.e. first key
+	accountKey := account.Keys[proposerAccount.KeyIndex]
+
+	sealed, err := flowClient.GetLatestBlockHeader(ctx, true)
+	if err != nil {
+		Exitf(1, "Failed to get latest sealed block: %s", err)
+	}
+
+	tx.SetReferenceBlockID(sealed.ID).
+		SetProposalKey(proposerAddress, accountKey.Index, accountKey.SequenceNumber).
+		SetPayer(payer)
+
+	return tx
+}

--- a/flow/txsend.go
+++ b/flow/txsend.go
@@ -1,0 +1,60 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/client"
+	"google.golang.org/grpc"
+)
+
+func SendTransaction(host string, signerAccount *Account, tx *flow.Transaction, withResults bool) {
+	ctx := context.Background()
+
+	flowClient, err := client.New(host, grpc.WithInsecure())
+	if err != nil {
+		Exitf(1, "Failed to connect to host: %s", err)
+	}
+
+	tx = signTransaction(ctx, flowClient, signerAccount, SignerRolePayer, tx)
+
+	fmt.Printf("Submitting transaction with ID %s ...\n", tx.ID())
+
+	err = flowClient.SendTransaction(context.Background(), *tx)
+	if err == nil {
+		fmt.Printf("Successfully submitted transaction with ID %s\n", tx.ID())
+	} else {
+		Exitf(1, "Failed to submit transaction: %s", err)
+	}
+	if withResults {
+		res, err := waitForSeal(ctx, flowClient, tx.ID())
+		if err != nil {
+			Exitf(1, "Failed to seal transaction: %s", err)
+		}
+		printTxResult(tx, res, true)
+	}
+}
+
+func PrepareAndSendTransaction(host string, signerAccount *Account, tx *flow.Transaction, payer flow.Address, withResults bool) {
+	preparedTx := PrepareTransaction(host, signerAccount, tx, payer)
+	SendTransaction(host, signerAccount, preparedTx, withResults)
+}

--- a/flow/txsign.go
+++ b/flow/txsign.go
@@ -60,7 +60,7 @@ func signTransaction(
 	}
 	accountKey := account.Keys[signerAccount.KeyIndex]
 	switch signerRole {
-	case SignerRoleAuthorizer:
+	case SignerRoleAuthorizer, SignerRoleProposer:
 		err := tx.SignPayload(signerAddress, accountKey.Index, signerAccount.Signer)
 		if err != nil {
 			Exitf(1, "Failed to sign transaction: %s", err)


### PR DESCRIPTION
## Description

- Improves the `sign` sub-function, by allowing it to sign payloads as well (similar to what the send function could do previously)
- Generalize some helper functions that were shared between `sign` and `send` sub commands.
- Split out some of the CLI package functions into their own files, to clean things up a bit
- Changed a few flags to better portray their purpose
  - `payer` -> `payer-address`
  - `partial-tx` -> `payload` I'm not 100% sure about this one, so open to comments here if people preferred the previous naming
- Updated to allow signing as the proposer
  - This was the main functionality that I needed.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
