### PR TITLE
QA: Preserve project commands

### DIFF
--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -31,14 +31,14 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
-type flagsInit struct {
+type FlagsInit struct {
 	ServicePrivateKey  string `flag:"service-private-key" info:"Service account private key"`
 	ServiceKeySigAlgo  string `default:"ECDSA_P256" flag:"service-sig-algo" info:"Service account key signature algorithm"`
 	ServiceKeyHashAlgo string `default:"SHA3_256" flag:"service-hash-algo" info:"Service account key hash algorithm"`
 	Reset              bool   `default:"false" flag:"reset" info:"Reset flow.json config file"`
 }
 
-var initFlag = flagsInit{}
+var initFlag = FlagsInit{}
 
 var InitCommand = &command.Command{
 	Cmd: &cobra.Command{

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -32,13 +32,9 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
-var Cmd = &cobra.Command{
-	Use:              "emulator",
-	Short:            "Flow emulator server",
-	TraverseChildren: true,
-}
+var Cmd *cobra.Command
 
-func configuredServiceKey(
+func ConfiguredServiceKey(
 	init bool,
 	sigAlgo crypto.SignatureAlgorithm,
 	hashAlgo crypto.HashAlgorithm,
@@ -99,6 +95,6 @@ func configuredServiceKey(
 }
 
 func init() {
-	Cmd = start.Cmd(configuredServiceKey)
+	Cmd = start.Cmd(ConfiguredServiceKey)
 	Cmd.Use = "emulator"
 }

--- a/internal/project/emulator.go
+++ b/internal/project/emulator.go
@@ -19,17 +19,15 @@
 package project
 
 import (
+	"github.com/onflow/flow-emulator/cmd/emulator/start"
 	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/emulator"
 )
 
-var Cmd = &cobra.Command{
-	Use:              "project",
-	Short:            "Manage your Cadence project",
-	TraverseChildren: true,
-}
+var EmulatorCommand *cobra.Command
 
 func init() {
-	InitCommand.AddToParent(Cmd)
-	DeployCommand.AddToParent(Cmd)
-	Cmd.AddCommand(EmulatorCommand)
+	EmulatorCommand = start.Cmd(emulator.ConfiguredServiceKey)
+	EmulatorCommand.Use = "start-emulator"
 }

--- a/internal/project/emulator.go
+++ b/internal/project/emulator.go
@@ -19,6 +19,8 @@
 package project
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-emulator/cmd/emulator/start"
 	"github.com/spf13/cobra"
 
@@ -29,5 +31,8 @@ var EmulatorCommand *cobra.Command
 
 func init() {
 	EmulatorCommand = start.Cmd(emulator.ConfiguredServiceKey)
+	EmulatorCommand.PreRun = func(cmd *cobra.Command, args []string) {
+		fmt.Printf("⚠️  DEPRECATION WARNING: use \"flow emulator\" instead\n\n")
+	}
 	EmulatorCommand.Use = "start-emulator"
 }

--- a/internal/project/init.go
+++ b/internal/project/init.go
@@ -1,0 +1,59 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/services"
+)
+
+var initFlag = config.FlagsInit{}
+
+var InitCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:   "init",
+		Short: "Initialize a new configuration",
+	},
+	Flags: &initFlag,
+	Run: func(
+		cmd *cobra.Command,
+		args []string,
+		globalFlags command.GlobalFlags,
+		services *services.Services,
+	) (command.Result, error) {
+		fmt.Println("⚠️  DEPRECATION WARNING: use \"flow init\" instead")
+
+		proj, err := services.Project.Init(
+			initFlag.Reset,
+			initFlag.ServiceKeySigAlgo,
+			initFlag.ServiceKeyHashAlgo,
+			initFlag.ServicePrivateKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &config.InitResult{Project: proj}, nil
+	},
+}


### PR DESCRIPTION
## Description

As I was testing the new CLI build, I found it confusing that the `project` command suddenly only had one command: `flow project deploy`

I think it would be good to keep the `project` commands around for a couple releases, mainly because so many users have gone through the Pinata tutorial which references these commands.

I think I found a way to do it with minimal additional code