### PR TITLE
Add goimports rule to linter, fix all imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,8 @@ linters:
     - ineffassign
     - typecheck
     - misspell
+    - goimports
+linters-settings:
+  goimports:
+    # put imports beginning with prefix after 3rd-party package
+    local-prefixes: github.com/onflow/flow-cli

--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/accounts"
 	"github.com/onflow/flow-cli/internal/blocks"
 	"github.com/onflow/flow-cli/internal/cadence"
@@ -33,7 +35,6 @@ import (
 	"github.com/onflow/flow-cli/internal/transactions"
 	"github.com/onflow/flow-cli/internal/version"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
-	"github.com/spf13/cobra"
 )
 
 func main() {

--- a/internal/accounts/account-add.go
+++ b/internal/accounts/account-add.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
+	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 type flagsAdd struct {

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -21,9 +21,10 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsAddContract struct {

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -21,9 +21,10 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsRemoveContract struct {

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -21,9 +21,10 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsUpdateContract struct {

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -21,9 +21,10 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsCreate struct {

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -21,9 +21,10 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsGet struct {

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -6,11 +6,11 @@ import (
 	"text/tabwriter"
 
 	"github.com/onflow/cadence"
+	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsStakingInfo struct{}

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -23,11 +23,11 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/onflow/flow-cli/internal/events"
-
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/events"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -21,9 +21,10 @@ package blocks
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsBlocks struct {

--- a/internal/cadence/vscode/vscode.go
+++ b/internal/cadence/vscode/vscode.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 const cadenceExt = "cadence.vsix"

--- a/internal/collections/get.go
+++ b/internal/collections/get.go
@@ -19,9 +19,10 @@
 package collections
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsCollections struct{}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -25,20 +25,17 @@ import (
 	"os"
 	"strings"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
-
-	"github.com/psiemens/sconfig"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
-	"github.com/onflow/flow-cli/pkg/flowcli/services"
 	"github.com/onflow/flow-go-sdk/client"
+	"github.com/psiemens/sconfig"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/pkg/flowcli/services"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 type RunCommand func(

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -21,12 +21,13 @@ package emulator
 import (
 	"strings"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/onflow/flow-emulator/cmd/emulator/start"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -24,12 +24,12 @@ import (
 	"io"
 	"text/tabwriter"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -21,9 +21,10 @@ package events
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsGenerate struct {

--- a/internal/keys/decode.go
+++ b/internal/keys/decode.go
@@ -1,9 +1,10 @@
 package keys
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsDecode struct{}

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -21,9 +21,10 @@ package keys
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsGenerate struct {

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -25,9 +25,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/onflow/flow-go-sdk"
-
 	"github.com/onflow/flow-go-sdk/crypto"
-
 	"github.com/spf13/cobra"
 )
 

--- a/internal/project/deploy.go
+++ b/internal/project/deploy.go
@@ -19,10 +19,11 @@
 package project
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/contracts"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsDeploy struct {

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -21,9 +21,10 @@ package scripts
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsScripts struct {

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -19,9 +19,10 @@
 package transactions
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsStatus struct {

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -21,9 +21,10 @@ package transactions
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsSend struct {

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/onflow/flow-cli/internal/events"
-
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/events"
 )
 
 var Cmd = &cobra.Command{

--- a/pkg/flowcli/config/config_test.go
+++ b/pkg/flowcli/config/config_test.go
@@ -20,11 +20,11 @@ package config_test
 import (
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
-
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 )
 
 func generateComplexConfig() config.Config {

--- a/pkg/flowcli/config/json/account.go
+++ b/pkg/flowcli/config/json/account.go
@@ -21,11 +21,11 @@ package json
 import (
 	"encoding/json"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 type jsonAccounts map[string]jsonAccount

--- a/pkg/flowcli/config/json/network.go
+++ b/pkg/flowcli/config/json/network.go
@@ -21,8 +21,9 @@ package json
 import (
 	"encoding/json"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
 	"github.com/onflow/flow-go-sdk"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 )
 
 type jsonNetworks map[string]jsonNetwork

--- a/pkg/flowcli/config/loader_test.go
+++ b/pkg/flowcli/config/loader_test.go
@@ -19,14 +19,13 @@ package config_test
 
 import (
 	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/config"
 	"github.com/onflow/flow-cli/pkg/flowcli/config/json"
-	"github.com/spf13/afero"
-
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_JSONSimple(t *testing.T) {

--- a/pkg/flowcli/events_test.go
+++ b/pkg/flowcli/events_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/onflow/cadence"
 	"github.com/onflow/flow-cli/pkg/flowcli"
 	"github.com/onflow/flow-cli/tests"
 )

--- a/pkg/flowcli/gateway/emulator.go
+++ b/pkg/flowcli/gateway/emulator.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 
 	"github.com/onflow/cadence"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	emulator "github.com/onflow/flow-emulator"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 type EmulatorGateway struct {

--- a/pkg/flowcli/gateway/gateway.go
+++ b/pkg/flowcli/gateway/gateway.go
@@ -20,9 +20,10 @@ package gateway
 
 import (
 	"github.com/onflow/cadence"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 type Gateway interface {

--- a/pkg/flowcli/gateway/grpc.go
+++ b/pkg/flowcli/gateway/grpc.go
@@ -24,10 +24,11 @@ import (
 	"time"
 
 	"github.com/onflow/cadence"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
 	"google.golang.org/grpc"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 // GrpcGateway contains all functions that need flow client to execute

--- a/pkg/flowcli/project/account.go
+++ b/pkg/flowcli/project/account.go
@@ -3,10 +3,11 @@ package project
 import (
 	"fmt"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 type Account struct {

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/afero"
@@ -32,6 +30,7 @@ import (
 
 	"github.com/onflow/flow-cli/pkg/flowcli/config"
 	"github.com/onflow/flow-cli/pkg/flowcli/config/json"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 var DefaultConfigPath = "flow.json"

--- a/pkg/flowcli/project/project_test.go
+++ b/pkg/flowcli/project/project_test.go
@@ -23,13 +23,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/spf13/afero"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/thoas/go-funk"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 )
 
 var composer = config.NewLoader(afero.NewOsFs())

--- a/pkg/flowcli/services/accounts.go
+++ b/pkg/flowcli/services/accounts.go
@@ -23,19 +23,18 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/onflow/flow-cli/pkg/flowcli"
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
 	"github.com/onflow/cadence"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	tmpl "github.com/onflow/flow-core-contracts/lib/go/templates"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/onflow/flow-go-sdk/templates"
+
+	"github.com/onflow/flow-cli/pkg/flowcli"
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 // Accounts service handles all interactions for accounts

--- a/pkg/flowcli/services/accounts_test.go
+++ b/pkg/flowcli/services/accounts_test.go
@@ -4,14 +4,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-go-sdk/crypto"
-
 	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/tests"
 )
 

--- a/pkg/flowcli/services/blocks.go
+++ b/pkg/flowcli/services/blocks.go
@@ -22,13 +22,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
+	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
-	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 // Blocks service handles all interactions for blocks

--- a/pkg/flowcli/services/blocks_test.go
+++ b/pkg/flowcli/services/blocks_test.go
@@ -3,14 +3,14 @@ package services
 import (
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-cli/tests"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/tests"
 )
 
 func TestBlocks(t *testing.T) {

--- a/pkg/flowcli/services/collections.go
+++ b/pkg/flowcli/services/collections.go
@@ -19,10 +19,11 @@
 package services
 
 import (
+	"github.com/onflow/flow-go-sdk"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
-	"github.com/onflow/flow-go-sdk"
 )
 
 // Collections service handles all interactions for collections

--- a/pkg/flowcli/services/collections_test.go
+++ b/pkg/flowcli/services/collections_test.go
@@ -3,13 +3,13 @@ package services
 import (
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-cli/tests"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/tests"
 )
 
 func TestCollections(t *testing.T) {

--- a/pkg/flowcli/services/events.go
+++ b/pkg/flowcli/services/events.go
@@ -22,12 +22,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
 	"github.com/onflow/flow-go-sdk/client"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 // Events service handles all interactions for scripts

--- a/pkg/flowcli/services/events_test.go
+++ b/pkg/flowcli/services/events_test.go
@@ -3,15 +3,14 @@ package services
 import (
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
 	"github.com/onflow/flow-go-sdk"
-
-	"github.com/onflow/flow-cli/tests"
 	"github.com/onflow/flow-go-sdk/client"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/tests"
 )
 
 func TestEvents(t *testing.T) {

--- a/pkg/flowcli/services/keys.go
+++ b/pkg/flowcli/services/keys.go
@@ -22,14 +22,13 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 // Keys service handles all interactions for keys

--- a/pkg/flowcli/services/keys_test.go
+++ b/pkg/flowcli/services/keys_test.go
@@ -3,13 +3,12 @@ package services
 import (
 	"testing"
 
-	"github.com/onflow/flow-cli/tests"
-
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/tests"
 )
 
 func TestKeys(t *testing.T) {

--- a/pkg/flowcli/services/scripts.go
+++ b/pkg/flowcli/services/scripts.go
@@ -19,14 +19,13 @@
 package services
 
 import (
+	"github.com/onflow/cadence"
+
 	"github.com/onflow/flow-cli/pkg/flowcli"
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
-
-	"github.com/onflow/cadence"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
 )
 
 // Scripts service handles all interactions for scripts

--- a/pkg/flowcli/services/transactions.go
+++ b/pkg/flowcli/services/transactions.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/onflow/flow-cli/pkg/flowcli"
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/config"
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+
+	"github.com/onflow/flow-cli/pkg/flowcli"
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 // Scripts service handles all interactions for transactions

--- a/pkg/flowcli/services/transactions_test.go
+++ b/pkg/flowcli/services/transactions_test.go
@@ -3,14 +3,13 @@ package services
 import (
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
 	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/tests"
-	"github.com/onflow/flow-go-sdk/crypto"
 )
 
 func TestTransactions(t *testing.T) {

--- a/pkg/flowcli/txsender/txsender.go
+++ b/pkg/flowcli/txsender/txsender.go
@@ -22,9 +22,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 const (

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -22,15 +22,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/onflow/flow-cli/pkg/flowcli/output"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
-
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
-	"github.com/onflow/flow-cli/pkg/flowcli/services"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/utils/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
 const (

--- a/tests/mockGateway.go
+++ b/tests/mockGateway.go
@@ -2,10 +2,11 @@ package tests
 
 import (
 	"github.com/onflow/cadence"
-	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
-	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
 type MockGateway struct {


### PR DESCRIPTION
## Description

This PR enables the [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) rule for golangci-lint: https://golangci-lint.run/usage/linters/