### PR TITLE
Increase grpc max message size to 16 mb

### DIFF
--- a/pkg/flowcli/gateway/grpc.go
+++ b/pkg/flowcli/gateway/grpc.go
@@ -31,6 +31,10 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
+// MaxGRPCMessageSize 16mb, matching the value set in onflow/flow-go
+// https://github.com/onflow/flow-go/blob/master/utils/grpc/grpc.go#L5
+const MaxGRPCMessageSize = 1024 * 1024 * 16
+
 // GrpcGateway is a gateway implementation that uses the Flow Access gRPC API.
 type GrpcGateway struct {
 	client *client.Client
@@ -39,7 +43,12 @@ type GrpcGateway struct {
 
 // NewGrpcGateway returns a new gRPC gateway.
 func NewGrpcGateway(host string) (*GrpcGateway, error) {
-	gClient, err := client.New(host, grpc.WithInsecure())
+
+	gClient, err := client.New(
+		host,
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize)),
+	)
 	ctx := context.Background()
 
 	if err != nil || gClient == nil {

--- a/pkg/flowcli/gateway/grpc.go
+++ b/pkg/flowcli/gateway/grpc.go
@@ -31,9 +31,9 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 )
 
-// MaxGRPCMessageSize 16mb, matching the value set in onflow/flow-go
+// maxGRPCMessageSize 16mb, matching the value set in onflow/flow-go
 // https://github.com/onflow/flow-go/blob/master/utils/grpc/grpc.go#L5
-const MaxGRPCMessageSize = 1024 * 1024 * 16
+const maxGRPCMessageSize = 1024 * 1024 * 16
 
 // GrpcGateway is a gateway implementation that uses the Flow Access gRPC API.
 type GrpcGateway struct {
@@ -47,7 +47,7 @@ func NewGrpcGateway(host string) (*GrpcGateway, error) {
 	gClient, err := client.New(
 		host,
 		grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxGRPCMessageSize)),
 	)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

Previously, the CLI had a max message size of [16mb](https://github.com/onflow/flow-go/blob/master/utils/grpc/grpc.go#L5) for getting transaction results. Now that we've consolidated the grpc client creation, we need to add this limit back at point of grpc client creation.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
