### PR TITLE
QA wrong flag value

### DIFF
--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -33,7 +33,7 @@ type flagsSend struct {
 	Signer   string   `default:"emulator-account" flag:"signer"`
 	Code     string   `default:"" flag:"code" info:"⚠️  Deprecated: use filename argument"`
 	Results  bool     `default:"" flag:"results" info:"⚠️  Deprecated: all transactions will provide result"`
-	Args     string   `default:"false" flag:"args" info:"⚠️  Deprecated: use arg or args-json flag"`
+	Args     string   `default:"" flag:"args" info:"⚠️  Deprecated: use arg or args-json flag"`
 }
 
 var sendFlags = flagsSend{}


### PR DESCRIPTION
## Description

Args flag had wrong default value causing warning to be shown everytime
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
