### PR TITLE
Account creation with multiple keys and non default key weights

### DIFF
--- a/docs/create-accounts.md
+++ b/docs/create-accounts.md
@@ -63,8 +63,9 @@ upon creation.
 - Valid inputs: number between 0 and 1000
 - Default: 1000
 
-Specify the weight of the key. When key weight is provided it must 
-match the number of keys. Specify key weight flag for each key flag.
+Specify the weight of the public key being added to the new account. 
+
+When opting to use this flag, you must specify a `--key-weight` flag for each public `--key` flag provided.
 
 ### Public Key Signature Algorithm
     


### PR DESCRIPTION
Closes #177 

## Description
Allow creating account with multiple keys and non default key weights. Currently CLI defaulted all key weights to max key weight. 

Flag was introduced to solve this as in show bellow:

```bash
accounts create --key 452...115b --key-weight 500 --key 85d...512 --key-weight 500 --key 046...26d7 --key-weight 500

Address	 0x01cf0e2f2f715450
Balance	 0.10000000
Keys	 3

Key 0	Public Key		 452...9115b
	Weight			 500
	Signature Algorithm	 ECDSA_P256
	Hash Algorithm		 SHA3_256
	Revoked 		 false


Key 1	Public Key		 855d0eb...ba512
	Weight			 500
	Signature Algorithm	 ECDSA_P256
	Hash Algorithm		 SHA3_256
	Revoked 		 false


Key 2	Public Key		 0646d8...26d87
	Weight			 500
	Signature Algorithm	 ECDSA_P256
	Hash Algorithm		 SHA3_256
	Revoked 		 false



```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
