### PR TITLE
Remove MarkDeprecated function for --init flag

### DIFF
--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -75,5 +75,4 @@ func configuredServiceKey(
 func init() {
 	Cmd = start.Cmd(configuredServiceKey)
 	Cmd.Use = "emulator"
-	Cmd.Flags().MarkDeprecated("init", "init is no longer supported use `flow project init` first")
 }


### PR DESCRIPTION
## Description

There was a linter error on this line:

```
internal/emulator/start.go:79:28: Error return value of `(*github.com/spf13/pflag.FlagSet).MarkDeprecated` is not checked (errcheck)
	Cmd.Flags().MarkDeprecated("init", "init is no longer supported use `flow project init` first")
```

After I added the error check, it turns out there was an error:

```go
err := Cmd.Flags().
  MarkDeprecated(
    "init",
    "init is no longer supported use `flow project init` first",
  )
if err != nil {
    panic(err)
}
```

```
go run cmd/flow/main.go emulator start --init
panic: flag "init" does not exist
```

I don't think `MarkDeprecated` was actually working as intended here, so I removed it.
