### PR TITLE
Sharedlib emulator init

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -52,21 +52,23 @@ type Command struct {
 }
 
 type GlobalFlags struct {
-	Filter  string
-	Format  string
-	Save    string
-	Host    string
-	Log     string
-	Network string
+	Filter     string
+	Format     string
+	Save       string
+	Host       string
+	Log        string
+	Network    string
+	ConfigPath []string
 }
 
 var flags = GlobalFlags{
-	Filter:  "",
-	Format:  "",
-	Save:    "",
-	Host:    "",
-	Log:     "info",
-	Network: "",
+	Filter:     "",
+	Format:     "",
+	Save:       "",
+	Host:       "",
+	Log:        "info",
+	Network:    "",
+	ConfigPath: project.DefaultConfigPaths,
 }
 
 // InitFlags init all the global persistent flags
@@ -112,10 +114,10 @@ func InitFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().StringSliceVarP(
-		&util.ConfigPath,
+		&flags.ConfigPath,
 		"conf",
 		"f",
-		util.ConfigPath,
+		flags.ConfigPath,
 		"Path to flow configuration file",
 	)
 
@@ -135,7 +137,7 @@ func InitFlags(cmd *cobra.Command) {
 func (c Command) AddToParent(parent *cobra.Command) {
 	c.Cmd.Run = func(cmd *cobra.Command, args []string) {
 		// initialize project but ignore error since config can be missing
-		proj, err := project.Load(util.ConfigPath)
+		proj, err := project.Load(flags.ConfigPath)
 		// here we ignore if config does not exist as some commands don't require it
 		if !errors.Is(err, config.ErrDoesNotExist) {
 			handleError("Config Error", err)

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -93,6 +93,9 @@ func Exists(path string) bool {
 // Init initializes a new Flow project.
 func Init(sigAlgo crypto.SignatureAlgorithm, hashAlgo crypto.HashAlgorithm) (*Project, error) {
 	emulatorServiceAccount, err := generateEmulatorServiceAccount(sigAlgo, hashAlgo)
+	if err != nil {
+		return nil, err
+	}
 
 	composer := config.NewLoader(afero.NewOsFs())
 	composer.AddConfigParser(json.NewParser())
@@ -101,7 +104,7 @@ func Init(sigAlgo crypto.SignatureAlgorithm, hashAlgo crypto.HashAlgorithm) (*Pr
 		composer: composer,
 		conf:     defaultConfig(emulatorServiceAccount),
 		accounts: []*Account{emulatorServiceAccount},
-	}, err
+	}, nil
 }
 
 const (

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -33,7 +33,10 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
-var DefaultConfigPath = "flow.json"
+var (
+	DefaultConfigPaths = []string{"flow.json"}
+	DefaultConfigPath  = DefaultConfigPaths[0]
+)
 
 // Project contains the configuration for a Flow project.
 type Project struct {

--- a/pkg/flowcli/util/cli.go
+++ b/pkg/flowcli/util/cli.go
@@ -33,8 +33,6 @@ const (
 	EnvPrefix = "FLOW"
 )
 
-var ConfigPath = []string{"flow.json"}
-
 func Exit(code int, msg string) {
 	fmt.Println(msg)
 	os.Exit(code)


### PR DESCRIPTION
## Description

Add back support for inline init of configuration with the emulator command.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
