### PR TITLE
Use default key as proposal key in Transactions.Send

### DIFF
--- a/pkg/flowcli/services/transactions.go
+++ b/pkg/flowcli/services/transactions.go
@@ -244,11 +244,13 @@ func (t *Transactions) Send(
 		return nil, nil, fmt.Errorf("signer account: [%s] doesn't exists in configuration", signerName)
 	}
 
+	signerKeyIndex := signerAccount.DefaultKey().Index()
+
 	tx, err := t.Build(
 		signerName,
 		[]string{signerName},
 		signerName,
-		0, // default 0 key
+		signerKeyIndex,
 		transactionFilename,
 		args,
 		argsJSON,


### PR DESCRIPTION
## Description

Currently the `"index"` field is ignored when using the `transactions send` command and instead defaults to 0. This hotfix allows the user to sign with a key that is not at index 0.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
