### PR TITLE
Log Transaction ID

### DIFF
--- a/pkg/flowcli/services/accounts.go
+++ b/pkg/flowcli/services/accounts.go
@@ -189,6 +189,8 @@ func (a *Accounts) Create(
 		return nil, err
 	}
 
+	a.logger.Info(fmt.Sprintf("Transaction ID: %s", tx.FlowTransaction().ID()))
+
 	sentTx, err := a.gateway.SendSignedTransaction(tx)
 	if err != nil {
 		return nil, err

--- a/pkg/flowcli/services/transactions.go
+++ b/pkg/flowcli/services/transactions.go
@@ -215,8 +215,10 @@ func (t *Transactions) SendSigned(
 		return nil, nil, err
 	}
 
-	t.logger.StartProgress(fmt.Sprintf("Sending Transaction with ID: %s", tx.FlowTransaction().ID()))
+	t.logger.StartProgress("Sending Transaction")
 	defer t.logger.StopProgress()
+
+	t.logger.Info(fmt.Sprintf("Transaction ID: %s", tx.FlowTransaction().ID()))
 
 	sentTx, err := t.gateway.SendSignedTransaction(tx)
 	if err != nil {
@@ -276,8 +278,10 @@ func (t *Transactions) Send(
 		return nil, nil, err
 	}
 
-	t.logger.StartProgress(fmt.Sprintf("Sending Transaction with ID: %s", signed.FlowTransaction().ID()))
+	t.logger.StartProgress("Sending Transaction")
 	defer t.logger.StopProgress()
+
+	t.logger.Info(fmt.Sprintf("Transaction ID: %s", signed.FlowTransaction().ID()))
 
 	sentTx, err := t.gateway.SendSignedTransaction(signed)
 	if err != nil {

--- a/pkg/flowcli/services/transactions.go
+++ b/pkg/flowcli/services/transactions.go
@@ -215,10 +215,10 @@ func (t *Transactions) SendSigned(
 		return nil, nil, err
 	}
 
+	t.logger.Info(fmt.Sprintf("Transaction ID: %s", tx.FlowTransaction().ID()))
+
 	t.logger.StartProgress("Sending Transaction")
 	defer t.logger.StopProgress()
-
-	t.logger.Info(fmt.Sprintf("Transaction ID: %s", tx.FlowTransaction().ID()))
 
 	sentTx, err := t.gateway.SendSignedTransaction(tx)
 	if err != nil {
@@ -278,10 +278,10 @@ func (t *Transactions) Send(
 		return nil, nil, err
 	}
 
+	t.logger.Info(fmt.Sprintf("Transaction ID: %s", signed.FlowTransaction().ID()))
+
 	t.logger.StartProgress("Sending Transaction")
 	defer t.logger.StopProgress()
-
-	t.logger.Info(fmt.Sprintf("Transaction ID: %s", signed.FlowTransaction().ID()))
 
 	sentTx, err := t.gateway.SendSignedTransaction(signed)
 	if err != nil {


### PR DESCRIPTION
Improve logging of transaction ID for:
- sending the transaction with logging ID before it is being sent.
- logging transaction ID on account creation.