### PR TITLE
Use the sigAlgo the user requested

### DIFF
--- a/flow/accounts/create/create.go
+++ b/flow/accounts/create/create.go
@@ -68,7 +68,7 @@ var Cmd = &cobra.Command{
 		}
 
 		for i, publicKeyHex := range conf.Keys {
-			publicKey := cli.MustDecodePublicKeyHex(cli.DefaultSigAlgo, publicKeyHex)
+			publicKey := cli.MustDecodePublicKeyHex(sigAlgo, publicKeyHex)
 			accountKeys[i] = &flow.AccountKey{
 				PublicKey: publicKey,
 				SigAlgo:   sigAlgo,


### PR DESCRIPTION
Fixes https://github.com/onflow/flow-cli/issues/122

## Description

Use the signature algorithm provided instead of assuming the public key is the default algorithm, P256.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
