### PR TITLE
QA: Spinner output fix

### DIFF
--- a/pkg/flowcli/output/spinner.go
+++ b/pkg/flowcli/output/spinner.go
@@ -75,4 +75,5 @@ func (s *Spinner) run() {
 
 func (s *Spinner) Stop() {
 	s.done <- ""
+	time.Sleep(50 * time.Millisecond)
 }


### PR DESCRIPTION
## Description
Spinner had a rare race condition where it would handle the stop function after another log was output so it erased the output of the new log instead of own spinner text.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
