### PR TITLE
Extract out the parsing of the arguments one layer

### DIFF
--- a/pkg/flowcli/services/transactions_test.go
+++ b/pkg/flowcli/services/transactions_test.go
@@ -132,7 +132,7 @@ func TestTransactions(t *testing.T) {
 		_, _, err := transactions.Send(
 			"nooo.cdc",
 			serviceName,
-			[]string{"Bar"},
+			[]string{"String:Bar"},
 			"",
 			"",
 		)


### PR DESCRIPTION
Why:

* I want to reimplement go-with-the-flow on top of flow-cli
* go-with-the-flow has a builder to add Arguments and already has an array of cadnece.Value
* with the new SendWithArguments method it can be used directly

This change addresses the need by:

* go-with-the-flow to reimplement on top of flow-cli

Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
