### PR TITLE
QA remove lower case match

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -331,7 +331,7 @@ func filterResultValue(result Result, filter string) (interface{}, error) {
 		possibleFilters = append(possibleFilters, key)
 	}
 
-	value := jsonResult[strings.ToLower(filter)]
+	value := jsonResult[filter]
 
 	if value == nil {
 		return nil, fmt.Errorf("value for filter: '%s' doesn't exists, possible values to filter by: %s", filter, possibleFilters)


### PR DESCRIPTION
Remove to lower case when accessing map keys as some have multi-word keys that then don't work. Example `parentId` key can not be accesses as it is converted to `parentid` 