### PR TITLE
Display transaction for confirmation

### DIFF
--- a/flow/transactions/send/send.go
+++ b/flow/transactions/send/send.go
@@ -34,6 +34,7 @@ type Config struct {
 	Args    string `default:"" flag:"args" info:"arguments in JSON-Cadence format"`
 	Code    string `flag:"code,c" info:"path to Cadence file"`
 	Payload string `flag:"payload" info:"path to Transaction Payload file"`
+	Confirm bool   `default:"false" flag:"confirm" info:"Auto confirm correctness of payload"`
 	Host    string `flag:"host" info:"Flow Access API host address"`
 	Signer  string `default:"service" flag:"signer,s"`
 	Results bool   `default:"false" flag:"results" info:"Display the results of the transaction"`
@@ -61,6 +62,7 @@ var Cmd = &cobra.Command{
 			cli.Exitf(1, "Both a partial transaction and Cadence code file provided, but cannot use both")
 		} else if conf.Payload != "" {
 			tx = utils.LoadTransactionPayloadFromFile(conf.Payload)
+			utils.DisplayTransactionForConfirmation(tx, conf.Confirm)
 		} else {
 			tx = utils.NewTransactionWithCodeArgsAuthorizers(conf.Code, conf.Args, []string{signerAccount.Address.String()})
 			tx = cli.PrepareTransaction(projectConf.HostWithOverride(conf.Host), signerAccount, tx, signerAccount.Address)

--- a/flow/transactions/sign/sign.go
+++ b/flow/transactions/sign/sign.go
@@ -42,6 +42,7 @@ type Config struct {
 	PayerAddress          string   `flag:"payer-address" info:"Specify payer of the transaction. Defaults to current signer."`
 	Code                  string   `flag:"code,c" info:"path to Cadence file"`
 	Payload               string   `flag:"payload" info:"path to Transaction Payload file"`
+	Confirm               bool     `default:"false" flag:"confirm" info:"Auto confirm correctness of payload"`
 	Host                  string   `flag:"host" info:"Flow Access API host address"`
 	Encoding              string   `default:"hexrlp" flag:"encoding" info:"Encoding to use for transactio (rlp)"`
 	Output                string   `default:"" flag:"output,o" info:"Output location for transaction file"`
@@ -94,6 +95,7 @@ var Cmd = &cobra.Command{
 			cli.Exitf(1, "Both a partial transaction and Cadence code file provided, but cannot use both")
 		} else if conf.Payload != "" {
 			tx = utils.LoadTransactionPayloadFromFile(conf.Payload)
+			utils.DisplayTransactionForConfirmation(tx, conf.Confirm)
 		} else {
 			// The additional authorizers and payer flags are only taken into account if we're
 			// generating a new transaction


### PR DESCRIPTION
## Description

Adds a confirmation step for signing/sending when the payload is loaded from a file.

@psiemens and I found that we when using the partial transaction functionality, we felt a little blind on what was being signed/sent. It was then suggested that we just print out the tx that was parsed.

This PR prints out the parsed TX in a way that will hopefully assist the user in deciding if they want to sign or not. Also includes an auto confirm option for when using in a setting where we always want to confirm (i.e. in a script, maybe)

The current Transaction display format is a bit ad-hoc. Open to suggestions on how to re-arrange the info if there are any.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
