### PR TITLE
check for old config and forward error

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -272,7 +272,10 @@ func handleError(description string, err error) {
 	case *client.RPCError:
 		fmt.Fprintf(os.Stderr, "❌ Grpc Error: %s \n", t.GRPCStatus().Err().Error())
 	default:
-		if strings.Contains(err.Error(), "transport:") {
+		if errors.Is(err, config.ErrOutdatedFormat) {
+			fmt.Fprintf(os.Stderr, "❌ Config Error: %s \n", err.Error())
+			fmt.Fprintf(os.Stderr, "🙏 Please reset configuration using: 'flow init --reset'. Read more about new configuration here: https://github.com/onflow/flow-cli/releases/tag/v0.17.0")
+		} else if strings.Contains(err.Error(), "transport:") {
 			fmt.Fprintf(os.Stderr, "❌ %s \n", strings.Split(err.Error(), "transport:")[1])
 			fmt.Fprintf(os.Stderr, "🙏 Make sure your emulator is running or connection address is correct.")
 		} else if strings.Contains(err.Error(), "NotFound desc =") {

--- a/pkg/flowcli/config/config.go
+++ b/pkg/flowcli/config/config.go
@@ -19,6 +19,8 @@
 package config
 
 import (
+	"errors"
+
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 )
@@ -93,6 +95,8 @@ const (
 	PrivateKeyField                   = "privateKey"
 	KMSContextField                   = "resourceName"
 )
+
+var ErrOutdatedFormat = errors.New("you are using old configuration format")
 
 // IsAlias checks if contract has an alias
 func (c *Contract) IsAlias() bool {

--- a/pkg/flowcli/config/json/config.go
+++ b/pkg/flowcli/config/json/config.go
@@ -20,7 +20,6 @@ package json
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/config"
 )
@@ -97,9 +96,7 @@ func (p *Parser) Serialize(conf *config.Config) ([]byte, error) {
 func (p *Parser) Deserialize(raw []byte) (*config.Config, error) {
 	// check if old format of config and return an error
 	if oldConfigFormat(raw) {
-		return nil, fmt.Errorf(
-			"you are using old configuration format. Please remove flow.json and generate a new configuration by using 'flow init' command	",
-		)
+		return nil, config.ErrOutdatedFormat
 	}
 
 	var jsonConf jsonConfig

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -62,7 +62,7 @@ func Load(configFilePath []string) (*Project, error) {
 			return nil, err
 		}
 
-		return nil, fmt.Errorf("failed to open project configuration: %s", configFilePath)
+		return nil, err
 	}
 
 	proj, err := newProject(conf, composer)


### PR DESCRIPTION
## Description
Handle old flow.json configuration with a warning for a user to generate a new one
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
