### PR TITLE
QA: Network default value in compare

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -209,7 +209,7 @@ func createGateway(host string) (gateway.Gateway, error) {
 // resolveHost from the flags provided
 func resolveHost(proj *project.Project, hostFlag string, networkFlag string) (string, error) {
 	// don't allow both network and host flag as the host might be different
-	if networkFlag != "" && hostFlag != "" {
+	if networkFlag != config.DefaultEmulatorNetwork().Name && hostFlag != "" {
 		return "", fmt.Errorf("shouldn't use both host and network flags, better to use network flag")
 	}
 


### PR DESCRIPTION
## Description
Network flag was compared to empty string but it should be to default value.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
