### PR TITLE
QA: Adjust JSON camelCase output

### DIFF
--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -66,8 +66,8 @@ type StakingResult struct {
 // JSON convert result to JSON
 func (r *StakingResult) JSON() interface{} {
 	result := make(map[string]interface{})
-	result["Staking"] = flowcli.NewStakingInfoFromValue(r.staking)
-	result["Delegation"] = flowcli.NewStakingInfoFromValue(r.delegation)
+	result["staking"] = flowcli.NewStakingInfoFromValue(r.staking)
+	result["delegation"] = flowcli.NewStakingInfoFromValue(r.delegation)
 
 	return result
 }

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -51,8 +51,8 @@ type BlockResult struct {
 // JSON convert result to JSON
 func (r *BlockResult) JSON() interface{} {
 	result := make(map[string]interface{})
-	result["blockID"] = r.block.ID.String()
-	result["parentID"] = r.block.ParentID.String()
+	result["blockId"] = r.block.ID.String()
+	result["parentId"] = r.block.ParentID.String()
 	result["height"] = r.block.Height
 	result["totalSeals"] = len(r.block.Seals)
 	result["totalCollections"] = len(r.block.CollectionGuarantees)
@@ -60,7 +60,7 @@ func (r *BlockResult) JSON() interface{} {
 	collections := make([]interface{}, 0)
 	for i, guarantee := range r.block.CollectionGuarantees {
 		collection := make(map[string]interface{})
-		collection["ID"] = guarantee.CollectionID.String()
+		collection["id"] = guarantee.CollectionID.String()
 
 		if r.verbose {
 			txs := make([]string, 0)

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -54,10 +54,10 @@ func (k *EventResult) JSON() interface{} {
 	for _, blockEvent := range k.BlockEvents {
 		if len(blockEvent.Events) > 0 {
 			for _, event := range blockEvent.Events {
-				result["blockID"][blockEvent.Height]["index"] = event.EventIndex
-				result["blockID"][blockEvent.Height]["type"] = event.Type
-				result["blockID"][blockEvent.Height]["txID"] = event.TransactionID
-				result["blockID"][blockEvent.Height]["values"] = event.Value
+				result["blockId"][blockEvent.Height]["index"] = event.EventIndex
+				result["blockId"][blockEvent.Height]["type"] = event.Type
+				result["blockId"][blockEvent.Height]["transactionId"] = event.TransactionID
+				result["blockId"][blockEvent.Height]["values"] = event.Value
 			}
 		}
 	}

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -51,7 +51,7 @@ type TransactionResult struct {
 // JSON convert result to JSON
 func (r *TransactionResult) JSON() interface{} {
 	result := make(map[string]string)
-	result["hash"] = r.tx.ID().String()
+	result["id"] = r.tx.ID().String()
 	result["status"] = r.result.Status.String()
 
 	if r.result != nil {
@@ -66,7 +66,7 @@ func (r *TransactionResult) String() string {
 	var b bytes.Buffer
 	writer := tabwriter.NewWriter(&b, 0, 8, 1, '\t', tabwriter.AlignRight)
 
-	fmt.Fprintf(writer, "Hash\t %s\n", r.tx.ID())
+	fmt.Fprintf(writer, "ID\t %s\n", r.tx.ID())
 	fmt.Fprintf(writer, "Status\t %s\n", r.result.Status)
 	fmt.Fprintf(writer, "Payer\t %s\n", r.tx.Payer.Hex())
 
@@ -85,5 +85,5 @@ func (r *TransactionResult) String() string {
 
 // Oneliner show result as one liner grep friendly
 func (r *TransactionResult) Oneliner() string {
-	return fmt.Sprintf("Hash: %s, Status: %s, Events: %s", r.tx.ID(), r.result.Status, r.result.Events)
+	return fmt.Sprintf("ID: %s, Status: %s, Events: %s", r.tx.ID(), r.result.Status, r.result.Events)
 }


### PR DESCRIPTION
## Description

- Noticed that staking info still had capitalized JSON output
- Opted use `Id` instead of `ID` -- I think it's a bit more JSONish
- Changed transaction `Hash` to `ID`, since that's what we say in our docs