### PR TITLE
Sharedlib deprecate flag

### DIFF
--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -29,7 +29,7 @@ import (
 
 type flagsAddContract struct {
 	Signer  string `default:"emulator-account" flag:"signer"`
-	Results bool   `default:"false" flag:"results" info:"⚠️  No longer supported: results are provided by default"`
+	Results bool   `default:"false" flag:"results" info:"⚠️  Deprecated: results are provided by default"`
 }
 
 var addContractFlags = flagsAddContract{}
@@ -49,7 +49,7 @@ var AddContractCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 		if createFlags.Results {
-			return nil, fmt.Errorf("⚠️ Results flag is no longer supported, results are by default included in all executions.")
+			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
 		account, err := services.Accounts.AddContract(

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -29,7 +29,7 @@ import (
 
 type flagsRemoveContract struct {
 	Signer  string `default:"emulator-account" flag:"signer"`
-	Results bool   `default:"false" flag:"results" info:"⚠️  No longer supported: results are provided by default"`
+	Results bool   `default:"false" flag:"results" info:"⚠️  Deprecated: results are provided by default"`
 }
 
 var flagsRemove = flagsRemoveContract{}
@@ -48,8 +48,8 @@ var RemoveCommand = &command.Command{
 		globalFlags command.GlobalFlags,
 		services *services.Services,
 	) (command.Result, error) {
-		if createFlags.Results {
-			return nil, fmt.Errorf("⚠️ Results flag is no longer supported, results are by default included in all executions.")
+		if flagsRemove.Results {
+			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
 		account, err := services.Accounts.RemoveContract(

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -29,7 +29,7 @@ import (
 
 type flagsUpdateContract struct {
 	Signer  string `default:"emulator-account" flag:"signer"`
-	Results bool   `default:"false" flag:"results" info:"⚠️  No longer supported: results are provided by default"`
+	Results bool   `default:"false" flag:"results" info:"⚠️  Deprecated: results are provided by default"`
 }
 
 var updateFlags = flagsUpdateContract{}
@@ -48,8 +48,8 @@ var UpdateCommand = &command.Command{
 		globalFlags command.GlobalFlags,
 		services *services.Services,
 	) (command.Result, error) {
-		if createFlags.Results {
-			return nil, fmt.Errorf("⚠️ Results flag is no longer supported, results are by default included in all executions.")
+		if updateFlags.Results {
+			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
 		account, err := services.Accounts.AddContract(

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -34,7 +34,7 @@ type flagsCreate struct {
 	HashAlgo  string   `default:"SHA3_256" flag:"hash-algo" info:"Hash used for the digest"`
 	Name      string   `default:"default" flag:"name" info:"Name used for saving account"`
 	Contracts []string `flag:"contract" info:"Contract to be deployed during account creation. <name:filename>"`
-	Results   bool     `default:"false" flag:"results" info:"⚠️  No longer supported: results are provided by default"`
+	Results   bool     `default:"false" flag:"results" info:"⚠️  Deprecated: results are provided by default"`
 }
 
 var createFlags = flagsCreate{}
@@ -53,7 +53,7 @@ var CreateCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 		if createFlags.Results {
-			return nil, fmt.Errorf("⚠️ Results flag is no longer supported, results are by default included in all executions.")
+			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
 		account, err := services.Accounts.Create(

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -29,7 +29,7 @@ import (
 
 type flagsGet struct {
 	Contracts bool `default:"false" flag:"contracts" info:"Display contracts deployed to the account"`
-	Code      bool `default:"false" flag:"code" info:"⚠️  No longer supported: use contracts flag instead"`
+	Code      bool `default:"false" flag:"code" info:"⚠️  Deprecated: use contracts flag instead"`
 }
 
 var getFlags = flagsGet{}
@@ -48,7 +48,7 @@ var GetCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 		if getFlags.Code {
-			return nil, fmt.Errorf("⚠️  No longer supported: use contracts flag instead")
+			fmt.Println("⚠️  DEPRECATION WARNING: use contracts flag instead")
 		}
 
 		account, err := services.Accounts.Get(args[0]) // address
@@ -58,7 +58,7 @@ var GetCommand = &command.Command{
 
 		return &AccountResult{
 			Account:  account,
-			showCode: getFlags.Contracts,
+			showCode: getFlags.Contracts || getFlags.Code,
 		}, nil
 	},
 }

--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -28,7 +28,7 @@ import (
 )
 
 type flagsGenerate struct {
-	Verbose bool `flag:"verbose" info:"⚠️  No longer supported"`
+	Verbose bool `flag:"verbose" info:"⚠️  Deprecated"`
 }
 
 var generateFlag = flagsGenerate{}
@@ -48,7 +48,7 @@ var GetCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 		if generateFlag.Verbose {
-			return nil, fmt.Errorf("⚠️  No longer supported.")
+			fmt.Println("⚠️  DEPRECATION WARNING: verbose flag is deprecated")
 		}
 
 		end := ""

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -30,7 +30,7 @@ import (
 type flagsGenerate struct {
 	Seed       string `flag:"seed" info:"Deterministic seed phrase"`
 	KeySigAlgo string `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm"`
-	Algo       string `default:"" flag:"algo" info:"⚠️  No longer supported: use sig-algo argument"`
+	Algo       string `default:"" flag:"algo" info:"⚠️  Deprecated: use sig-algo argument"`
 }
 
 var generateFlags = flagsGenerate{}
@@ -49,7 +49,7 @@ var GenerateCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 		if generateFlags.Algo != "" {
-			return nil, fmt.Errorf("⚠️ Algo flag no longer supported: use '--sig-algo' flag.")
+			fmt.Println("⚠️ DEPRECATION WARNING: flag no longer supported, use '--sig-algo' instead.")
 		}
 
 		privateKey, err := services.Keys.Generate(generateFlags.Seed, generateFlags.KeySigAlgo)

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -50,6 +50,7 @@ var GenerateCommand = &command.Command{
 	) (command.Result, error) {
 		if generateFlags.Algo != "" {
 			fmt.Println("⚠️ DEPRECATION WARNING: flag no longer supported, use '--sig-algo' instead.")
+			generateFlags.KeySigAlgo = generateFlags.Algo
 		}
 
 		privateKey, err := services.Keys.Generate(generateFlags.Seed, generateFlags.KeySigAlgo)

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -30,8 +30,8 @@ import (
 type flagsScripts struct {
 	ArgsJSON string   `default:"" flag:"args-json" info:"arguments in JSON-Cadence format"`
 	Arg      []string `default:"" flag:"arg" info:"argument in Type:Value format"`
-	Code     bool     `default:"false" flag:"code" info:"⚠️  No longer supported: use filename argument"`
-	Args     string   `default:"false" flag:"args" info:"⚠️  No longer supported: use arg or args-json flag"`
+	Code     string   `default:"" flag:"code" info:"⚠️  Deprecated: use filename argument"`
+	Args     string   `default:"" flag:"args" info:"⚠️  Deprecated: use arg or args-json flag"`
 }
 
 var scriptFlags = flagsScripts{}
@@ -41,7 +41,7 @@ var ExecuteCommand = &command.Command{
 		Use:     "execute <filename>",
 		Short:   "Execute a script",
 		Example: `flow scripts execute script.cdc --arg String:"Meow" --arg String:"Woof"`,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 	},
 	Flags: &scriptFlags,
 	Run: func(
@@ -50,15 +50,26 @@ var ExecuteCommand = &command.Command{
 		globalFlags command.GlobalFlags,
 		services *services.Services,
 	) (command.Result, error) {
-		if scriptFlags.Code {
-			return nil, fmt.Errorf("⚠️  No longer supported: use filename argument")
+		filename := ""
+		if len(args) == 1 {
+			filename = args[0]
+		} else if scriptFlags.Code != "" {
+			fmt.Println("⚠️  DEPRECATION WARNING: use filename as a command argument <filename>")
+			filename = scriptFlags.Code
+		} else {
+			return nil, fmt.Errorf("provide a valide filename command argument")
 		}
+
 		if scriptFlags.Args != "" {
-			return nil, fmt.Errorf("⚠️  No longer supported: use arg flag in Type:Value format or arg-json for JSON format")
+			fmt.Println("⚠️  DEPRECATION WARNING: use arg flag in Type:Value format or arg-json for JSON format")
+
+			if len(scriptFlags.Arg) == 0 && scriptFlags.ArgsJSON == "" {
+				scriptFlags.ArgsJSON = scriptFlags.Args // backward compatible, args was in json format
+			}
 		}
 
 		value, err := services.Scripts.Execute(
-			args[0], // filename
+			filename,
 			scriptFlags.Arg,
 			scriptFlags.ArgsJSON,
 		)

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -61,7 +61,7 @@ var ExecuteCommand = &command.Command{
 		}
 
 		if scriptFlags.Args != "" {
-			fmt.Println("⚠️  DEPRECATION WARNING: use arg flag in Type:Value format or arg-json for JSON format")
+			fmt.Println("⚠️  DEPRECATION WARNING: use arg flag in Type:Value format or args-json for JSON format")
 
 			if len(scriptFlags.Arg) == 0 && scriptFlags.ArgsJSON == "" {
 				scriptFlags.ArgsJSON = scriptFlags.Args // backward compatible, args was in json format

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -25,12 +25,12 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
-type flagsStatus struct {
+type flagsGet struct {
 	Sealed bool `default:"true" flag:"sealed" info:"Wait for a sealed result"`
 	Code   bool `default:"false" flag:"code" info:"Display transaction code"`
 }
 
-var statusFlags = flagsStatus{}
+var getFlags = flagsGet{}
 
 var GetCommand = &command.Command{
 	Cmd: &cobra.Command{
@@ -38,7 +38,7 @@ var GetCommand = &command.Command{
 		Short: "Get the transaction status",
 		Args:  cobra.ExactArgs(1),
 	},
-	Flags: &statusFlags,
+	Flags: &getFlags,
 	Run: func(
 		cmd *cobra.Command,
 		args []string,
@@ -47,7 +47,7 @@ var GetCommand = &command.Command{
 	) (command.Result, error) {
 		tx, result, err := services.Transactions.GetStatus(
 			args[0], // transaction id
-			statusFlags.Sealed,
+			getFlags.Sealed,
 		)
 		if err != nil {
 			return nil, err
@@ -56,7 +56,7 @@ var GetCommand = &command.Command{
 		return &TransactionResult{
 			result: result,
 			tx:     tx,
-			code:   statusFlags.Code,
+			code:   getFlags.Code,
 		}, nil
 	},
 }

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -35,7 +35,7 @@ var getFlags = flagsGet{}
 var GetCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:   "get <tx_id>",
-		Short: "Get the transaction status",
+		Short: "Get the transaction by ID",
 		Args:  cobra.ExactArgs(1),
 	},
 	Flags: &getFlags,

--- a/internal/transactions/status.go
+++ b/internal/transactions/status.go
@@ -3,9 +3,10 @@ package transactions
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
-	"github.com/spf13/cobra"
 )
 
 type flagsStatus struct{}

--- a/internal/transactions/status.go
+++ b/internal/transactions/status.go
@@ -16,7 +16,6 @@ var StatusCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:   "status",
 		Short: "⚠️  No longer supported: use 'transactions get' command",
-		Args:  cobra.ExactArgs(1),
 	},
 	Flags: &statusFlags,
 	Run: func(

--- a/internal/transactions/status.go
+++ b/internal/transactions/status.go
@@ -1,0 +1,30 @@
+package transactions
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowcli/services"
+	"github.com/spf13/cobra"
+)
+
+type flagsStatus struct{}
+
+var statusFlags = flagsStatus{}
+
+var StatusCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:   "status",
+		Short: "⚠️  No longer supported: use 'transactions get' command",
+		Args:  cobra.ExactArgs(1),
+	},
+	Flags: &statusFlags,
+	Run: func(
+		cmd *cobra.Command,
+		args []string,
+		globalFlags command.GlobalFlags,
+		services *services.Services,
+	) (command.Result, error) {
+		return nil, fmt.Errorf("⚠️  No longer supported: use 'transactions get' command.")
+	},
+}

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
 func init() {
 	GetCommand.AddToParent(Cmd)
 	SendCommand.AddToParent(Cmd)
+	StatusCommand.AddToParent(Cmd)
 }
 
 // TransactionResult represent result from all account commands

--- a/pkg/flowcli/services/transactions_test.go
+++ b/pkg/flowcli/services/transactions_test.go
@@ -94,7 +94,7 @@ func TestTransactions(t *testing.T) {
 
 	t.Run("Send Transaction Fails wrong args", func(t *testing.T) {
 		_, _, err := transactions.Send("../../../tests/transaction.cdc", serviceName, []string{"Bar"}, "")
-		assert.Equal(t, err.Error(), "Argument not passed in correct format, correct format is: Type:Value, got Bar")
+		assert.Equal(t, err.Error(), "argument not passed in correct format, correct format is: Type:Value, got Bar")
 	})
 
 	t.Run("Send Transaction Fails wrong filename", func(t *testing.T) {


### PR DESCRIPTION
## Description
Flags and commands should first be deprecated and a warning should be shown in case it has been used after they can be removed. Do this for all commands unless those requiring a lot of additional programming to support.

Sample outputs:

```
scripts execute --code ./tests/script.cdc --args="[{\"type\": \"String\", \"value\": \"Hello, Cadence\"}]"
⚠️  DEPRECATION WARNING: use filename as a command argument <filename>
⚠️  DEPRECATION WARNING: use arg flag in Type:Value format or arg-json for JSON format
```

```
accounts get f8d6e0586b0a20c7 --code 
⚠️  DEPRECATION WARNING: use contracts flag instead
```

```
transactions status
❌ Command Error: ⚠️  No longer supported: use 'transactions get' command.
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
