### PR TITLE
Bugfix: Use config path in emulator

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -74,7 +74,7 @@ const (
 	logLevelNone  = "none"
 )
 
-var flags = GlobalFlags{
+var Flags = GlobalFlags{
 	Filter:     "",
 	Format:     formatText,
 	Save:       "",
@@ -87,58 +87,58 @@ var flags = GlobalFlags{
 // InitFlags init all the global persistent flags
 func InitFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
-		&flags.Filter,
+		&Flags.Filter,
 		"filter",
 		"x",
-		flags.Filter,
+		Flags.Filter,
 		"Filter result values by property name",
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&flags.Host,
+		&Flags.Host,
 		"host",
 		"",
-		flags.Host,
+		Flags.Host,
 		"Flow Access API host address",
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&flags.Format,
+		&Flags.Format,
 		"output",
 		"o",
-		flags.Format,
+		Flags.Format,
 		"Output format, options: \"text\", \"json\", \"inline\"",
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&flags.Save,
+		&Flags.Save,
 		"save",
 		"s",
-		flags.Save,
+		Flags.Save,
 		"Save result to a filename",
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&flags.Log,
+		&Flags.Log,
 		"log",
 		"l",
-		flags.Log,
+		Flags.Log,
 		"Log level, options: \"debug\", \"info\", \"error\", \"none\"",
 	)
 
 	cmd.PersistentFlags().StringSliceVarP(
-		&flags.ConfigPath,
+		&Flags.ConfigPath,
 		"config-path",
 		"f",
-		flags.ConfigPath,
+		Flags.ConfigPath,
 		"Path to flow configuration file",
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&flags.Network,
+		&Flags.Network,
 		"network",
 		"n",
-		flags.Network,
+		Flags.Network,
 		"Network from configuration file",
 	)
 }
@@ -150,32 +150,32 @@ func InitFlags(cmd *cobra.Command) {
 func (c Command) AddToParent(parent *cobra.Command) {
 	c.Cmd.Run = func(cmd *cobra.Command, args []string) {
 		// initialize project but ignore error since config can be missing
-		proj, err := project.Load(flags.ConfigPath)
+		proj, err := project.Load(Flags.ConfigPath)
 		// here we ignore if config does not exist as some commands don't require it
 		if !errors.Is(err, config.ErrDoesNotExist) {
 			handleError("Config Error", err)
 		}
 
-		host, err := resolveHost(proj, flags.Host, flags.Network)
+		host, err := resolveHost(proj, Flags.Host, Flags.Network)
 		handleError("Host Error", err)
 
 		clientGateway, err := createGateway(host)
 		handleError("Gateway Error", err)
 
-		logger := createLogger(flags.Log, flags.Format)
+		logger := createLogger(Flags.Log, Flags.Format)
 
 		service := services.NewServices(clientGateway, proj, logger)
 
 		// run command
-		result, err := c.Run(cmd, args, flags, service)
+		result, err := c.Run(cmd, args, Flags, service)
 		handleError("Command Error", err)
 
 		// format output result
-		formattedResult, err := formatResult(result, flags.Filter, flags.Format)
+		formattedResult, err := formatResult(result, Flags.Filter, Flags.Format)
 		handleError("Result", err)
 
 		// output result
-		err = outputResult(formattedResult, flags.Save)
+		err = outputResult(formattedResult, Flags.Save)
 		handleError("Output Error", err)
 	}
 

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -21,6 +21,8 @@ package emulator
 import (
 	"errors"
 
+	"github.com/onflow/flow-cli/internal/command"
+
 	emulator "github.com/onflow/flow-emulator"
 
 	"github.com/onflow/flow-emulator/cmd/emulator/start"
@@ -65,7 +67,7 @@ func ConfiguredServiceKey(
 			}
 		}
 	} else {
-		proj, err = project.Load(project.DefaultConfigPaths)
+		proj, err = project.Load(command.Flags.ConfigPath)
 		if err != nil {
 			if errors.Is(err, config.ErrDoesNotExist) {
 				util.Exitf(1, "🙏 Configuration is missing, initialize it with: 'flow project init' and then rerun this command.")


### PR DESCRIPTION
Closes #182 

## 🐛  Description
Pass global config flag to the emulator special command

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
