### PR TITLE
Update cadence/languageserver to v0.15.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/manifoldco/promptui v0.8.0
 	github.com/onflow/cadence v0.15.1
-	github.com/onflow/cadence/languageserver v0.15.2-0.20210505062024-cb797539f41a
+	github.com/onflow/cadence/languageserver v0.15.2
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0
 	github.com/onflow/flow-emulator v0.19.0
 	github.com/onflow/flow-go-sdk v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,8 @@ github.com/onflow/cadence/languageserver v0.15.1 h1:4fq94I/wIK3tnlQathRtSK+5lO4w
 github.com/onflow/cadence/languageserver v0.15.1/go.mod h1:j0SY6m5/9+/ldm/rP3LvJtKcPfe2hVoozJMx1nZfyC0=
 github.com/onflow/cadence/languageserver v0.15.2-0.20210505062024-cb797539f41a h1:BCUBpAgQ5lcb4Sp52Lq+iVi/QAvy4H16cByZls185t4=
 github.com/onflow/cadence/languageserver v0.15.2-0.20210505062024-cb797539f41a/go.mod h1:hQGE8dYH5CfQ1Oe0nXglchgURzZwR3JQhmuXtv4ROHs=
+github.com/onflow/cadence/languageserver v0.15.2 h1:NahnFrirnwBiHXoDwn7Od73BvQ2mpU2x7eKPAMOWnA8=
+github.com/onflow/cadence/languageserver v0.15.2/go.mod h1:hQGE8dYH5CfQ1Oe0nXglchgURzZwR3JQhmuXtv4ROHs=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2 h1:6+zfvSv03ROULuq27BNC+1CYFQ7tkPtD9l52BwVQjq8=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0 h1:2v10ZSCE4e3TyeDQvKplGJ4/d0X/+xgU2NmeXRmFYRw=


### PR DESCRIPTION
## Description

Update cadence/languageserver to v0.15.2
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
