### PR TITLE
QA: Change --conf flag back to --config-path

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -122,7 +122,7 @@ func InitFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringSliceVarP(
 		&flags.ConfigPath,
-		"conf",
+		"config-path",
 		"f",
 		flags.ConfigPath,
 		"Path to flow configuration file",


### PR DESCRIPTION
## Description

I think it'd be best if we avoided this breaking change in this release