### PR TITLE
Improved deploying output log

### DIFF
--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -217,13 +217,15 @@ func (p *Project) ContractsByNetwork(network string) []Contract {
 	return contracts
 }
 
-// AllAccountName returns all configured account names.
-func (p *Project) AllAccountName() []string {
+// AllAccountsNames returns all configured account names.
+func (p *Project) AccountNamesForNetwork(network string) []string {
 	names := make([]string, 0)
 
 	for _, account := range p.accounts {
-		if !util.StringContains(names, account.name) {
-			names = append(names, account.name)
+		if len(p.conf.Deployments.GetByAccountAndNetwork(account.name, network)) > 0 {
+			if !util.StringContains(names, account.name) {
+				names = append(names, account.name)
+			}
 		}
 	}
 

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -217,7 +217,7 @@ func (p *Project) ContractsByNetwork(network string) []Contract {
 	return contracts
 }
 
-// AllAccountsNames returns all configured account names.
+// AccountNamesForNetwork returns all configured account names for a network.
 func (p *Project) AccountNamesForNetwork(network string) []string {
 	names := make([]string, 0)
 


### PR DESCRIPTION
## Description

Output when deploying was improved:
- Deploying to account message was fixed so it outputs only the account used in this deploy:
```
Deploying 4 contracts for accounts: emulator-account
```

- Error handling is more explicit for each contract:
```
Deploying 4 contracts for accounts: emulator-account

❌  contract Kibble is already deployed to this account. Use the --update flag to force update
❌  contract NonFungibleToken is already deployed to this account. Use the --update flag to force update
❌  contract KittyItems is already deployed to this account. Use the --update flag to force update
❌  contract KittyItemsMarket is already deployed to this account. Use the --update flag to force update
❌  failed to deploy contracts

❌ Command Error: failed to deploy contracts
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
