### PR TITLE
Global Configuration

### DIFF
--- a/docs/initialize-configuration.md
+++ b/docs/initialize-configuration.md
@@ -34,18 +34,42 @@ or by removing the configuration file first.
 ❌ Command Error: configuration already exists at: flow.json, if you want to reset configuration use the reset flag
 ```
 
+## Global Configuration
+
+Flow supports global configuration which is a `.flow.json` file saved in your home 
+directory and loaded as the first configuration file wherever you execute the CLI command. 
+
+Please be aware that global configuration has the lowest priority and is overwritten 
+by any other configuration file if they exist (if `flow.json` exist in your current 
+directory it will overwrite properties in global configuration, but only those which overlap).
+
+You can generate a global configuration using `--global` flag. 
+
+Command example: `flow init --global`.
+
+Global flow configuration is saved as:
+- MacOs: `~/.flow.json`
+- Linux: `~/.flow.json`
+- Windows: `C:\Users\$USER\.flow.json`
+
 
 ## Flags
 
 ### Reset
 
-- Flag: `reset`
+- Flag: `--reset`
 
 Using this flag will reset the existing configuration and create a new one.
 
+### Global
+
+- Flag: `--global`
+
+Using this flag will create a global Flow configuration.
+
 ### Service Private Key
 
-- Flag: `service-private-key`
+- Flag: `--service-private-key`
 - Valid inputs: a hex-encoded private key in raw form.
 
 Private key used on the default service account.
@@ -53,7 +77,7 @@ Private key used on the default service account.
 
 ### Service Key Signature Algorithm
 
-- Flag: `--sig-algo`
+- Flag: `--service-sig-algo`
 - Valid inputs: `"ECDSA_P256", "ECDSA_secp256k1"`
 - Default: `"ECDSA_P256"`
 
@@ -63,7 +87,7 @@ Flow supports the secp256k1 and P-256 curves.
 
 ### Service Key Hash Algorithm
 
-- Flag: `--hash-algo`
+- Flag: `--service-hash-algo`
 - Valid inputs: `"SHA2_256", "SHA3_256"`
 - Default: `"SHA3_256"`
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -86,7 +86,7 @@ var Flags = GlobalFlags{
 	Network:    config.DefaultEmulatorNetwork().Name,
 	Log:        logLevelInfo,
 	Yes:        false,
-	ConfigPath: project.DefaultConfigPaths,
+	ConfigPath: config.DefaultConfigPaths,
 }
 
 // InitFlags init all the global persistent flags

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -35,7 +35,8 @@ type FlagsInit struct {
 	ServicePrivateKey  string `flag:"service-private-key" info:"Service account private key"`
 	ServiceKeySigAlgo  string `default:"ECDSA_P256" flag:"service-sig-algo" info:"Service account key signature algorithm"`
 	ServiceKeyHashAlgo string `default:"SHA3_256" flag:"service-hash-algo" info:"Service account key hash algorithm"`
-	Reset              bool   `default:"false" flag:"reset" info:"Reset flow.json config file"`
+	Reset              bool   `default:"false" flag:"reset" info:"Reset configuration file"`
+	Global             bool   `default:"false" flag:"global" info:"Initialize global user configuration"`
 }
 
 var initFlag = FlagsInit{}
@@ -54,6 +55,7 @@ var InitCommand = &command.Command{
 	) (command.Result, error) {
 		proj, err := services.Project.Init(
 			initFlag.Reset,
+			initFlag.Global,
 			initFlag.ServiceKeySigAlgo,
 			initFlag.ServiceKeyHashAlgo,
 			initFlag.ServicePrivateKey,

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -61,13 +61,13 @@ func ConfiguredServiceKey(
 		if err != nil {
 			util.Exitf(1, err.Error())
 		} else {
-			err = proj.Save(config.DefaultConfigPath)
+			err = proj.Save(config.DefaultPath)
 			if err != nil {
 				util.Exitf(1, err.Error())
 			}
 		}
 	} else {
-		proj, err = project.Load(command.Flags.ConfigPath)
+		proj, err = project.Load(command.Flags.ConfigPaths)
 		if err != nil {
 			if errors.Is(err, config.ErrDoesNotExist) {
 				util.Exitf(1, "🙏 Configuration is missing, initialize it with: 'flow init' and then rerun this command.")

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -61,7 +61,7 @@ func ConfiguredServiceKey(
 		if err != nil {
 			util.Exitf(1, err.Error())
 		} else {
-			err = proj.Save(project.DefaultConfigPath)
+			err = proj.Save(config.DefaultConfigPath)
 			if err != nil {
 				util.Exitf(1, err.Error())
 			}

--- a/internal/project/init.go
+++ b/internal/project/init.go
@@ -47,6 +47,7 @@ var InitCommand = &command.Command{
 
 		proj, err := services.Project.Init(
 			initFlag.Reset,
+			initFlag.Global,
 			initFlag.ServiceKeySigAlgo,
 			initFlag.ServiceKeyHashAlgo,
 			initFlag.ServicePrivateKey,

--- a/pkg/flowcli/config/config.go
+++ b/pkg/flowcli/config/config.go
@@ -20,6 +20,8 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/onflow/cadence"
 
@@ -111,11 +113,6 @@ const (
 	DefaultEmulatorServiceAccountName         = "emulator-account"
 )
 
-var (
-	DefaultConfigPaths = []string{"flow.json"}
-	DefaultConfigPath  = DefaultConfigPaths[0]
-)
-
 // DefaultEmulatorNetwork get default emulator network
 func DefaultEmulatorNetwork() Network {
 	return Network{
@@ -175,6 +172,26 @@ func DefaultEmulators() Emulators {
 }
 
 var ErrOutdatedFormat = errors.New("you are using old configuration format")
+
+const DefaultPath = "flow.json"
+
+// GlobalPath gets global path based on home dir
+func GlobalPath() string {
+	dirname, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/.%s", dirname, DefaultPath)
+}
+
+// DefaultPaths determines default paths for configuration
+func DefaultPaths() []string {
+	return []string{
+		GlobalPath(),
+		DefaultPath,
+	}
+}
 
 // IsAlias checks if contract has an alias
 func (c *Contract) IsAlias() bool {

--- a/pkg/flowcli/config/config.go
+++ b/pkg/flowcli/config/config.go
@@ -111,6 +111,11 @@ const (
 	DefaultEmulatorServiceAccountName         = "emulator-account"
 )
 
+var (
+	DefaultConfigPaths = []string{"flow.json"}
+	DefaultConfigPath  = DefaultConfigPaths[0]
+)
+
 // DefaultEmulatorNetwork get default emulator network
 func DefaultEmulatorNetwork() Network {
 	return Network{

--- a/pkg/flowcli/config/loader.go
+++ b/pkg/flowcli/config/loader.go
@@ -107,16 +107,21 @@ func (l *Loader) Save(conf *Config, path string) error {
 func (l *Loader) Load(paths []string) (*Config, error) {
 	var baseConf *Config
 
-	for _, path := range paths {
-		raw, err := l.loadFile(path)
+	for _, confPath := range paths {
+		raw, err := l.loadFile(confPath)
+		// if we don't find local config or global config skip as either may miss
+		if err != nil && (confPath == DefaultPath || confPath == GlobalPath()) {
+			continue
+		}
+
 		if err != nil {
 			return nil, err
 		}
 
 		preProcessed := l.preprocess(raw)
-		configParser := l.configParsers.FindForFormat(filepath.Ext(path))
+		configParser := l.configParsers.FindForFormat(filepath.Ext(confPath))
 		if configParser == nil {
-			return nil, fmt.Errorf("Parser not found for config: %s", path)
+			return nil, fmt.Errorf("parser not found for config: %s", confPath)
 		}
 
 		conf, err := configParser.Deserialize(preProcessed)
@@ -131,6 +136,11 @@ func (l *Loader) Load(paths []string) (*Config, error) {
 		}
 
 		l.composeConfig(baseConf, conf)
+	}
+
+	// if no config was loaded - neither local nor global return an error
+	if baseConf == nil {
+		return nil, fmt.Errorf("configuration not found, create one using `flow init`")
 	}
 
 	baseConf, err := l.postprocess(baseConf)

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -34,11 +34,6 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/config/json"
 )
 
-var (
-	DefaultConfigPaths = []string{"flow.json"}
-	DefaultConfigPath  = DefaultConfigPaths[0]
-)
-
 // Project contains the configuration for a Flow project.
 type Project struct {
 	composer *config.Loader

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -50,12 +50,12 @@ type Contract struct {
 }
 
 // Load loads a project configuration and returns the resulting project.
-func Load(configFilePath []string) (*Project, error) {
+func Load(configFilePaths []string) (*Project, error) {
 	composer := config.NewLoader(afero.NewOsFs())
 
 	// here we add all available parsers (more to add yaml etc...)
 	composer.AddConfigParser(json.NewParser())
-	conf, err := composer.Load(configFilePath)
+	conf, err := composer.Load(configFilePaths)
 
 	if err != nil {
 		if errors.Is(err, config.ErrDoesNotExist) {

--- a/pkg/flowcli/services/project.go
+++ b/pkg/flowcli/services/project.go
@@ -60,15 +60,15 @@ func (p *Project) Init(
 	serviceKeyHashAlgo string,
 	servicePrivateKey string,
 ) (*project.Project, error) {
-	path := config.DefaultConfigPath
+	path := config.DefaultPath
 	if global {
-		path = ""
+		path = config.GlobalPath()
 	}
 
 	if project.Exists(path) && !reset {
 		return nil, fmt.Errorf(
 			"configuration already exists at: %s, if you want to reset configuration use the reset flag",
-			config.DefaultConfigPath,
+			path,
 		)
 	}
 

--- a/pkg/flowcli/services/project.go
+++ b/pkg/flowcli/services/project.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
 	"github.com/onflow/flow-go-sdk/crypto"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/contracts"
@@ -53,14 +55,20 @@ func NewProject(
 
 func (p *Project) Init(
 	reset bool,
+	global bool,
 	serviceKeySigAlgo string,
 	serviceKeyHashAlgo string,
 	servicePrivateKey string,
 ) (*project.Project, error) {
-	if project.Exists(project.DefaultConfigPath) && !reset {
+	path := config.DefaultConfigPath
+	if global {
+		path = ""
+	}
+
+	if project.Exists(path) && !reset {
 		return nil, fmt.Errorf(
 			"configuration already exists at: %s, if you want to reset configuration use the reset flag",
-			project.DefaultConfigPath,
+			config.DefaultConfigPath,
 		)
 	}
 
@@ -83,7 +91,7 @@ func (p *Project) Init(
 		proj.SetEmulatorServiceKey(serviceKey)
 	}
 
-	err = proj.Save(project.DefaultConfigPath)
+	err = proj.Save(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #211 

## Description
Create a global configuration file in the user home directory as `~/.flow.json` and load it as the first configuration, so in case there is a `flow.json` configuration present in the current directory overwrite the global configuration but only with properties that overlap.

Command for creating global config:
`flow init --global`
