### PR TITLE
Sharedlib camelcase

### DIFF
--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -50,7 +50,33 @@ type AccountResult struct {
 
 // JSON convert result to JSON
 func (r *AccountResult) JSON() interface{} {
-	return r
+	result := make(map[string]interface{})
+	result["address"] = r.Address
+	result["balance"] = r.Balance
+
+	keys := make([]string, 0)
+	for _, key := range r.Keys {
+		keys = append(keys, fmt.Sprintf("%x", key.PublicKey.Encode()))
+	}
+
+	result["keys"] = keys
+
+	contracts := make([]string, 0)
+	for name := range r.Contracts {
+		contracts = append(contracts, name)
+	}
+
+	result["contracts"] = contracts
+
+	if r.showCode {
+		c := make(map[string]string)
+		for name, code := range r.Contracts {
+			c[name] = string(code)
+		}
+		result["code"] = c
+	}
+
+	return result
 }
 
 // String convert result to string

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -51,11 +51,11 @@ type BlockResult struct {
 // JSON convert result to JSON
 func (r *BlockResult) JSON() interface{} {
 	result := make(map[string]interface{})
-	result["BlockID"] = r.block.ID.String()
-	result["ParentID"] = r.block.ParentID.String()
-	result["Height"] = r.block.Height
-	result["TotalSeals"] = len(r.block.Seals)
-	result["TotalCollections"] = len(r.block.CollectionGuarantees)
+	result["blockID"] = r.block.ID.String()
+	result["parentID"] = r.block.ParentID.String()
+	result["height"] = r.block.Height
+	result["totalSeals"] = len(r.block.Seals)
+	result["totalCollections"] = len(r.block.CollectionGuarantees)
 
 	collections := make([]interface{}, 0)
 	for i, guarantee := range r.block.CollectionGuarantees {
@@ -67,13 +67,13 @@ func (r *BlockResult) JSON() interface{} {
 			for _, tx := range r.collections[i].TransactionIDs {
 				txs = append(txs, tx.String())
 			}
-			collection["Transactions"] = txs
+			collection["transactions"] = txs
 		}
 
 		collections = append(collections, collection)
 	}
 
-	result["Collection"] = collections
+	result["collection"] = collections
 	return result
 }
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -54,10 +54,10 @@ func (k *EventResult) JSON() interface{} {
 	for _, blockEvent := range k.BlockEvents {
 		if len(blockEvent.Events) > 0 {
 			for _, event := range blockEvent.Events {
-				result["BlockID"][blockEvent.Height]["Index"] = event.EventIndex
-				result["BlockID"][blockEvent.Height]["Type"] = event.Type
-				result["BlockID"][blockEvent.Height]["TxID"] = event.TransactionID
-				result["BlockID"][blockEvent.Height]["Values"] = event.Value
+				result["blockID"][blockEvent.Height]["index"] = event.EventIndex
+				result["blockID"][blockEvent.Height]["type"] = event.Type
+				result["blockID"][blockEvent.Height]["txID"] = event.TransactionID
+				result["blockID"][blockEvent.Height]["values"] = event.Value
 			}
 		}
 	}

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -49,8 +49,8 @@ type KeyResult struct {
 // JSON convert result to JSON
 func (k *KeyResult) JSON() interface{} {
 	result := make(map[string]string)
-	result["Private"] = hex.EncodeToString(k.privateKey.PublicKey().Encode())
-	result["Public"] = hex.EncodeToString(k.privateKey.Encode())
+	result["private"] = hex.EncodeToString(k.privateKey.PublicKey().Encode())
+	result["public"] = hex.EncodeToString(k.privateKey.Encode())
 
 	return result
 }

--- a/internal/project/init.go
+++ b/internal/project/init.go
@@ -73,7 +73,12 @@ type InitResult struct {
 
 // JSON convert result to JSON
 func (r *InitResult) JSON() interface{} {
-	return r
+	account, _ := r.Project.EmulatorServiceAccount()
+	result := make(map[string]string)
+
+	result["serviceAccount"] = account.Address().Hex()
+
+	return result
 }
 
 // String convert result to string

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -43,7 +43,9 @@ type ScriptResult struct {
 
 // JSON convert result to JSON
 func (r *ScriptResult) JSON() interface{} {
-	return r
+	result := make(map[string]interface{})
+	result["result"] = r.Value
+	return result
 }
 
 // String convert result to string

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -50,11 +50,11 @@ type TransactionResult struct {
 // JSON convert result to JSON
 func (r *TransactionResult) JSON() interface{} {
 	result := make(map[string]string)
-	result["Hash"] = r.tx.ID().String()
-	result["Status"] = r.result.Status.String()
+	result["hash"] = r.tx.ID().String()
+	result["status"] = r.result.Status.String()
 
 	if r.result != nil {
-		result["Events"] = fmt.Sprintf("%s", r.result.Events)
+		result["events"] = fmt.Sprintf("%s", r.result.Events)
 	}
 
 	return result


### PR DESCRIPTION
## Description

Change values from JSON result to camel case.

Camel casing result values in JSON format causes a problem with the user knowing which values can now use in `--filter` flag as they are different from the normal output. 

In any case, it was bad UX to not show to the user possible filter values.

Handle invalid filter values and offer possible valid filter values:

```
❌ Result: value for filter: 'addres' doesn't exist, possible values to filter by: [address balance contracts keys]
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
