### PR TITLE
flow-go-sdk update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onflow/cadence/languageserver v0.15.2
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0
 	github.com/onflow/flow-emulator v0.19.0
-	github.com/onflow/flow-go-sdk v0.19.0
+	github.com/onflow/flow-go-sdk v0.20.0-alpha.1
 	github.com/psiemens/sconfig v0.0.0-20190623041652-6e01eb1354fc
 	github.com/spf13/afero v1.1.2
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,9 @@ github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWK
 github.com/onflow/flow-go v0.16.3-0.20210427194927-6050c2a3ae42 h1:oPY+9K2bVcyqPXqjYjeeGGI7iXgKK3Unwx93bTAmlCY=
 github.com/onflow/flow-go v0.16.3-0.20210427194927-6050c2a3ae42/go.mod h1:9GUEbBhOGDVf91ZJB6QWqVNQkrM3INEudNyDtIttOu0=
 github.com/onflow/flow-go-sdk v0.18.0/go.mod h1:AjXHdxguP/PK5P8tWKHH4jR6oLISTgLoXXQrbQsHY+E=
-github.com/onflow/flow-go-sdk v0.19.0 h1:c3Cl5zHl+tvpAEoVmKggT2DwzCQcTphpc7sJ5RB2m/o=
 github.com/onflow/flow-go-sdk v0.19.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
+github.com/onflow/flow-go-sdk v0.20.0-alpha.1 h1:zy5viTpSQsfKgaoj9PgDOhoklLkG0Fze4okGFZ21Mus=
+github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go/crypto v0.12.0 h1:TMsqn5nsW4vrCIFG/HRE/oy/a5/sffHrDRDYqicwO98=
 github.com/onflow/flow-go/crypto v0.12.0/go.mod h1:oXuvU0Dr4lHKgye6nHEFbBXIWNv+dBQUzoVW5Go38+o=
 github.com/onflow/flow/protobuf/go/flow v0.1.9/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=


### PR DESCRIPTION
References: https://github.com/dapperlabs/flow-go/issues/5204

## Description

flow-go-sdk update, to get signing with transaction domain tag in.
