### PR TITLE
Sharedlib prepopulate config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,14 @@ Flow configuration (`flow.json`) file will contain the following properties:
     "emulator": {
       "host": "127.0.0.1:3569",
       "chain": "flow-emulator"
+    },
+    "mainnet": {
+      "host": "access.mainnet.nodes.onflow.org:9000",
+      "chain": "flow-mainnet"
+    },
+    "testnet": {
+      "host": "access.devnet.nodes.onflow.org:9000",
+      "chain": "flow-testnet"
     }
   },
   "accounts": {
@@ -97,9 +105,23 @@ We'll walk through each property one by one.
   "networks": {
     "emulator": {
       "host": "127.0.0.1:3569",
-      "serviceAccount": "emulator-service"
+      "chain": "flow-emulator"
     },
-    "testnet": "access.testnet.nodes.onflow.org:9000"
+    "mainnet": {
+      "host": "access.mainnet.nodes.onflow.org:9000",
+      "chain": "flow-mainnet"
+    },
+    "testnet": {
+      "host": "access.devnet.nodes.onflow.org:9000",
+      "chain": "flow-testnet"
+    }
+  },
+
+  "emulators": {
+    "default": {
+      "port": 3569,
+      "serviceAccount": "emulator-account"
+    }
   }
 }
 ```
@@ -256,9 +278,16 @@ Use this section to define networks and connection parameters for that specific 
 "networks": {
   "emulator": {
     "host": "127.0.0.1:3569",
-    "serviceAccount": "emulator-service"
+    "chain": "flow-emulator"
   },
-  "testnet": "access.testnet.nodes.onflow.org:9000"
+  "mainnet": {
+    "host": "access.mainnet.nodes.onflow.org:9000",
+    "chain": "flow-mainnet"
+  },
+  "testnet": {
+    "host": "access.devnet.nodes.onflow.org:9000",
+    "chain": "flow-testnet"
+  }
 }
 
 ...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,11 +4,11 @@ sidebar_title: Configuration
 description: What is Flow CLI Configuration
 ---
 
-Flow CLI uses a state called configuration and it is stored to a file (usually `flow.json`). 
+Flow CLI uses a state called configuration which is stored in a file (usually `flow.json`). 
 
 Flow configuration (`flow.json`) file will contain the following properties:
 
-- A `networks` list pre-populated with the Flow Emulator connection configuration.
+- A `networks` list pre-populated with the Flow emulator, testnet and mainnet connection configuration.
 - An `accounts` list pre-populated with the Flow Emulator service account.
 - An `emulators` list pre-populated with Flow Emulator configuration.
 - A `deployments` empty object where all [deployment targets](https://docs.onflow.org/flow-cli/project-contracts/) can be defined. 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -187,7 +187,7 @@ func resolveHost(proj *project.Project, hostFlag string, networkFlag string) (st
 
 		host = proj.NetworkByName(networkFlag).Host
 	} else if host == "" {
-		host = project.DefaultEmulatorHost
+		host = config.DefaultEmulatorNetwork().Host
 	}
 
 	return host, nil

--- a/pkg/flowcli/config/config.go
+++ b/pkg/flowcli/config/config.go
@@ -86,13 +86,97 @@ type Emulator struct {
 type KeyType string
 
 const (
-	KeyTypeHex                KeyType = "hex"        // Hex private key with in memory signer
-	KeyTypeGoogleKMS          KeyType = "google-kms" // Google KMS signer
-	KeyTypeShell              KeyType = "shell"      // Exec out to a shell script
-	DefaultEmulatorConfigName         = "default"
-	PrivateKeyField                   = "privateKey"
-	KMSContextField                   = "resourceName"
+	KeyTypeHex                        KeyType = "hex"        // Hex private key with in memory signer
+	KeyTypeGoogleKMS                  KeyType = "google-kms" // Google KMS signer
+	KeyTypeShell                      KeyType = "shell"      // Exec out to a shell script
+	DefaultEmulatorConfigName                 = "default"
+	PrivateKeyField                           = "privateKey"
+	KMSContextField                           = "resourceName"
+	DefaultEmulatorServiceAccountName         = "emulator-account"
 )
+
+// DefaultEmulatorNetwork get default emulator network
+func DefaultEmulatorNetwork() Network {
+	return Network{
+		Name:    "emulator",
+		Host:    "127.0.0.1:3569",
+		ChainID: flow.Emulator,
+	}
+}
+
+// DefaultTestnetNetwork get default testnet network
+func DefaultTestnetNetwork() Network {
+	return Network{
+		Name:    "testnet",
+		Host:    "access.devnet.nodes.onflow.org:9000",
+		ChainID: flow.Testnet,
+	}
+}
+
+// DefaultMainnetNetwork get default mainnet network
+func DefaultMainnetNetwork() Network {
+	return Network{
+		Name:    "mainnet",
+		Host:    "access.mainnet.nodes.onflow.org:9000",
+		ChainID: flow.Testnet,
+	}
+}
+
+// DefaultNetworks gets all default networks
+func DefaultNetworks() Networks {
+	return Networks{
+		DefaultEmulatorNetwork(),
+		DefaultTestnetNetwork(),
+		DefaultMainnetNetwork(),
+	}
+}
+
+// DefaultEmulator gets default emulator
+func DefaultEmulator() Emulator {
+	return Emulator{
+		Name:           "default",
+		ServiceAccount: DefaultEmulatorServiceAccountName,
+		Port:           3569,
+	}
+}
+
+// DefaultContracts get all standard contracts
+func StandardContracts() Contracts {
+	return Contracts{
+		Contract{
+			Name:    "FlowToken",
+			Source:  "",
+			Network: DefaultTestnetNetwork().Name,
+			Alias:   "0x7e60df042a9c0868",
+		},
+		Contract{
+			Name:    "FlowToken",
+			Source:  "",
+			Network: DefaultEmulatorNetwork().Name,
+			Alias:   "0x0ae53cb6e3f42a79",
+		},
+		Contract{
+			Name:    "FlowToken",
+			Source:  "",
+			Network: DefaultMainnetNetwork().Name,
+			Alias:   "0x1654653399040a61",
+		},
+	}
+}
+
+// DefaultConfig gets default configuration
+func DefaultConfig() *Config {
+	return &Config{
+		Emulators: DefaultEmulators(),
+		Networks:  DefaultNetworks(),
+		Contracts: StandardContracts(),
+	}
+}
+
+// DefaultEmulators gets all default emulators
+func DefaultEmulators() Emulators {
+	return Emulators{DefaultEmulator()}
+}
 
 // IsAlias checks if contract has an alias
 func (c *Contract) IsAlias() bool {

--- a/pkg/flowcli/config/config.go
+++ b/pkg/flowcli/config/config.go
@@ -118,7 +118,7 @@ func DefaultMainnetNetwork() Network {
 	return Network{
 		Name:    "mainnet",
 		Host:    "access.mainnet.nodes.onflow.org:9000",
-		ChainID: flow.Testnet,
+		ChainID: flow.Mainnet,
 	}
 }
 
@@ -140,36 +140,11 @@ func DefaultEmulator() Emulator {
 	}
 }
 
-// DefaultContracts get all standard contracts
-func StandardContracts() Contracts {
-	return Contracts{
-		Contract{
-			Name:    "FlowToken",
-			Source:  "",
-			Network: DefaultTestnetNetwork().Name,
-			Alias:   "0x7e60df042a9c0868",
-		},
-		Contract{
-			Name:    "FlowToken",
-			Source:  "",
-			Network: DefaultEmulatorNetwork().Name,
-			Alias:   "0x0ae53cb6e3f42a79",
-		},
-		Contract{
-			Name:    "FlowToken",
-			Source:  "",
-			Network: DefaultMainnetNetwork().Name,
-			Alias:   "0x1654653399040a61",
-		},
-	}
-}
-
 // DefaultConfig gets default configuration
 func DefaultConfig() *Config {
 	return &Config{
 		Emulators: DefaultEmulators(),
 		Networks:  DefaultNetworks(),
-		Contracts: StandardContracts(),
 	}
 }
 

--- a/pkg/flowcli/project/account.go
+++ b/pkg/flowcli/project/account.go
@@ -119,7 +119,7 @@ func generateEmulatorServiceAccount(sigAlgo crypto.SignatureAlgorithm, hashAlgo 
 	serviceAccountKey := NewHexAccountKeyFromPrivateKey(0, hashAlgo, privateKey)
 
 	return &Account{
-		name:    DefaultEmulatorServiceAccountName,
+		name:    config.DefaultEmulatorServiceAccountName,
 		address: flow.ServiceAddress(flow.Emulator),
 		chainID: flow.Emulator,
 		keys: []AccountKey{

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -99,32 +99,9 @@ func Init(sigAlgo crypto.SignatureAlgorithm, hashAlgo crypto.HashAlgorithm) (*Pr
 
 	return &Project{
 		composer: composer,
-		conf:     defaultConfig(emulatorServiceAccount),
+		conf:     config.DefaultConfig(),
 		accounts: []*Account{emulatorServiceAccount},
 	}, err
-}
-
-const (
-	DefaultEmulatorNetworkName        = "emulator"
-	DefaultEmulatorServiceAccountName = "emulator-account"
-	DefaultEmulatorPort               = 3569
-	DefaultEmulatorHost               = "127.0.0.1:3569"
-)
-
-// defaultConfig returns a new default configuration object.
-func defaultConfig(defaultEmulatorServiceAccount *Account) *config.Config {
-	return &config.Config{
-		Emulators: config.Emulators{{
-			Name:           config.DefaultEmulatorConfigName,
-			ServiceAccount: defaultEmulatorServiceAccount.name,
-			Port:           DefaultEmulatorPort,
-		}},
-		Networks: config.Networks{{
-			Name:    DefaultEmulatorNetworkName,
-			Host:    DefaultEmulatorHost,
-			ChainID: flow.Emulator,
-		}},
-	}
 }
 
 // newProject creates a new project from a configuration object.
@@ -176,7 +153,7 @@ func (p *Project) EmulatorServiceAccount() (*Account, error) {
 
 // SetEmulatorServiceKey sets the default emulator service account private key.
 func (p *Project) SetEmulatorServiceKey(privateKey crypto.PrivateKey) {
-	acc := p.AccountByName(DefaultEmulatorServiceAccountName)
+	acc := p.AccountByName(config.DefaultEmulatorServiceAccountName)
 	acc.SetDefaultKey(
 		NewHexAccountKeyFromPrivateKey(
 			acc.DefaultKey().Index(),

--- a/pkg/flowcli/services/transactions_test.go
+++ b/pkg/flowcli/services/transactions_test.go
@@ -94,7 +94,7 @@ func TestTransactions(t *testing.T) {
 
 	t.Run("Send Transaction Fails wrong args", func(t *testing.T) {
 		_, _, err := transactions.Send("../../../tests/transaction.cdc", serviceName, []string{"Bar"}, "")
-		assert.Equal(t, err.Error(), "Argument not passed in correct format, correct format is: Type:Value, got Bar")
+		assert.Equal(t, err.Error(), "argument not passed in correct format, correct format is: Type:Value, got Bar")
 	})
 
 	t.Run("Send Transaction Fails wrong filename", func(t *testing.T) {


### PR DESCRIPTION
Closes #125 

## Description
Prepopulate configuration with standard networks.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
