### PR TITLE
QA: Add default output format

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -62,6 +62,12 @@ type GlobalFlags struct {
 }
 
 const (
+	formatText   = "text"
+	formatInline = "inline"
+	formatJSON   = "json"
+)
+
+const (
 	logLevelDebug = "debug"
 	logLevelInfo  = "info"
 	logLevelError = "error"
@@ -70,7 +76,7 @@ const (
 
 var flags = GlobalFlags{
 	Filter:     "",
-	Format:     "",
+	Format:     formatText,
 	Save:       "",
 	Host:       "",
 	Log:        logLevelInfo,
@@ -101,7 +107,7 @@ func InitFlags(cmd *cobra.Command) {
 		"output",
 		"o",
 		flags.Format,
-		"Output format, values: 'json', 'inline'",
+		"Output format, options: \"text\", \"json\", \"inline\"",
 	)
 
 	cmd.PersistentFlags().StringVarP(
@@ -243,10 +249,10 @@ func formatResult(result Result, filterFlag string, formatFlag string) (string, 
 	}
 
 	switch formatFlag {
-	case "json":
+	case formatJSON:
 		jsonRes, _ := json.Marshal(result.JSON())
 		return string(jsonRes), nil
-	case "inline":
+	case formatInline:
 		return result.Oneliner(), nil
 	default:
 		return result.String(), nil


### PR DESCRIPTION
## Description

It felt a bit confusing to have no name for the default output 

"text" is inspired by this doc: https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-output-format.html