### PR TITLE
Remove multiple keys

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -218,7 +218,7 @@ func resolveHost(proj *project.Project, hostFlag string, networkFlag string) (st
 		return hostFlag, nil
 	}
 	// network flag with project initialized is next
-	if networkFlag != "" && proj != nil {
+	if proj != nil {
 		check := proj.NetworkByName(networkFlag)
 		if check == nil {
 			return "", fmt.Errorf("network with name %s does not exist in configuration", networkFlag)

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -77,23 +77,22 @@ func ConfiguredServiceKey(
 		}
 	}
 
-	serviceAccount, _ := proj.EmulatorServiceAccount()
+	serviceAccount, err := proj.EmulatorServiceAccount()
+	if err != nil {
+		util.Exit(1, err.Error())
+	}
 
-	serviceKeyHex, ok := serviceAccount.Key().(*project.HexAccountKey)
-	if !ok {
+	privateKey, err := serviceAccount.Key().PrivateKey()
+	if err != nil {
 		util.Exit(1, "Only hexadecimal keys can be used as the emulator service account key.")
 	}
 
-	privateKey, err := crypto.DecodePrivateKeyHex(serviceKeyHex.SigAlgo(), serviceKeyHex.PrivateKeyHex())
+	err = serviceAccount.Key().Validate()
 	if err != nil {
-		util.Exitf(
-			1,
-			"Invalid private key in \"%s\" emulator configuration",
-			config.DefaultEmulatorConfigName,
-		)
+		util.Exit(1, err.Error())
 	}
 
-	return privateKey, serviceKeyHex.SigAlgo(), serviceKeyHex.HashAlgo()
+	return *privateKey, serviceAccount.Key().SigAlgo(), serviceAccount.Key().HashAlgo()
 }
 
 func init() {

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -79,7 +79,7 @@ func ConfiguredServiceKey(
 
 	serviceAccount, _ := proj.EmulatorServiceAccount()
 
-	serviceKeyHex, ok := serviceAccount.DefaultKey().(*project.HexAccountKey)
+	serviceKeyHex, ok := serviceAccount.Key().(*project.HexAccountKey)
 	if !ok {
 		util.Exit(1, "Only hexadecimal keys can be used as the emulator service account key.")
 	}

--- a/pkg/flowcli/config/config.go
+++ b/pkg/flowcli/config/config.go
@@ -80,7 +80,7 @@ type Account struct {
 	Name    string
 	Address flow.Address
 	ChainID flow.ChainID
-	Keys    []AccountKey
+	Key     AccountKey
 }
 
 // AccountKey defines the configuration for a Flow account key.

--- a/pkg/flowcli/config/config_test.go
+++ b/pkg/flowcli/config/config_test.go
@@ -87,7 +87,7 @@ func generateComplexConfig() config.Config {
 			Name:    "emulator-account",
 			Address: flow.ServiceAddress(flow.Emulator),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -95,12 +95,12 @@ func generateComplexConfig() config.Config {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}, {
 			Name:    "account-2",
 			Address: flow.HexToAddress("2c1162386b0a245f"),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -108,12 +108,12 @@ func generateComplexConfig() config.Config {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}, {
 			Name:    "account-4",
 			Address: flow.HexToAddress("f8d6e0586b0a20c1"),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -121,7 +121,7 @@ func generateComplexConfig() config.Config {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}},
 		Networks: config.Networks{{
 			Name:    "emulator",

--- a/pkg/flowcli/config/json/account.go
+++ b/pkg/flowcli/config/json/account.go
@@ -20,6 +20,7 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -168,6 +169,16 @@ type jsonAccountKey struct {
 	Context  map[string]string `json:"context"`
 }
 
+type jsonAccountSimpleOld struct {
+	Address string `json:"address"`
+	Keys    string `json:"keys"`
+}
+
+type jsonAccountAdvancedOld struct {
+	Address string           `json:"address"`
+	Keys    []jsonAccountKey `json:"keys"`
+}
+
 type jsonAccount struct {
 	Simple   jsonAccountSimple
 	Advanced jsonAccountAdvanced
@@ -175,9 +186,33 @@ type jsonAccount struct {
 
 func (j *jsonAccount) UnmarshalJSON(b []byte) error {
 
+	fmt.Println("IN", string(b))
+
+	// try simple old format
+	var simpleOld jsonAccountSimpleOld
+	err := json.Unmarshal(b, &simpleOld)
+	if err == nil {
+		j.Simple = jsonAccountSimple{
+			Address: simpleOld.Address,
+			Key:     simpleOld.Keys,
+		}
+		return nil
+	}
+
+	// try advanced old format
+	var advancedOld jsonAccountAdvancedOld
+	err = json.Unmarshal(b, &advancedOld)
+	if err == nil {
+		j.Advanced = jsonAccountAdvanced{
+			Address: advancedOld.Address,
+			Key:     advancedOld.Keys[0],
+		}
+		return nil
+	}
+
 	// try simple format
 	var simple jsonAccountSimple
-	err := json.Unmarshal(b, &simple)
+	err = json.Unmarshal(b, &simple)
 	if err == nil {
 		j.Simple = simple
 		return nil

--- a/pkg/flowcli/config/json/account.go
+++ b/pkg/flowcli/config/json/account.go
@@ -20,7 +20,6 @@ package json
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -184,49 +183,74 @@ type jsonAccount struct {
 	Advanced jsonAccountAdvanced
 }
 
+type FormatType int
+
+const (
+	simpleFormat      FormatType = 0
+	advancedFormat    FormatType = 1
+	simpleOldFormat   FormatType = 2
+	advancedOldFormat FormatType = 3
+)
+
+func decideFormat(b []byte) (FormatType, error) {
+	var raw map[string]interface{}
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return 0, err
+	}
+
+	if raw["keys"] != nil {
+		switch raw["keys"].(type) {
+		case string:
+			return simpleOldFormat, nil
+		default:
+			return advancedOldFormat, nil
+		}
+	}
+
+	switch raw["key"].(type) {
+	case string:
+		return simpleFormat, nil
+	default:
+		return advancedFormat, nil
+	}
+}
+
 func (j *jsonAccount) UnmarshalJSON(b []byte) error {
 
-	fmt.Println("IN", string(b))
+	format, err := decideFormat(b)
+	if err != nil {
+		return err
+	}
 
-	// try simple old format
-	var simpleOld jsonAccountSimpleOld
-	err := json.Unmarshal(b, &simpleOld)
-	if err == nil {
+	switch format {
+	case simpleFormat:
+		var simple jsonAccountSimple
+		err = json.Unmarshal(b, &simple)
+		j.Simple = simple
+
+	case advancedFormat:
+		var advanced jsonAccountAdvanced
+		err = json.Unmarshal(b, &advanced)
+		j.Advanced = advanced
+
+	case simpleOldFormat:
+		var simpleOld jsonAccountSimpleOld
+		err = json.Unmarshal(b, &simpleOld)
 		j.Simple = jsonAccountSimple{
 			Address: simpleOld.Address,
 			Key:     simpleOld.Keys,
 		}
-		return nil
-	}
 
-	// try advanced old format
-	var advancedOld jsonAccountAdvancedOld
-	err = json.Unmarshal(b, &advancedOld)
-	if err == nil {
+	case advancedOldFormat:
+		var advancedOld jsonAccountAdvancedOld
+		err = json.Unmarshal(b, &advancedOld)
 		j.Advanced = jsonAccountAdvanced{
 			Address: advancedOld.Address,
 			Key:     advancedOld.Keys[0],
 		}
-		return nil
 	}
 
-	// try simple format
-	var simple jsonAccountSimple
-	err = json.Unmarshal(b, &simple)
-	if err == nil {
-		j.Simple = simple
-		return nil
-	}
-
-	// try advanced format
-	var advanced jsonAccountAdvanced
-	err = json.Unmarshal(b, &advanced)
-	if err == nil {
-		j.Advanced = advanced
-		return nil
-	}
-
-	// TODO: better error handling - here we just return error from advanced case
 	return err
 }
 

--- a/pkg/flowcli/config/json/account_test.go
+++ b/pkg/flowcli/config/json/account_test.go
@@ -29,7 +29,7 @@ func Test_ConfigAccountKeysSimple(t *testing.T) {
 		"test": {
 			"address": "service",
 			"chain": "flow-emulator",
-			"keys": "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+			"key": "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 		}
 	}`)
 
@@ -41,7 +41,6 @@ func Test_ConfigAccountKeysSimple(t *testing.T) {
 
 	assert.Equal(t, accounts.GetByName("test").Address.String(), "f8d6e0586b0a20c7")
 	assert.Equal(t, accounts.GetByName("test").ChainID.String(), "flow-emulator")
-	assert.Len(t, accounts.GetByName("test").Key, 1)
 	assert.Equal(t, accounts.GetByName("test").Key.HashAlgo.String(), "SHA3_256")
 	assert.Equal(t, accounts.GetByName("test").Key.Index, 0)
 	assert.Equal(t, accounts.GetByName("test").Key.SigAlgo.String(), "ECDSA_P256")
@@ -53,17 +52,15 @@ func Test_ConfigAccountKeysAdvanced(t *testing.T) {
 		"test": {
 			"address": "service",
 			"chain": "flow-emulator",
-			"keys": [
-				{
-					"type": "hex",
-					"index": 0,
-					"signatureAlgorithm": "ECDSA_P256",
-					"hashAlgorithm": "SHA3_256",
-					"context": {
-						"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
-					}
+			"key": {
+				"type": "hex",
+				"index": 0,
+				"signatureAlgorithm": "ECDSA_P256",
+				"hashAlgorithm": "SHA3_256",
+				"context": {
+					"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 				}
-			]
+			}
 		}
 	}`)
 
@@ -87,12 +84,12 @@ func Test_ConfigMultipleAccountsSimple(t *testing.T) {
 		"emulator-account": {
 			"address": "service-1",
 			"chain": "flow-emulator",
-			"keys": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+			"key": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 		},
 		"testnet-account": {
 			"address": "0x2c1162386b0a245f",
 			"chain": "testnet",
-			"keys": "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+			"key": "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 		}
 	}`)
 
@@ -123,32 +120,28 @@ func Test_ConfigMultipleAccountsAdvanced(t *testing.T) {
 		"emulator-account": {
 			"address": "service",
 			"chain": "flow-emulator",
-			"keys": [
-				{
-					"type": "hex",
-					"index": 0,
-					"signatureAlgorithm": "ECDSA_P256",
-					"hashAlgorithm": "SHA3_256",
-					"context": {
-						"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
-					}
+			"key": {
+				"type": "hex",
+				"index": 0,
+				"signatureAlgorithm": "ECDSA_P256",
+				"hashAlgorithm": "SHA3_256",
+				"context": {
+					"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 				}
-			]
+			}
 		},
 		"testnet-account": {
 			"address": "1c1162386b0a245f",
 			"chain": "testnet",
-			"keys": [
-				{
-					"type": "0x18d6e0586b0a20c7",
-					"index": 0,
-					"signatureAlgorithm": "ECDSA_P256",
-					"hashAlgorithm": "SHA3_256",
-					"context": {
-						"privateKey": "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
-					}
+			"key": {
+				"type": "0x18d6e0586b0a20c7",
+				"index": 0,
+				"signatureAlgorithm": "ECDSA_P256",
+				"hashAlgorithm": "SHA3_256",
+				"context": {
+					"privateKey": "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 				}
-			]
+			}
 		}
 	}`)
 
@@ -178,22 +171,20 @@ func Test_ConfigMixedAccounts(t *testing.T) {
 		"emulator-account": {
 			"address": "service",
 			"chain": "flow-emulator",
-			"keys": [
-				{
-					"type": "hex",
-					"index": 0,
-					"signatureAlgorithm": "ECDSA_P256",
-					"hashAlgorithm": "SHA3_256",
-					"context": {
-						"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
-					}
+			"key": {
+				"type": "hex",
+				"index": 0,
+				"signatureAlgorithm": "ECDSA_P256",
+				"hashAlgorithm": "SHA3_256",
+				"context": {
+					"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 				}
-			]
+			}
 		},
 		"testnet-account": {
 			"address": "3c1162386b0a245f",
 			"chain": "testnet",
-			"keys": "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+			"key": "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 		}
 	}`)
 
@@ -223,12 +214,12 @@ func Test_ConfigAccountsMap(t *testing.T) {
 		"emulator-account": {
 			"address": "service-1",
 			"chain": "flow-emulator",
-			"keys": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+			"key": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 		},
 		"testnet-account": {
 			"address": "3c1162386b0a245f",
 			"chain": "testnet",
-			"keys": "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+			"key": "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
 		}
 	}`)
 
@@ -243,7 +234,7 @@ func Test_ConfigAccountsMap(t *testing.T) {
 }
 
 func Test_TransformDefaultAccountToJSON(t *testing.T) {
-	b := []byte(`{"emulator-account":{"address":"f8d6e0586b0a20c7","chain":"flow-emulator","keys":[{"type":"hex","index":0,"signatureAlgorithm":"ECDSA_P256","hashAlgorithm":"SHA3_256","context":{"privateKey":"1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"}}]},"testnet-account":{"address":"3c1162386b0a245f","keys":"2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47","chain":"testnet"}}`)
+	b := []byte(`{"emulator-account":{"address":"f8d6e0586b0a20c7","chain":"flow-emulator","key":{"type":"hex","index":0,"signatureAlgorithm":"ECDSA_P256","hashAlgorithm":"SHA3_256","context":{"privateKey":"1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"}}},"testnet-account":{"address":"3c1162386b0a245f","key":"2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47","chain":"testnet"}}`)
 
 	var jsonAccounts jsonAccounts
 	err := json.Unmarshal(b, &jsonAccounts)
@@ -259,7 +250,7 @@ func Test_TransformDefaultAccountToJSON(t *testing.T) {
 }
 
 func Test_TransformAccountToJSON(t *testing.T) {
-	b := []byte(`{"emulator-account":{"address":"f8d6e0586b0a20c7","chain":"flow-emulator","keys":[{"type":"hex","index":1,"signatureAlgorithm":"ECDSA_P256","hashAlgorithm":"SHA3_256","context":{"privateKey":"1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"}}]},"testnet-account":{"address":"3c1162386b0a245f","keys":"2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47","chain":"testnet"}}`)
+	b := []byte(`{"emulator-account":{"address":"f8d6e0586b0a20c7","chain":"flow-emulator","key":{"type":"hex","index":1,"signatureAlgorithm":"ECDSA_P256","hashAlgorithm":"SHA3_256","context":{"privateKey":"1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"}}},"testnet-account":{"address":"3c1162386b0a245f","key":"2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47","chain":"testnet"}}`)
 
 	var jsonAccounts jsonAccounts
 	err := json.Unmarshal(b, &jsonAccounts)

--- a/pkg/flowcli/config/json/account_test.go
+++ b/pkg/flowcli/config/json/account_test.go
@@ -41,11 +41,11 @@ func Test_ConfigAccountKeysSimple(t *testing.T) {
 
 	assert.Equal(t, accounts.GetByName("test").Address.String(), "f8d6e0586b0a20c7")
 	assert.Equal(t, accounts.GetByName("test").ChainID.String(), "flow-emulator")
-	assert.Len(t, accounts.GetByName("test").Keys, 1)
-	assert.Equal(t, accounts.GetByName("test").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("test").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("test").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("test").Keys[0].Context["privateKey"], "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Len(t, accounts.GetByName("test").Key, 1)
+	assert.Equal(t, accounts.GetByName("test").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("test").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("test").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("test").Key.Context["privateKey"], "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_ConfigAccountKeysAdvanced(t *testing.T) {
@@ -76,61 +76,10 @@ func Test_ConfigAccountKeysAdvanced(t *testing.T) {
 
 	assert.Equal(t, account.Address.String(), "f8d6e0586b0a20c7")
 	assert.Equal(t, account.ChainID.String(), "flow-emulator")
-	assert.Len(t, account.Keys, 1)
-	assert.Equal(t, account.Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, account.Keys[0].Index, 0)
-	assert.Equal(t, account.Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, account.Keys[0].Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
-}
-
-func Test_ConfigAccountKeysAdvancedMultiple(t *testing.T) {
-	b := []byte(`{
-		"test": {
-			"address": "service",
-			"chain": "flow-emulator",
-			"keys": [
-				{
-					"type": "hex",
-					"index": 0,
-					"signatureAlgorithm": "ECDSA_P256",
-					"hashAlgorithm": "SHA3_256",
-					"context": {
-						"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
-					}
-				},
-				{
-					"type": "hex",
-					"index": 1,
-					"signatureAlgorithm": "ECDSA_P256",
-					"hashAlgorithm": "SHA3_256",
-					"context": {
-						"privateKey": "2372967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
-					}
-				}
-			]
-		}
-	}`)
-
-	var jsonAccounts jsonAccounts
-	err := json.Unmarshal(b, &jsonAccounts)
-	assert.NoError(t, err)
-
-	accounts := jsonAccounts.transformToConfig()
-	account := accounts.GetByName("test")
-
-	assert.Equal(t, account.Address.String(), "f8d6e0586b0a20c7")
-	assert.Equal(t, account.ChainID.String(), "flow-emulator")
-	assert.Len(t, account.Keys, 2)
-
-	assert.Equal(t, account.Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, account.Keys[0].Index, 0)
-	assert.Equal(t, account.Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, account.Keys[0].Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
-
-	assert.Equal(t, account.Keys[1].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, account.Keys[1].Index, 1)
-	assert.Equal(t, account.Keys[1].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, account.Keys[1].Context["privateKey"], "2372967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, account.Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, account.Key.Index, 0)
+	assert.Equal(t, account.Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, account.Key.Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_ConfigMultipleAccountsSimple(t *testing.T) {
@@ -156,19 +105,17 @@ func Test_ConfigMultipleAccountsSimple(t *testing.T) {
 	assert.Equal(t, accounts.GetByName("emulator-account").Name, "emulator-account")
 	assert.Equal(t, accounts.GetByName("emulator-account").Address.String(), "0000000000000000")
 	assert.Equal(t, accounts.GetByName("emulator-account").ChainID.String(), "flow-emulator")
-	assert.Len(t, accounts.GetByName("emulator-account").Keys, 1)
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 
 	assert.Equal(t, accounts.GetByName("testnet-account").Address.String(), "2c1162386b0a245f")
 	assert.Equal(t, accounts.GetByName("testnet-account").ChainID.String(), "testnet")
-	assert.Len(t, accounts.GetByName("testnet-account").Keys, 1)
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].Context["privateKey"], "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.Context["privateKey"], "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_ConfigMultipleAccountsAdvanced(t *testing.T) {
@@ -213,19 +160,17 @@ func Test_ConfigMultipleAccountsAdvanced(t *testing.T) {
 
 	assert.Equal(t, accounts.GetByName("emulator-account").Address.String(), "f8d6e0586b0a20c7")
 	assert.Equal(t, accounts.GetByName("emulator-account").ChainID.String(), "flow-emulator")
-	assert.Len(t, accounts.GetByName("emulator-account").Keys, 1)
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 
 	assert.Equal(t, accounts.GetByName("testnet-account").Address.String(), "1c1162386b0a245f")
 	assert.Equal(t, accounts.GetByName("testnet-account").ChainID.String(), "testnet")
-	assert.Len(t, accounts.GetByName("testnet-account").Keys, 1)
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].Context["privateKey"], "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.Context["privateKey"], "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_ConfigMixedAccounts(t *testing.T) {
@@ -260,19 +205,17 @@ func Test_ConfigMixedAccounts(t *testing.T) {
 
 	assert.Equal(t, accounts.GetByName("emulator-account").Address.String(), "f8d6e0586b0a20c7")
 	assert.Equal(t, accounts.GetByName("emulator-account").ChainID.String(), "flow-emulator")
-	assert.Len(t, accounts.GetByName("emulator-account").Keys, 1)
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("emulator-account").Keys[0].Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("emulator-account").Key.Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 
 	assert.Equal(t, accounts.GetByName("testnet-account").Address.String(), "3c1162386b0a245f")
 	assert.Equal(t, accounts.GetByName("testnet-account").ChainID.String(), "testnet")
-	assert.Len(t, accounts.GetByName("testnet-account").Keys, 1)
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].HashAlgo.String(), "SHA3_256")
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].Index, 0)
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].SigAlgo.String(), "ECDSA_P256")
-	assert.Equal(t, accounts.GetByName("testnet-account").Keys[0].Context["privateKey"], "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.HashAlgo.String(), "SHA3_256")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.Index, 0)
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.SigAlgo.String(), "ECDSA_P256")
+	assert.Equal(t, accounts.GetByName("testnet-account").Key.Context["privateKey"], "2272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_ConfigAccountsMap(t *testing.T) {
@@ -328,4 +271,8 @@ func Test_TransformAccountToJSON(t *testing.T) {
 	x, _ := json.Marshal(j)
 
 	assert.Equal(t, string(b), string(x))
+}
+
+func Test_SupportForOldFormatWithMultipleKeys(t *testing.T) {
+	assert.Fail(t, "todo")
 }

--- a/pkg/flowcli/config/json/account_test.go
+++ b/pkg/flowcli/config/json/account_test.go
@@ -265,5 +265,43 @@ func Test_TransformAccountToJSON(t *testing.T) {
 }
 
 func Test_SupportForOldFormatWithMultipleKeys(t *testing.T) {
-	assert.Fail(t, "todo")
+	b := []byte(`{
+		"emulator-account": {
+			"address": "service-1",
+			"chain": "flow-emulator",
+			"keys": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+		},
+		"testnet-account": {
+			"address": "3c1162386b0a245f",
+			"chain": "testnet",
+			"keys": [
+				{
+					"type": "hex",
+					"index": 0,
+					"signatureAlgorithm": "ECDSA_P256",
+					"hashAlgorithm": "SHA3_256",
+					"context": {
+						"privateKey": "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+					}
+				},{
+					"type": "hex",
+					"index": 0,
+					"signatureAlgorithm": "ECDSA_P256",
+					"hashAlgorithm": "SHA3_256",
+					"context": {
+						"privateKey": "2332967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b44"
+					}
+				}
+			]
+		}
+	}`)
+
+	var jsonAccounts jsonAccounts
+	err := json.Unmarshal(b, &jsonAccounts)
+	assert.NoError(t, err)
+
+	conf := jsonAccounts.transformToConfig()
+
+	assert.Equal(t, conf.GetByName("testnet-account").Key.Context["privateKey"], "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, conf.GetByName("emulator-account").Key.Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }

--- a/pkg/flowcli/config/json/config_test.go
+++ b/pkg/flowcli/config/json/config_test.go
@@ -54,6 +54,6 @@ func Test_SimpleJSONConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(conf.Accounts))
 	assert.Equal(t, "emulator-account", conf.Accounts[0].Name)
-	assert.Equal(t, "11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Keys[0].Context["privateKey"])
+	assert.Equal(t, "11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Key.Context["privateKey"])
 	assert.Equal(t, "127.0.0.1:3569", conf.Networks.GetByName("emulator").Host)
 }

--- a/pkg/flowcli/config/json/config_test.go
+++ b/pkg/flowcli/config/json/config_test.go
@@ -41,7 +41,7 @@ func Test_SimpleJSONConfig(t *testing.T) {
 		"accounts": {
 			"emulator-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
+				"key": "11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
 				"chain": "flow-emulator"
 			}
 		},

--- a/pkg/flowcli/config/loader_test.go
+++ b/pkg/flowcli/config/loader_test.go
@@ -46,7 +46,7 @@ func Test_JSONSimple(t *testing.T) {
 		"accounts": {
 			"emulator-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
 				"chain": "flow-emulator"
 			}
 		},
@@ -72,7 +72,7 @@ func Test_ComposeJSON(t *testing.T) {
 		"accounts": {
 			"emulator-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 			}
 		}
 	}`)
@@ -81,7 +81,7 @@ func Test_ComposeJSON(t *testing.T) {
 		 "accounts":{
 				"admin-account":{
 					 "address":"f1d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				}
 		 }
 	}`)
@@ -114,7 +114,7 @@ func Test_ComposeJSONOverwrite(t *testing.T) {
 		"accounts": {
 			"admin-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 			}
 		}
 	}`)
@@ -123,7 +123,7 @@ func Test_ComposeJSONOverwrite(t *testing.T) {
 		 "accounts":{
 				"admin-account":{
 					 "address":"f1d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				}
 		 }
 	}`)
@@ -153,7 +153,7 @@ func Test_FromFileAccountSimple(t *testing.T) {
 		"accounts": {
 			"service-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 			},
 			"admin-account": { "fromFile": "private.json" }
 		}
@@ -163,7 +163,7 @@ func Test_FromFileAccountSimple(t *testing.T) {
 		 "accounts":{
 				"admin-account":{
 					 "address":"f1d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				}
 		 }
 	}`)
@@ -192,7 +192,7 @@ func Test_FromFileAccountComplex(t *testing.T) {
 		"accounts": {
 			"service-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 			},
 			"admin-account-1": { "fromFile": "private.json" },
 			"admin-account-3": { "fromFile": "private.json" },
@@ -204,15 +204,15 @@ func Test_FromFileAccountComplex(t *testing.T) {
 		 "accounts":{
 				"admin-account-1":{
 					 "address":"f1d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				},
 				"admin-account-2":{
 					 "address":"f2d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				},
 				"admin-account-3":{
 					 "address":"f3d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				}
 		 }
 	}`)
@@ -221,7 +221,7 @@ func Test_FromFileAccountComplex(t *testing.T) {
 		 "accounts":{
 				"admin-account-5":{
 					 "address":"f5d6e0586b0a20c7",
-					 "keys":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				}
 		 }
 	}`)
@@ -257,7 +257,7 @@ func Test_JSONEnv(t *testing.T) {
 		"accounts": {
 			"emulator-account": {
 				"address": "f8d6e0586b0a20c7",
-				"keys": "$EMULATOR_KEY",
+				"key": "$EMULATOR_KEY",
 				"chain": "flow-emulator"
 			}
 		}

--- a/pkg/flowcli/config/loader_test.go
+++ b/pkg/flowcli/config/loader_test.go
@@ -64,7 +64,7 @@ func Test_JSONSimple(t *testing.T) {
 
 	assert.NoError(t, loadErr)
 	assert.Equal(t, 1, len(conf.Accounts))
-	assert.Equal(t, "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Keys[0].Context["privateKey"])
+	assert.Equal(t, "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Key.Context["privateKey"])
 }
 
 func Test_ComposeJSON(t *testing.T) {
@@ -101,11 +101,11 @@ func Test_ComposeJSON(t *testing.T) {
 	assert.NoError(t, loadErr)
 	assert.Equal(t, 2, len(conf.Accounts))
 	assert.Equal(t, "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
-		conf.Accounts.GetByName("emulator-account").Keys[0].Context["privateKey"],
+		conf.Accounts.GetByName("emulator-account").Key.Context["privateKey"],
 	)
 	assert.NotNil(t, conf.Accounts.GetByName("admin-account"))
 	assert.Equal(t, "3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
-		conf.Accounts.GetByName("admin-account").Keys[0].Context["privateKey"],
+		conf.Accounts.GetByName("admin-account").Key.Context["privateKey"],
 	)
 }
 
@@ -144,7 +144,7 @@ func Test_ComposeJSONOverwrite(t *testing.T) {
 	assert.Equal(t, 1, len(conf.Accounts))
 	assert.NotNil(t, conf.Accounts.GetByName("admin-account"))
 	assert.Equal(t, "3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
-		conf.Accounts.GetByName("admin-account").Keys[0].Context["privateKey"],
+		conf.Accounts.GetByName("admin-account").Key.Context["privateKey"],
 	)
 }
 
@@ -276,5 +276,5 @@ func Test_JSONEnv(t *testing.T) {
 
 	assert.NoError(t, loadErr)
 	assert.Equal(t, 1, len(conf.Accounts))
-	assert.Equal(t, "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Keys[0].Context["privateKey"])
+	assert.Equal(t, "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Key.Context["privateKey"])
 }

--- a/pkg/flowcli/project/keys.go
+++ b/pkg/flowcli/project/keys.go
@@ -40,6 +40,7 @@ type AccountKey interface {
 	Signer(ctx context.Context) (crypto.Signer, error)
 	ToConfig() config.AccountKey
 	Validate() error
+	PrivateKey() (*crypto.PrivateKey, error)
 }
 
 func NewAccountKey(accountKeyConf config.AccountKey) (AccountKey, error) {
@@ -129,6 +130,10 @@ func (a *KmsAccountKey) Validate() error {
 	return util.GcloudApplicationSignin(resourceID)
 }
 
+func (a *KmsAccountKey) PrivateKey() (*crypto.PrivateKey, error) {
+	return nil, fmt.Errorf("private key not accessible")
+}
+
 func newKmsAccountKey(key config.AccountKey) (AccountKey, error) {
 	accountKMSKey, err := cloudkms.KeyFromResourceID(key.Context[config.KMSContextField])
 	if err != nil {
@@ -188,8 +193,8 @@ func (a *HexAccountKey) Signer(ctx context.Context) (crypto.Signer, error) {
 	return crypto.NewInMemorySigner(a.privateKey, a.HashAlgo()), nil
 }
 
-func (a *HexAccountKey) PrivateKey() crypto.PrivateKey {
-	return a.privateKey
+func (a *HexAccountKey) PrivateKey() (*crypto.PrivateKey, error) {
+	return &a.privateKey, nil
 }
 
 func (a *HexAccountKey) ToConfig() config.AccountKey {
@@ -202,6 +207,15 @@ func (a *HexAccountKey) ToConfig() config.AccountKey {
 			config.PrivateKeyField: a.PrivateKeyHex(),
 		},
 	}
+}
+
+func (a *HexAccountKey) Validate() error {
+	_, err := crypto.DecodePrivateKeyHex(a.sigAlgo, a.PrivateKeyHex())
+	if err != nil {
+		return fmt.Errorf("invalid private key")
+	}
+
+	return nil
 }
 
 func (a *HexAccountKey) PrivateKeyHex() string {

--- a/pkg/flowcli/project/project.go
+++ b/pkg/flowcli/project/project.go
@@ -165,10 +165,10 @@ func (p *Project) EmulatorServiceAccount() (*Account, error) {
 // SetEmulatorServiceKey sets the default emulator service account private key.
 func (p *Project) SetEmulatorServiceKey(privateKey crypto.PrivateKey) {
 	acc := p.AccountByName(config.DefaultEmulatorServiceAccountName)
-	acc.SetDefaultKey(
+	acc.SetKey(
 		NewHexAccountKeyFromPrivateKey(
-			acc.DefaultKey().Index(),
-			acc.DefaultKey().HashAlgo(),
+			acc.Key().Index(),
+			acc.Key().HashAlgo(),
 			privateKey,
 		),
 	)

--- a/pkg/flowcli/project/project_test.go
+++ b/pkg/flowcli/project/project_test.go
@@ -97,7 +97,7 @@ func generateComplexProject() Project {
 			Name:    "emulator-account",
 			Address: flow.ServiceAddress(flow.Emulator),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -105,12 +105,12 @@ func generateComplexProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}, {
 			Name:    "account-2",
 			Address: flow.HexToAddress("2c1162386b0a245f"),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -118,12 +118,12 @@ func generateComplexProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}, {
 			Name:    "account-4",
 			Address: flow.HexToAddress("f8d6e0586b0a20c1"),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -131,7 +131,7 @@ func generateComplexProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}},
 		Networks: config.Networks{{
 			Name:    "emulator",
@@ -171,7 +171,7 @@ func generateSimpleProject() Project {
 			Name:    "emulator-account",
 			Address: flow.ServiceAddress(flow.Emulator),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -179,7 +179,7 @@ func generateSimpleProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}},
 		Networks: config.Networks{{
 			Name:    "emulator",
@@ -224,7 +224,7 @@ func generateAliasesProject() Project {
 			Name:    "emulator-account",
 			Address: flow.ServiceAddress(flow.Emulator),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -232,7 +232,7 @@ func generateAliasesProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}},
 		Networks: config.Networks{{
 			Name:    "emulator",
@@ -293,7 +293,7 @@ func generateAliasesComplexProject() Project {
 			Name:    "emulator-account",
 			Address: flow.ServiceAddress(flow.Emulator),
 			ChainID: flow.Emulator,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -301,12 +301,12 @@ func generateAliasesComplexProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}, {
 			Name:    "testnet-account",
 			Address: flow.HexToAddress("1e82856bf20e2aa6"),
 			ChainID: flow.Testnet,
-			Keys: []config.AccountKey{{
+			Key: config.AccountKey{
 				Type:     config.KeyTypeHex,
 				Index:    0,
 				SigAlgo:  crypto.ECDSA_P256,
@@ -314,7 +314,7 @@ func generateAliasesComplexProject() Project {
 				Context: map[string]string{
 					"privateKey": "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47",
 				},
-			}},
+			},
 		}},
 		Networks: config.Networks{{
 			Name:    "emulator",
@@ -354,7 +354,7 @@ func Test_EmulatorConfigSimple(t *testing.T) {
 	emulatorServiceAccount, _ := p.EmulatorServiceAccount()
 
 	assert.Equal(t, emulatorServiceAccount.name, "emulator-account")
-	assert.Equal(t, emulatorServiceAccount.keys[0].ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, emulatorServiceAccount.key.ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 	assert.Equal(t, flow.ServiceAddress("flow-emulator").String(), emulatorServiceAccount.Address().String())
 }
 
@@ -370,7 +370,7 @@ func Test_AccountByNameSimple(t *testing.T) {
 	acc := p.AccountByName("emulator-account")
 
 	assert.Equal(t, flow.ServiceAddress("flow-emulator").String(), acc.Address().String())
-	assert.Equal(t, acc.DefaultKey().ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, acc.key.ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_HostSimple(t *testing.T) {
@@ -433,7 +433,7 @@ func Test_EmulatorConfigComplex(t *testing.T) {
 	emulatorServiceAccount, _ := p.EmulatorServiceAccount()
 
 	assert.Equal(t, emulatorServiceAccount.name, "emulator-account")
-	assert.Equal(t, emulatorServiceAccount.keys[0].ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, emulatorServiceAccount.key.ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 	assert.Equal(t, emulatorServiceAccount.Address().String(), flow.ServiceAddress("flow-emulator").String())
 }
 
@@ -451,7 +451,7 @@ func Test_AccountByNameComplex(t *testing.T) {
 	acc := p.AccountByName("account-2")
 
 	assert.Equal(t, acc.Address().String(), "2c1162386b0a245f")
-	assert.Equal(t, acc.DefaultKey().ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, acc.key.ToConfig().Context["privateKey"], "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 }
 
 func Test_HostComplex(t *testing.T) {

--- a/pkg/flowcli/project/transaction.go
+++ b/pkg/flowcli/project/transaction.go
@@ -219,7 +219,7 @@ func (t *Transaction) SetScriptWithArgs(script []byte, args []string, argsJSON s
 
 // SetSigner sets the signer for transaction
 func (t *Transaction) SetSigner(account *Account) error {
-	err := account.DefaultKey().Validate()
+	err := account.Key().Validate()
 	if err != nil {
 		return err
 	}
@@ -298,8 +298,8 @@ func (t *Transaction) AddAuthorizers(authorizers []flow.Address) *Transaction {
 
 // Sign signs transaction using signer account
 func (t *Transaction) Sign() (*Transaction, error) {
-	keyIndex := t.signer.DefaultKey().Index()
-	signer, err := t.signer.DefaultKey().Signer(context.Background())
+	keyIndex := t.signer.Key().Index()
+	signer, err := t.signer.Key().Signer(context.Background())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #136 

## Description
Remove support for multiple keys as it necessarily adds complexity and is a rare case that can still be solved by specifying multiple accounts with a single key and the same address.