### PR TITLE
Bugfix: init reset fixed

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -152,7 +152,7 @@ func (c Command) AddToParent(parent *cobra.Command) {
 		// initialize project but ignore error since config can be missing
 		proj, err := project.Load(flags.ConfigPath)
 		// here we ignore if config does not exist as some commands don't require it
-		if !errors.Is(err, config.ErrDoesNotExist) {
+		if !errors.Is(err, config.ErrDoesNotExist) && cmd.CommandPath() != "flow init" { // ignore configs errors if we are doing init config
 			handleError("Config Error", err)
 		}
 


### PR DESCRIPTION
Closes #180 

## 🐛  Description
Add an exception to the handling of errors in command in case the command is flow init. 
Better implementation could be possible but if we compare the command itself we get circular dependency and since this is only a temporary fix (soon or later we won't need anymore I don't think refactor is needed).
