### PR TITLE
Refactor Typed Service API

### DIFF
--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -54,7 +54,7 @@ var AddContractCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if createFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -53,13 +55,17 @@ var AddContractCommand = &command.Command{
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
-		account, err := services.Accounts.AddContract(
-			addContractFlags.Signer,
-			args[0], // name
-			args[1], // filename
-			false,
-		)
+		name := args[0]
+		filename := args[1]
 
+		code, err := util.LoadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error loading contract file: %w", err)
+		}
+
+		to := nil // todo refactor project
+
+		account, err := services.Accounts.AddContract(to, name, code, false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -68,10 +68,10 @@ var AddContractCommand = &command.Command{
 			return nil, fmt.Errorf("error loading contract file: %w", err)
 		}
 
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
-		to := project.AccountByName(addContractFlags.Signer)
+		to := proj.AccountByName(addContractFlags.Signer)
 
 		account, err := services.Accounts.AddContract(to, name, code, false)
 		if err != nil {

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -55,7 +55,6 @@ var AddContractCommand = &command.Command{
 		globalFlags command.GlobalFlags,
 		services *services.Services,
 		project *project.Project,
-		project *project.Project,
 	) (command.Result, error) {
 		if createFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -21,6 +21,10 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 
 	"github.com/spf13/cobra"
@@ -50,6 +54,8 @@ var AddContractCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
+		project *project.Project,
 	) (command.Result, error) {
 		if createFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
@@ -63,7 +69,10 @@ var AddContractCommand = &command.Command{
 			return nil, fmt.Errorf("error loading contract file: %w", err)
 		}
 
-		to := nil // todo refactor project
+		if project == nil {
+			return nil, config.ErrDoesNotExist
+		}
+		to := project.AccountByName(addContractFlags.Signer)
 
 		account, err := services.Accounts.AddContract(to, name, code, false)
 		if err != nil {

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -53,10 +53,10 @@ var RemoveCommand = &command.Command{
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
-		account, err := services.Accounts.RemoveContract(
-			args[0], // name
-			flagsRemove.Signer,
-		)
+		contractName := args[0]
+		from := nil // todo refactor project
+
+		account, err := services.Accounts.RemoveContract(contractName, from)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -48,6 +50,7 @@ var RemoveCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if flagsRemove.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 
 	"github.com/spf13/cobra"
@@ -57,7 +59,11 @@ var RemoveCommand = &command.Command{
 		}
 
 		contractName := args[0]
-		from := nil // todo refactor project
+
+		if project == nil {
+			return nil, config.ErrDoesNotExist
+		}
+		from := project.AccountByName(flagsRemove.Signer)
 
 		account, err := services.Accounts.RemoveContract(contractName, from)
 		if err != nil {

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -52,7 +52,7 @@ var RemoveCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if flagsRemove.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -60,10 +60,10 @@ var RemoveCommand = &command.Command{
 
 		contractName := args[0]
 
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
-		from := project.AccountByName(flagsRemove.Signer)
+		from := proj.AccountByName(flagsRemove.Signer)
 
 		account, err := services.Accounts.RemoveContract(contractName, from)
 		if err != nil {

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -53,12 +55,17 @@ var UpdateCommand = &command.Command{
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
-		account, err := services.Accounts.AddContract(
-			updateFlags.Signer,
-			args[0], // name
-			args[1], // filename
-			true,
-		)
+		name := args[0]
+		filename := args[1]
+
+		code, err := util.LoadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error loading contract file: %w", err)
+		}
+
+		to := nil // todo refactor project
+
+		account, err := services.Accounts.AddContract(to, name, code, false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -68,10 +68,10 @@ var UpdateCommand = &command.Command{
 			return nil, fmt.Errorf("error loading contract file: %w", err)
 		}
 
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
-		to := project.AccountByName(addContractFlags.Signer)
+		to := proj.AccountByName(addContractFlags.Signer)
 
 		account, err := services.Accounts.AddContract(to, name, code, false)
 		if err != nil {

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
@@ -66,7 +68,10 @@ var UpdateCommand = &command.Command{
 			return nil, fmt.Errorf("error loading contract file: %w", err)
 		}
 
-		to := nil // todo refactor project
+		if project == nil {
+			return nil, config.ErrDoesNotExist
+		}
+		to := project.AccountByName(addContractFlags.Signer)
 
 		account, err := services.Accounts.AddContract(to, name, code, false)
 		if err != nil {

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 
 	"github.com/spf13/cobra"
@@ -50,6 +52,7 @@ var UpdateCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if updateFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/contract-update.go
+++ b/internal/accounts/contract-update.go
@@ -54,7 +54,7 @@ var UpdateCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if updateFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -59,7 +59,7 @@ var CreateCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if createFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -20,6 +20,9 @@ package accounts
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/onflow/flow-go-sdk/crypto"
 
 	"github.com/spf13/cobra"
 
@@ -57,12 +60,45 @@ var CreateCommand = &command.Command{
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
+		sigAlgo := crypto.StringToSignatureAlgorithm(createFlags.SigAlgo)
+		if sigAlgo == crypto.UnknownSignatureAlgorithm {
+			return nil, fmt.Errorf("invalid signature algorithm: %s", createFlags.SigAlgo)
+		}
+
+		hashAlgo := crypto.StringToHashAlgorithm(createFlags.HashAlgo)
+		if hashAlgo == crypto.UnknownHashAlgorithm {
+			return nil, fmt.Errorf("invalid hash algorithm: %s", createFlags.HashAlgo)
+		}
+
+		keyWeights := createFlags.Weights
+
+		signer := nil // todo refactor project
+
+		var pubKeys []crypto.PublicKey
+		for _, k := range createFlags.Keys {
+			k = strings.ReplaceAll(k, "0x", "") // clear possible prefix
+			key, err := crypto.DecodePublicKeyHex(sigAlgo, k)
+			if err != nil {
+				return nil, fmt.Errorf("failed decoding public key: %s with error: %w", key, err)
+			}
+			pubKeys = append(pubKeys, key)
+		}
+
+		// if more than one key is provided and at least one weight is specified, make sure there isn't a mismatch
+		if len(pubKeys) > 1 && len(keyWeights) > 0 && len(pubKeys) != len(keyWeights) {
+			return nil, fmt.Errorf(
+				"number of keys and weights provided must match, number of provided keys: %d, number of provided key weights: %d",
+				len(pubKeys),
+				len(keyWeights),
+			)
+		}
+
 		account, err := services.Accounts.Create(
-			createFlags.Signer,
-			createFlags.Keys,
-			createFlags.Weights,
-			createFlags.SigAlgo,
-			createFlags.HashAlgo,
+			signer,
+			pubKeys,
+			keyWeights,
+			sigAlgo,
+			hashAlgo,
 			createFlags.Contracts,
 		)
 

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -85,7 +85,7 @@ var CreateCommand = &command.Command{
 		// decode public keys
 		var pubKeys []crypto.PublicKey
 		for _, k := range createFlags.Keys {
-			k = strings.ReplaceAll(k, "0x", "") // clear possible prefix
+			k = strings.TrimPrefix(k, "0x") // clear possible prefix
 			key, err := crypto.DecodePublicKeyHex(sigAlgo, k)
 			if err != nil {
 				return nil, fmt.Errorf("failed decoding public key: %s with error: %w", key, err)

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -74,6 +74,7 @@ var CreateCommand = &command.Command{
 
 		signer := nil // todo refactor project
 
+		// decode public keys
 		var pubKeys []crypto.PublicKey
 		for _, k := range createFlags.Keys {
 			k = strings.ReplaceAll(k, "0x", "") // clear possible prefix

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -63,6 +65,11 @@ var CreateCommand = &command.Command{
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
+		if project == nil {
+			return nil, config.ErrDoesNotExist
+		}
+		signer := project.AccountByName(addContractFlags.Signer)
+
 		sigAlgo := crypto.StringToSignatureAlgorithm(createFlags.SigAlgo)
 		if sigAlgo == crypto.UnknownSignatureAlgorithm {
 			return nil, fmt.Errorf("invalid signature algorithm: %s", createFlags.SigAlgo)
@@ -74,8 +81,6 @@ var CreateCommand = &command.Command{
 		}
 
 		keyWeights := createFlags.Weights
-
-		signer := nil // todo refactor project
 
 		// decode public keys
 		var pubKeys []crypto.PublicKey

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/onflow/flow-go-sdk/crypto"
 
 	"github.com/spf13/cobra"
@@ -55,6 +57,7 @@ var CreateCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if createFlags.Results {
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -65,10 +65,10 @@ var CreateCommand = &command.Command{
 			fmt.Println("⚠️ DEPRECATION WARNING: results flag is deprecated, results are by default included in all executions")
 		}
 
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
-		signer := project.AccountByName(addContractFlags.Signer)
+		signer := proj.AccountByName(addContractFlags.Signer)
 
 		sigAlgo := crypto.StringToSignatureAlgorithm(createFlags.SigAlgo)
 		if sigAlgo == crypto.UnknownSignatureAlgorithm {

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -52,7 +52,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if getFlags.Code {
 			fmt.Println("⚠️  DEPRECATION WARNING: use contracts flag instead")

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -64,7 +64,7 @@ var GetCommand = &command.Command{
 
 		address := flow.HexToAddress(args[0])
 
-		account, err := services.Accounts.Get(address) // address
+		account, err := services.Accounts.Get(address)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/onflow/flow-go-sdk"
 
 	"github.com/spf13/cobra"
@@ -50,6 +52,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if getFlags.Code {
 			fmt.Println("⚠️  DEPRECATION WARNING: use contracts flag instead")

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -21,6 +21,8 @@ package accounts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-go-sdk"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -57,7 +59,9 @@ var GetCommand = &command.Command{
 			fmt.Println("⚠️  DEPRECATION WARNING: use include contracts flag instead")
 		}
 
-		account, err := services.Accounts.Get(args[0]) // address
+		address := flow.HexToAddress(args[0])
+
+		account, err := services.Accounts.Get(address) // address
 		if err != nil {
 			return nil, err
 		}

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -56,7 +56,7 @@ var StakingCommand = &command.Command{
 	) (command.Result, error) {
 		address := flow.HexToAddress(args[0])
 
-		staking, delegation, err := services.Accounts.StakingInfo(address) // address
+		staking, delegation, err := services.Accounts.StakingInfo(address)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -52,7 +52,7 @@ var StakingCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		address := flow.HexToAddress(args[0])
 

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -22,6 +22,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/onflow/flow-go-sdk"
 
 	"github.com/onflow/cadence"
@@ -50,6 +52,7 @@ var StakingCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		address := flow.HexToAddress(args[0])
 

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -22,6 +22,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/onflow/flow-go-sdk"
+
 	"github.com/onflow/cadence"
 	"github.com/spf13/cobra"
 
@@ -49,7 +51,9 @@ var StakingCommand = &command.Command{
 		globalFlags command.GlobalFlags,
 		services *services.Services,
 	) (command.Result, error) {
-		staking, delegation, err := services.Accounts.StakingInfo(args[0]) // address
+		address := flow.HexToAddress(args[0])
+
+		staking, delegation, err := services.Accounts.StakingInfo(address) // address
 		if err != nil {
 			return nil, err
 		}

--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -53,7 +53,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if blockFlags.Latest || blockFlags.BlockID != "" || blockFlags.BlockHeight != 0 {
 			return nil, fmt.Errorf("⚠️  No longer supported: use command argument.")

--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -21,6 +21,8 @@ package blocks
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -51,6 +53,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if blockFlags.Latest || blockFlags.BlockID != "" || blockFlags.BlockHeight != 0 {
 			return nil, fmt.Errorf("⚠️  No longer supported: use command argument.")

--- a/internal/collections/get.go
+++ b/internal/collections/get.go
@@ -19,6 +19,7 @@
 package collections
 
 import (
+	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -43,7 +44,9 @@ var GetCommand = &command.Command{
 		globalFlags command.GlobalFlags,
 		services *services.Services,
 	) (command.Result, error) {
-		collection, err := services.Collections.Get(args[0]) // collection id
+		id := flow.HexToID(args[0])
+
+		collection, err := services.Collections.Get(id)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/collections/get.go
+++ b/internal/collections/get.go
@@ -44,7 +44,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		id := flow.HexToID(args[0])
 

--- a/internal/collections/get.go
+++ b/internal/collections/get.go
@@ -19,6 +19,7 @@
 package collections
 
 import (
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
@@ -43,6 +44,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		id := flow.HexToID(args[0])
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -52,7 +52,7 @@ type RunCommand func(
 type Command struct {
 	Cmd   *cobra.Command
 	Flags interface{}
-	Run   RunCommand
+	Run   RunCommand // todo add run with project
 }
 
 type GlobalFlags struct {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -46,6 +46,7 @@ type RunCommand func(
 	[]string,
 	GlobalFlags,
 	*services.Services,
+	*project.Project,
 ) (Result, error)
 
 type Command struct {
@@ -183,7 +184,7 @@ func (c Command) AddToParent(parent *cobra.Command) {
 		checkVersion(logger)
 
 		// run command
-		result, err := c.Run(cmd, args, Flags, service)
+		result, err := c.Run(cmd, args, Flags, service, proj)
 		handleError("Command Error", err)
 
 		// format output result

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -56,7 +56,7 @@ var AddAccountCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
 
@@ -86,9 +86,9 @@ var AddAccountCommand = &command.Command{
 			return nil, err
 		}
 
-		project.AddOrUpdateAccount(acc)
+		proj.AddOrUpdateAccount(acc)
 
-		err = project.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -54,11 +54,10 @@ var AddAccountCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if project == nil {
+			return nil, config.ErrDoesNotExist
 		}
 
 		accountData, flagsProvided, err := flagsToAccountData(addAccountFlags)
@@ -87,9 +86,9 @@ var AddAccountCommand = &command.Command{
 			return nil, err
 		}
 
-		p.AddOrUpdateAccount(acc)
+		project.AddOrUpdateAccount(acc)
 
-		err = p.SaveDefault()
+		err = project.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -54,6 +54,7 @@ var AddAccountCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -52,6 +52,7 @@ var AddContractCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -54,7 +54,7 @@ var AddContractCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
 
@@ -75,10 +75,10 @@ var AddContractCommand = &command.Command{
 		)
 
 		for _, contract := range contracts {
-			project.Config().Contracts.AddOrUpdate(contract.Name, contract)
+			proj.Config().Contracts.AddOrUpdate(contract.Name, contract)
 		}
 
-		err = project.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -52,11 +52,10 @@ var AddContractCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if project == nil {
+			return nil, config.ErrDoesNotExist
 		}
 
 		contractData, flagsProvided, err := flagsToContractData(addContractFlags)
@@ -76,10 +75,10 @@ var AddContractCommand = &command.Command{
 		)
 
 		for _, contract := range contracts {
-			p.Config().Contracts.AddOrUpdate(contract.Name, contract)
+			project.Config().Contracts.AddOrUpdate(contract.Name, contract)
 		}
 
-		err = p.SaveDefault()
+		err = project.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -53,10 +53,10 @@ var AddDeploymentCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		if project == nil {
+		if proj == nil {
 			return nil, config.ErrDoesNotExist
 		}
-		conf := project.Config()
+		conf := proj.Config()
 
 		deployData, flagsProvided, err := flagsToDeploymentData(addDeploymentFlags)
 		if err != nil {
@@ -75,7 +75,7 @@ var AddDeploymentCommand = &command.Command{
 
 		conf.Deployments.AddOrUpdate(deployment)
 
-		err = p.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -51,6 +51,7 @@ var AddDeploymentCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -51,13 +51,12 @@ var AddDeploymentCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if project == nil {
+			return nil, config.ErrDoesNotExist
 		}
-		conf := p.Config()
+		conf := project.Config()
 
 		deployData, flagsProvided, err := flagsToDeploymentData(addDeploymentFlags)
 		if err != nil {

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -51,6 +51,7 @@ var AddNetworkCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -53,9 +53,8 @@ var AddNetworkCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
 		}
 
 		networkData, flagsProvided, err := flagsToNetworkData(addNetworkFlags)
@@ -68,9 +67,9 @@ var AddNetworkCommand = &command.Command{
 		}
 
 		network := config.StringToNetwork(networkData["name"], networkData["host"])
-		p.Config().Networks.AddOrUpdate(network.Name, network)
+		proj.Config().Networks.AddOrUpdate(network.Name, network)
 
-		err = p.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -51,7 +51,7 @@ var AddNetworkCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -53,7 +53,7 @@ var InitCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		proj, err := services.Project.Init(
 			initFlag.Reset,

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -22,6 +22,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/onflow/flow-go-sdk/crypto"
+
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
 
 	"github.com/spf13/cobra"
@@ -55,12 +57,28 @@ var InitCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		proj, err := services.Project.Init(
+
+		sigAlgo := crypto.StringToSignatureAlgorithm(initFlag.ServiceKeySigAlgo)
+		if sigAlgo == crypto.UnknownSignatureAlgorithm {
+			return nil, fmt.Errorf("invalid signature algorithm: %s", initFlag.ServiceKeySigAlgo)
+		}
+
+		hashAlgo := crypto.StringToHashAlgorithm(initFlag.ServiceKeyHashAlgo)
+		if hashAlgo == crypto.UnknownHashAlgorithm {
+			return nil, fmt.Errorf("invalid hash algorithm: %s", initFlag.ServiceKeyHashAlgo)
+		}
+
+		privateKey, err := crypto.DecodePrivateKeyHex(sigAlgo, initFlag.ServicePrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid private key: %w", err)
+		}
+
+		proj, err = services.Project.Init(
 			initFlag.Reset,
 			initFlag.Global,
-			initFlag.ServiceKeySigAlgo,
-			initFlag.ServiceKeyHashAlgo,
-			initFlag.ServicePrivateKey,
+			sigAlgo,
+			hashAlgo,
+			privateKey,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -53,6 +53,7 @@ var InitCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		proj, err := services.Project.Init(
 			initFlag.Reset,

--- a/internal/config/remove-account.go
+++ b/internal/config/remove-account.go
@@ -19,7 +19,7 @@
 package config
 
 import (
-	"fmt"
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 
 	"github.com/spf13/cobra"
 
@@ -48,11 +48,11 @@ var RemoveAccountCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
 		}
-		conf := p.Config()
+
+		conf := proj.Config()
 
 		name := ""
 		if len(args) == 1 {
@@ -61,12 +61,12 @@ var RemoveAccountCommand = &command.Command{
 			name = output.RemoveAccountPrompt(conf.Accounts)
 		}
 
-		err = p.RemoveAccount(name)
+		err := proj.RemoveAccount(name)
 		if err != nil {
 			return nil, err
 		}
 
-		err = p.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/remove-account.go
+++ b/internal/config/remove-account.go
@@ -46,6 +46,7 @@ var RemoveAccountCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-account.go
+++ b/internal/config/remove-account.go
@@ -46,7 +46,7 @@ var RemoveAccountCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-contract.go
+++ b/internal/config/remove-contract.go
@@ -46,6 +46,7 @@ var RemoveContractCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-contract.go
+++ b/internal/config/remove-contract.go
@@ -46,7 +46,7 @@ var RemoveContractCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-contract.go
+++ b/internal/config/remove-contract.go
@@ -19,7 +19,7 @@
 package config
 
 import (
-	"fmt"
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 
 	"github.com/spf13/cobra"
 
@@ -48,24 +48,23 @@ var RemoveContractCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
 		}
 
 		name := ""
 		if len(args) == 1 {
 			name = args[0]
 		} else {
-			name = output.RemoveContractPrompt(p.Config().Contracts)
+			name = output.RemoveContractPrompt(proj.Config().Contracts)
 		}
 
-		err = p.Config().Contracts.Remove(name)
+		err := proj.Config().Contracts.Remove(name)
 		if err != nil {
 			return nil, err
 		}
 
-		err = p.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/remove-deployment.go
+++ b/internal/config/remove-deployment.go
@@ -46,7 +46,7 @@ var RemoveDeploymentCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-deployment.go
+++ b/internal/config/remove-deployment.go
@@ -46,6 +46,7 @@ var RemoveDeploymentCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-deployment.go
+++ b/internal/config/remove-deployment.go
@@ -19,7 +19,7 @@
 package config
 
 import (
-	"fmt"
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 
 	"github.com/spf13/cobra"
 
@@ -48,9 +48,8 @@ var RemoveDeploymentCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
 		}
 
 		account := ""
@@ -59,15 +58,15 @@ var RemoveDeploymentCommand = &command.Command{
 			account = args[0]
 			network = args[1]
 		} else {
-			account, network = output.RemoveDeploymentPrompt(p.Config().Deployments)
+			account, network = output.RemoveDeploymentPrompt(proj.Config().Deployments)
 		}
 
-		err = p.Config().Deployments.Remove(account, network)
+		err := proj.Config().Deployments.Remove(account, network)
 		if err != nil {
 			return nil, err
 		}
 
-		err = p.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/remove-network.go
+++ b/internal/config/remove-network.go
@@ -19,7 +19,7 @@
 package config
 
 import (
-	"fmt"
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
 
 	"github.com/spf13/cobra"
 
@@ -48,24 +48,23 @@ var RemoveNetworkCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
-		p, err := project.Load(globalFlags.ConfigPaths)
-		if err != nil {
-			return nil, fmt.Errorf("configuration does not exists")
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
 		}
 
 		name := ""
 		if len(args) == 1 {
 			name = args[0]
 		} else {
-			name = output.RemoveNetworkPrompt(p.Config().Networks)
+			name = output.RemoveNetworkPrompt(proj.Config().Networks)
 		}
 
-		err = p.Config().Networks.Remove(name)
+		err := proj.Config().Networks.Remove(name)
 		if err != nil {
 			return nil, err
 		}
 
-		err = p.SaveDefault()
+		err = proj.SaveDefault()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/remove-network.go
+++ b/internal/config/remove-network.go
@@ -46,6 +46,7 @@ var RemoveNetworkCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/config/remove-network.go
+++ b/internal/config/remove-network.go
@@ -46,7 +46,7 @@ var RemoveNetworkCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		p, err := project.Load(globalFlags.ConfigPaths)
 		if err != nil {

--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -47,7 +47,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if generateFlag.Verbose {
 			fmt.Println("⚠️  DEPRECATION WARNING: verbose flag is deprecated")

--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -46,6 +47,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if generateFlag.Verbose {
 			fmt.Println("⚠️  DEPRECATION WARNING: verbose flag is deprecated")

--- a/internal/keys/decode.go
+++ b/internal/keys/decode.go
@@ -55,7 +55,7 @@ var DecodeCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		encoding := args[0]
 		fromFile := decodeFlags.FromFile

--- a/internal/keys/decode.go
+++ b/internal/keys/decode.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/onflow/flow-go-sdk/crypto"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/spf13/cobra"
 
@@ -54,6 +55,7 @@ var DecodeCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		encoding := args[0]
 		fromFile := decodeFlags.FromFile

--- a/internal/keys/decode.go
+++ b/internal/keys/decode.go
@@ -19,6 +19,14 @@
 package keys
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/onflow/flow-go-sdk"
+
+	"github.com/onflow/flow-go-sdk/crypto"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -48,6 +56,7 @@ var DecodeCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 		encoding := args[0]
+		fromFile := decodeFlags.FromFile
 
 		var encoded string
 		if len(args) > 1 {
@@ -56,7 +65,37 @@ var DecodeCommand = &command.Command{
 
 		/* todo from file flag should be remove and should be replaced with $(echo file)
 		but cobra has an issue with parsing pem content as it recognize it as flag due to ---- characters */
-		accountKey, err := services.Keys.Decode(encoded, encoding, decodeFlags.FromFile, decodeFlags.SigAlgo)
+		if encoded != "" && fromFile != "" {
+			return nil, fmt.Errorf("can not pass both command argument and from file flag")
+		}
+		if encoded == "" && fromFile == "" {
+			return nil, fmt.Errorf("provide argument for encoded key or use from file flag")
+		}
+
+		if fromFile != "" {
+			e, err := util.LoadFile(fromFile) // todo replace with file loader
+			if err != nil {
+				return nil, err
+			}
+			encoded = strings.TrimSpace(string(e))
+		}
+
+		var accountKey *flow.AccountKey
+		var err error
+		switch strings.ToLower(encoding) {
+		case "pem":
+			sigAlgo := crypto.StringToSignatureAlgorithm(decodeFlags.SigAlgo)
+			if sigAlgo == crypto.UnknownSignatureAlgorithm {
+				return nil, fmt.Errorf("invalid signature algorithm: %s", decodeFlags.SigAlgo)
+			}
+
+			accountKey, err = services.Keys.DecodePEM(encoded, sigAlgo)
+		case "rlp":
+			accountKey, err = services.Keys.DecodeRLP(encoded)
+		default:
+			return nil, fmt.Errorf("encoding type not supported. Valid encoding: RLP and PEM")
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -49,6 +50,7 @@ var GenerateCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if generateFlags.Algo != "" {
 			fmt.Println("⚠️ DEPRECATION WARNING: flag no longer supported, use '--sig-algo' instead.")

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -21,6 +21,8 @@ package keys
 import (
 	"fmt"
 
+	"github.com/onflow/flow-go-sdk/crypto"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -53,7 +55,12 @@ var GenerateCommand = &command.Command{
 			generateFlags.KeySigAlgo = generateFlags.Algo
 		}
 
-		privateKey, err := services.Keys.Generate(generateFlags.Seed, generateFlags.KeySigAlgo)
+		sigAlgo := crypto.StringToSignatureAlgorithm(generateFlags.KeySigAlgo)
+		if sigAlgo == crypto.UnknownSignatureAlgorithm {
+			return nil, fmt.Errorf("invalid signature algorithm: %s", generateFlags.KeySigAlgo)
+		}
+
+		privateKey, err := services.Keys.Generate(generateFlags.Seed, sigAlgo)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -50,7 +50,7 @@ var GenerateCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if generateFlags.Algo != "" {
 			fmt.Println("⚠️ DEPRECATION WARNING: flag no longer supported, use '--sig-algo' instead.")

--- a/internal/project/deploy.go
+++ b/internal/project/deploy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowcli/contracts"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -44,6 +45,7 @@ var DeployCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		c, err := services.Project.Deploy(globalFlags.Network, deployFlags.Update)
 		if err != nil {

--- a/internal/project/deploy.go
+++ b/internal/project/deploy.go
@@ -45,7 +45,7 @@ var DeployCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		c, err := services.Project.Deploy(globalFlags.Network, deployFlags.Update)
 		if err != nil {

--- a/internal/quick/init.go
+++ b/internal/quick/init.go
@@ -43,7 +43,7 @@ var InitCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		proj, err := services.Project.Init(
 			initFlag.Reset,

--- a/internal/quick/init.go
+++ b/internal/quick/init.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/config"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -42,6 +43,7 @@ var InitCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		proj, err := services.Project.Init(
 			initFlag.Reset,

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -54,7 +54,7 @@ var ExecuteCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		filename := ""
 		if len(args) == 1 {

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/flow-cli/pkg/flowcli"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 
 	"github.com/spf13/cobra"
@@ -53,6 +54,7 @@ var ExecuteCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		filename := ""
 		if len(args) == 1 {

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -21,6 +21,10 @@ package scripts
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -68,10 +72,20 @@ var ExecuteCommand = &command.Command{
 			}
 		}
 
+		code, err := util.LoadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error loading script file: %w", err)
+		}
+
+		scriptArgs, err := flowcli.ParseArguments(scriptFlags.Arg, scriptFlags.ArgsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing script arguments: %w", err)
+		}
+
 		value, err := services.Scripts.Execute(
+			code,
+			scriptArgs,
 			filename,
-			scriptFlags.Arg,
-			scriptFlags.ArgsJSON,
 			globalFlags.Network,
 		)
 		if err != nil {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 
 	"github.com/spf13/cobra"
 
@@ -47,6 +48,7 @@ var Command = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		accessNode, err := services.Status.Ping(globalFlags.Network)
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -48,7 +48,7 @@ var Command = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		accessNode, err := services.Status.Ping(globalFlags.Network)
 

--- a/internal/transactions/build.go
+++ b/internal/transactions/build.go
@@ -56,7 +56,7 @@ var BuildCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		proposer := flow.HexToAddress(buildFlags.Proposer)
 		if proposer == flow.EmptyAddress {

--- a/internal/transactions/build.go
+++ b/internal/transactions/build.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/onflow/flow-cli/pkg/flowcli"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
@@ -55,6 +56,7 @@ var BuildCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		proposer := flow.HexToAddress(buildFlags.Proposer)
 		if proposer == flow.EmptyAddress {

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -54,7 +54,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if cmd.CalledAs() == "status" {
 			fmt.Println("⚠️  DEPRECATION WARNING: use \"flow transactions get\" instead")

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -64,7 +64,7 @@ var GetCommand = &command.Command{
 			fmt.Println("⚠️  DEPRECATION WARNING: use include flag instead")
 		}
 
-		id := flow.HexToID(strings.ReplaceAll(args[0], "0x", ""))
+		id := flow.HexToID(strings.TrimPrefix(args[0], "0x"))
 
 		tx, result, err := services.Transactions.GetStatus(id, getFlags.Sealed)
 		if err != nil {

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -53,6 +54,7 @@ var GetCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if cmd.CalledAs() == "status" {
 			fmt.Println("⚠️  DEPRECATION WARNING: use \"flow transactions get\" instead")

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -20,6 +20,9 @@ package transactions
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/onflow/flow-go-sdk"
 
 	"github.com/spf13/cobra"
 
@@ -59,10 +62,9 @@ var GetCommand = &command.Command{
 			fmt.Println("⚠️  DEPRECATION WARNING: use include flag instead")
 		}
 
-		tx, result, err := services.Transactions.GetStatus(
-			args[0], // transaction id
-			getFlags.Sealed,
-		)
+		id := flow.HexToID(strings.ReplaceAll(args[0], "0x", ""))
+
+		tx, result, err := services.Transactions.GetStatus(id, getFlags.Sealed)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/transactions/send-signed.go
+++ b/internal/transactions/send-signed.go
@@ -46,7 +46,7 @@ var SendSignedCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 
 		tx, result, err := services.Transactions.SendSigned(

--- a/internal/transactions/send-signed.go
+++ b/internal/transactions/send-signed.go
@@ -19,6 +19,9 @@
 package transactions
 
 import (
+	"fmt"
+
+	"github.com/onflow/flow-cli/pkg/flowcli/util"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -48,10 +51,14 @@ var SendSignedCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
+		filename := args[0]
 
-		tx, result, err := services.Transactions.SendSigned(
-			args[0], // signed filename
-		)
+		code, err := util.LoadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error loading transaction payload: %w", err)
+		}
+
+		tx, result, err := services.Transactions.SendSigned(code)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/transactions/send-signed.go
+++ b/internal/transactions/send-signed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -45,6 +46,7 @@ var SendSignedCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 
 		tx, result, err := services.Transactions.SendSigned(

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-cli/pkg/flowcli"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
 
 	"github.com/spf13/cobra"
@@ -57,6 +58,7 @@ var SendCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 		if sendFlags.Results {
 			fmt.Println("⚠️  DEPRECATION WARNING: all transactions will provide results")

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -21,6 +21,8 @@ package transactions
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
 	"github.com/onflow/flow-cli/pkg/flowcli"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/util"
@@ -72,6 +74,10 @@ var SendCommand = &command.Command{
 			}
 		}
 
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
+		}
+
 		codeFilename := ""
 		if len(args) == 1 {
 			codeFilename = args[0]
@@ -80,14 +86,14 @@ var SendCommand = &command.Command{
 			codeFilename = sendFlags.Code
 		}
 
-		signer := t.project.AccountByName(sendFlags.Signer) // todo refactor project
+		signer := proj.AccountByName(sendFlags.Signer)
 		if signer == nil {
-			return nil, nil, fmt.Errorf("signer account: [%s] doesn't exists in configuration", sendFlags.Signer)
+			return nil, fmt.Errorf("signer account: [%s] doesn't exists in configuration", sendFlags.Signer)
 		}
 
 		code, err := util.LoadFile(codeFilename)
 		if err != nil {
-			return nil, fmt.Errorf("error loading script file: %w", err)
+			return nil, fmt.Errorf("error loading transaction file: %w", err)
 		}
 
 		txArgs, err := flowcli.ParseArguments(buildFlags.Args, buildFlags.ArgsJSON) // todo refactor flowcli

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -58,7 +58,7 @@ var SendCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 		if sendFlags.Results {
 			fmt.Println("⚠️  DEPRECATION WARNING: all transactions will provide results")

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -19,6 +19,9 @@
 package transactions
 
 import (
+	"fmt"
+	"io/ioutil"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -46,11 +49,18 @@ var SignCommand = &command.Command{
 		services *services.Services,
 	) (command.Result, error) {
 
-		signed, err := services.Transactions.Sign(
-			args[0], // transaction payload
-			signFlags.Signer,
-			globalFlags.Yes,
-		)
+		filename := args[0]
+		payload, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read partial transaction from %s: %v", filename, err)
+		}
+
+		signer := nil // todo refactor from project
+		if signer == nil {
+			return nil, fmt.Errorf("signer account: [%s] doesn't exists in configuration", signerName)
+		}
+
+		signed, err := services.Transactions.Sign(payload, signer, globalFlags.Yes)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/onflow/flow-cli/pkg/flowcli/config"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
@@ -50,6 +52,9 @@ var SignCommand = &command.Command{
 		services *services.Services,
 		proj *project.Project,
 	) (command.Result, error) {
+		if proj == nil {
+			return nil, config.ErrDoesNotExist
+		}
 
 		filename := args[0]
 		payload, err := ioutil.ReadFile(filename)
@@ -57,9 +62,9 @@ var SignCommand = &command.Command{
 			return nil, fmt.Errorf("failed to read partial transaction from %s: %v", filename, err)
 		}
 
-		signer := nil // todo refactor from project
+		signer := proj.AccountByName(signFlags.Signer)
 		if signer == nil {
-			return nil, fmt.Errorf("signer account: [%s] doesn't exists in configuration", signerName)
+			return nil, fmt.Errorf("signer account: [%s] doesn't exists in configuration", signFlags.Signer)
 		}
 
 		signed, err := services.Transactions.Sign(payload, signer, globalFlags.Yes)

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -48,7 +48,7 @@ var SignCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-		project *project.Project,
+		proj *project.Project,
 	) (command.Result, error) {
 
 		filename := args[0]

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowcli/project"
 	"github.com/onflow/flow-cli/pkg/flowcli/services"
 )
 
@@ -47,6 +48,7 @@ var SignCommand = &command.Command{
 		args []string,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
+		project *project.Project,
 	) (command.Result, error) {
 
 		filename := args[0]

--- a/pkg/flowcli/config/json/account.go
+++ b/pkg/flowcli/config/json/account.go
@@ -49,7 +49,7 @@ func transformAddress(address string) (flow.Address, error) {
 func transformSimpleToConfig(accountName string, a simpleAccount) (*config.Account, error) {
 	pkey, err := crypto.DecodePrivateKeyHex(
 		crypto.ECDSA_P256,
-		strings.ReplaceAll(a.Key, "0x", ""),
+		strings.TrimPrefix(a.Key, "0x"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("invalid private key for account: %s", accountName)
@@ -92,7 +92,7 @@ func transformAdvancedToConfig(accountName string, a advanceAccount) (*config.Ac
 		if a.Key.PrivateKey != "" {
 			pKey, err = crypto.DecodePrivateKeyHex(
 				sigAlgo,
-				strings.ReplaceAll(a.Key.PrivateKey, "0x", ""),
+				strings.TrimPrefix(a.Key.PrivateKey, "0x"),
 			)
 			if err != nil {
 				return nil, err
@@ -173,7 +173,7 @@ func transformSimpleAccountToJSON(a config.Account) account {
 	return account{
 		Simple: simpleAccount{
 			Address: a.Address.String(),
-			Key:     strings.ReplaceAll(a.Key.PrivateKey.String(), "0x", ""),
+			Key:     strings.TrimPrefix(a.Key.PrivateKey.String(), "0x"),
 		},
 	}
 }
@@ -188,7 +188,7 @@ func transformAdvancedAccountToJSON(a config.Account) account {
 				SigAlgo:    a.Key.SigAlgo.String(),
 				HashAlgo:   a.Key.HashAlgo.String(),
 				ResourceID: a.Key.ResourceID,
-				PrivateKey: strings.ReplaceAll(a.Key.PrivateKey.String(), "0x", ""),
+				PrivateKey: strings.TrimPrefix(a.Key.PrivateKey.String(), "0x"),
 			},
 		},
 	}

--- a/pkg/flowcli/project/transaction.go
+++ b/pkg/flowcli/project/transaction.go
@@ -141,7 +141,7 @@ func addAccountContractWithArgs(
 // NewCreateAccountTransaction creates new transaction for account
 func NewCreateAccountTransaction(
 	signer *Account,
-	keys []flow.AccountKey,
+	keys []*flow.AccountKey,
 	contractArgs []string,
 ) (*Transaction, error) {
 

--- a/pkg/flowcli/project/transaction.go
+++ b/pkg/flowcli/project/transaction.go
@@ -149,7 +149,7 @@ func addAccountContractWithArgs(
 // NewCreateAccountTransaction creates new transaction for account
 func NewCreateAccountTransaction(
 	signer *Account,
-	keys []*flow.AccountKey,
+	keys []flow.AccountKey,
 	contractArgs []string,
 ) (*Transaction, error) {
 

--- a/pkg/flowcli/project/transaction.go
+++ b/pkg/flowcli/project/transaction.go
@@ -183,13 +183,13 @@ func newTransactionFromTemplate(templateTx *flow.Transaction, signer *Account) (
 
 // Transaction builder of flow transactions
 type Transaction struct {
-	signer   Account
+	signer   *Account
 	proposer *flow.Account
 	tx       *flow.Transaction
 }
 
 // Signer get signer
-func (t *Transaction) Signer() Account {
+func (t *Transaction) Signer() *Account {
 	return t.signer
 }
 
@@ -209,7 +209,7 @@ func (t *Transaction) SetScriptWithArgs(script []byte, args []cadence.Value) err
 }
 
 // SetSigner sets the signer for transaction
-func (t *Transaction) SetSigner(account Account) error {
+func (t *Transaction) SetSigner(account *Account) error {
 	err := account.Key().Validate()
 	if err != nil {
 		return err

--- a/pkg/flowcli/services/accounts.go
+++ b/pkg/flowcli/services/accounts.go
@@ -120,14 +120,14 @@ func (a *Accounts) Create(
 		return nil, config.ErrDoesNotExist
 	}
 
-	var accKeys []flow.AccountKey
+	var accKeys []*flow.AccountKey
 	for i, pubKey := range pubKeys {
 		weight := flow.AccountKeyWeightThreshold
 		if len(keyWeights) > i { // if key weight is specified
 			weight = keyWeights[i]
 		}
 
-		accKey := flow.AccountKey{
+		accKey := &flow.AccountKey{
 			PublicKey: pubKey,
 			SigAlgo:   sigAlgo,
 			HashAlgo:  hashAlgo,

--- a/pkg/flowcli/services/accounts.go
+++ b/pkg/flowcli/services/accounts.go
@@ -218,68 +218,8 @@ func (a *Accounts) Create(
 	return a.gateway.GetAccount(*newAccountAddress)
 }
 
-// AddContract adds a new contract to an account and returns the updated account.
+// AddContract deploys a contract code to the account provided with possible update flag
 func (a *Accounts) AddContract(
-	accountName string,
-	contractName string,
-	contractFilename string,
-	updateExisting bool,
-) (*flow.Account, error) {
-	if a.project == nil {
-		return nil, config.ErrDoesNotExist
-	}
-
-	account := a.project.AccountByName(accountName)
-	if account == nil {
-		return nil, fmt.Errorf("account: [%s] doesn't exists in configuration", accountName)
-	}
-
-	contractSource, err := util.LoadFile(contractFilename)
-	if err != nil {
-		return nil, err
-	}
-
-	return a.addContract(account, contractName, contractSource, updateExisting)
-}
-
-// AddContractForAddress adds a new contract to an address using private key specified
-func (a *Accounts) AddContractForAddress(
-	accountAddress string,
-	accountPrivateKey string,
-	contractName string,
-	contractFilename string,
-	updateExisting bool,
-) (*flow.Account, error) {
-	account, err := accountFromAddressAndKey(accountAddress, accountPrivateKey)
-	if err != nil {
-		return nil, err
-	}
-
-	contractSource, err := util.LoadFile(contractFilename)
-	if err != nil {
-		return nil, err
-	}
-
-	return a.addContract(account, contractName, contractSource, updateExisting)
-}
-
-// AddContractForAddressWithCode adds a new contract to an address using private key and code specified
-func (a *Accounts) AddContractForAddressWithCode(
-	accountAddress string,
-	accountPrivateKey string,
-	contractName string,
-	contractCode []byte,
-	updateExisting bool,
-) (*flow.Account, error) {
-	account, err := accountFromAddressAndKey(accountAddress, accountPrivateKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return a.addContract(account, contractName, contractCode, updateExisting)
-}
-
-func (a *Accounts) addContract(
 	account *project.Account,
 	contractName string,
 	contractSource []byte,

--- a/pkg/flowcli/services/accounts.go
+++ b/pkg/flowcli/services/accounts.go
@@ -56,23 +56,19 @@ func NewAccounts(
 }
 
 // Get returns an account by on address.
-func (a *Accounts) Get(address string) (*flow.Account, error) {
+func (a *Accounts) Get(address flow.Address) (*flow.Account, error) {
 	a.logger.StartProgress(fmt.Sprintf("Loading %s...", address))
 
-	flowAddress := flow.HexToAddress(address)
-
-	account, err := a.gateway.GetAccount(flowAddress)
+	account, err := a.gateway.GetAccount(address)
 	a.logger.StopProgress()
 
 	return account, err
 }
 
 // StakingInfo returns the staking information for an account.
-func (a *Accounts) StakingInfo(accountAddress string) (*cadence.Value, *cadence.Value, error) {
-	a.logger.StartProgress(fmt.Sprintf("Fetching info for %s...", accountAddress))
+func (a *Accounts) StakingInfo(address flow.Address) (*cadence.Value, *cadence.Value, error) {
+	a.logger.StartProgress(fmt.Sprintf("Fetching info for %s...", address.String()))
 	defer a.logger.StopProgress()
-
-	address := flow.HexToAddress(accountAddress)
 
 	cadenceAddress := []cadence.Value{cadence.NewAddress(address)}
 

--- a/pkg/flowcli/services/collections.go
+++ b/pkg/flowcli/services/collections.go
@@ -47,7 +47,6 @@ func NewCollections(
 }
 
 // Get returns a collection by ID.
-func (c *Collections) Get(id string) (*flow.Collection, error) {
-	collectionID := flow.HexToID(id)
-	return c.gateway.GetCollection(collectionID)
+func (c *Collections) Get(id flow.Identifier) (*flow.Collection, error) {
+	return c.gateway.GetCollection(id)
 }

--- a/pkg/flowcli/services/keys.go
+++ b/pkg/flowcli/services/keys.go
@@ -21,7 +21,6 @@ package services
 import (
 	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -52,11 +51,8 @@ func NewKeys(
 	}
 }
 
-const PEM string = "pem"
-const RLP string = "rlp"
-
 // Generate generates a new private key from the given seed and signature algorithm.
-func (k *Keys) Generate(inputSeed string, signatureAlgo string) (crypto.PrivateKey, error) {
+func (k *Keys) Generate(inputSeed string, sigAlgo crypto.SignatureAlgorithm) (crypto.PrivateKey, error) {
 	var seed []byte
 	var err error
 
@@ -69,11 +65,6 @@ func (k *Keys) Generate(inputSeed string, signatureAlgo string) (crypto.PrivateK
 		seed = []byte(inputSeed)
 	}
 
-	sigAlgo := crypto.StringToSignatureAlgorithm(signatureAlgo)
-	if sigAlgo == crypto.UnknownSignatureAlgorithm {
-		return nil, fmt.Errorf("invalid signature algorithm: %s", signatureAlgo)
-	}
-
 	privateKey, err := crypto.GeneratePrivateKey(sigAlgo, seed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate private key: %w", err)
@@ -82,35 +73,8 @@ func (k *Keys) Generate(inputSeed string, signatureAlgo string) (crypto.PrivateK
 	return privateKey, nil
 }
 
-// Decode encoded public key using supported encoding type
-func (k *Keys) Decode(encoded string, encoding string, fromFile string, sigAlgo string) (*flow.AccountKey, error) {
-	// todo refactor this to commands (as part of api refactor) and pass typed values
-	if encoded != "" && fromFile != "" {
-		return nil, fmt.Errorf("can not pass both command argument and from file flag")
-	}
-	if encoded == "" && fromFile == "" {
-		return nil, fmt.Errorf("provide argument for encoded key or use from file flag")
-	}
-
-	if fromFile != "" {
-		e, err := util.LoadFile(fromFile)
-		if err != nil {
-			return nil, err
-		}
-		encoded = strings.TrimSpace(string(e))
-	}
-
-	switch strings.ToLower(encoding) {
-	case PEM:
-		return decodePEM(encoded, sigAlgo)
-	case RLP:
-		return decodeRLP(encoded)
-	default:
-		return nil, fmt.Errorf("encoding type not supported. Valid encoding: RLP and PEM")
-	}
-}
-
-func decodeRLP(publicKey string) (*flow.AccountKey, error) {
+// DecodeRLP decodes an RLP encoded public key
+func (k *Keys) DecodeRLP(publicKey string) (*flow.AccountKey, error) {
 	publicKeyBytes, err := hex.DecodeString(publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode public key: %w", err)
@@ -124,11 +88,9 @@ func decodeRLP(publicKey string) (*flow.AccountKey, error) {
 	return accountKey, nil
 }
 
-func decodePEM(key string, sigAlgo string) (*flow.AccountKey, error) {
-	pk, err := crypto.DecodePublicKeyPEM(
-		crypto.StringToSignatureAlgorithm(sigAlgo),
-		key,
-	)
+// DecodePEM decodes a PEM encoded public key with specified signature algorithm
+func (k *Keys) DecodePEM(key string, sigAlgo crypto.SignatureAlgorithm) (*flow.AccountKey, error) {
+	pk, err := crypto.DecodePublicKeyPEM(sigAlgo, key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flowcli/services/project.go
+++ b/pkg/flowcli/services/project.go
@@ -30,7 +30,6 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 // Project is a service that handles all interactions for a project.
@@ -56,9 +55,9 @@ func NewProject(
 func (p *Project) Init(
 	reset bool,
 	global bool,
-	serviceKeySigAlgo string,
-	serviceKeyHashAlgo string,
-	servicePrivateKey string,
+	sigAlgo crypto.SignatureAlgorithm,
+	hashAlgo crypto.HashAlgorithm,
+	serviceKey crypto.PrivateKey,
 ) (*project.Project, error) {
 	path := config.DefaultPath
 	if global {
@@ -72,24 +71,12 @@ func (p *Project) Init(
 		)
 	}
 
-	sigAlgo, hashAlgo, err := util.ConvertSigAndHashAlgo(serviceKeySigAlgo, serviceKeyHashAlgo)
-	if err != nil {
-		return nil, err
-	}
-
 	proj, err := project.Init(sigAlgo, hashAlgo)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(servicePrivateKey) > 0 {
-		serviceKey, err := crypto.DecodePrivateKeyHex(sigAlgo, servicePrivateKey)
-		if err != nil {
-			return nil, fmt.Errorf("could not decode private key for a service account, provided private key: %s", servicePrivateKey)
-		}
-
-		proj.SetEmulatorServiceKey(serviceKey)
-	}
+	proj.SetEmulatorServiceKey(serviceKey)
 
 	err = proj.Save(path)
 	if err != nil {

--- a/pkg/flowcli/services/scripts.go
+++ b/pkg/flowcli/services/scripts.go
@@ -25,12 +25,10 @@ import (
 
 	"github.com/onflow/cadence"
 
-	"github.com/onflow/flow-cli/pkg/flowcli"
 	"github.com/onflow/flow-cli/pkg/flowcli/contracts"
 	"github.com/onflow/flow-cli/pkg/flowcli/gateway"
 	"github.com/onflow/flow-cli/pkg/flowcli/output"
 	"github.com/onflow/flow-cli/pkg/flowcli/project"
-	"github.com/onflow/flow-cli/pkg/flowcli/util"
 )
 
 // Scripts is a service that handles all script-related interactions.
@@ -53,27 +51,8 @@ func NewScripts(
 	}
 }
 
-// Execute executes a Cadence script from a file.
-func (s *Scripts) Execute(scriptPath string, args []string, argsJSON string, network string) (cadence.Value, error) {
-	script, err := util.LoadFile(scriptPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.execute(script, args, argsJSON, scriptPath, network)
-}
-
-// ExecuteWithCode executes a Cadence script from a source code string.
-func (s *Scripts) ExecuteWithCode(code []byte, args []string, argsJSON string) (cadence.Value, error) {
-	return s.execute(code, args, argsJSON, "", "")
-}
-
-func (s *Scripts) execute(code []byte, args []string, argsJSON string, scriptPath string, network string) (cadence.Value, error) {
-	scriptArgs, err := flowcli.ParseArguments(args, argsJSON)
-	if err != nil {
-		return nil, err
-	}
-
+// Execute script code with passed arguments on the selected network
+func (s *Scripts) Execute(code []byte, args []cadence.Value, scriptPath string, network string) (cadence.Value, error) {
 	resolver, err := contracts.NewResolver(code)
 	if err != nil {
 		return nil, err
@@ -86,7 +65,7 @@ func (s *Scripts) execute(code []byte, args []string, argsJSON string, scriptPat
 		if network == "" {
 			return nil, fmt.Errorf("missing network, specify which network to use to resolve imports in script code")
 		}
-		if scriptPath == "" { // when used as lib with code we don't support imports
+		if scriptPath == "" {
 			return nil, fmt.Errorf("resolving imports in scripts not supported")
 		}
 
@@ -105,5 +84,5 @@ func (s *Scripts) execute(code []byte, args []string, argsJSON string, scriptPat
 		}
 	}
 
-	return s.gateway.ExecuteScript(code, scriptArgs)
+	return s.gateway.ExecuteScript(code, args)
 }

--- a/pkg/flowcli/services/transactions.go
+++ b/pkg/flowcli/services/transactions.go
@@ -144,7 +144,7 @@ func (t *Transactions) Build(
 // Sign transaction
 func (t *Transactions) Sign(
 	payload []byte,
-	signer project.Account,
+	signer *project.Account,
 	approveSigning bool,
 ) (*project.Transaction, error) {
 	if t.project == nil {
@@ -200,7 +200,7 @@ func (t *Transactions) SendSigned(
 // Send sends a transaction from a file.
 func (t *Transactions) Send(
 	code []byte,
-	signer project.Account,
+	signer *project.Account,
 	codeFilename string,
 	gasLimit uint64,
 	args []cadence.Value,

--- a/pkg/flowcli/services/transactions.go
+++ b/pkg/flowcli/services/transactions.go
@@ -210,7 +210,7 @@ func (t *Transactions) Send(
 		return nil, nil, fmt.Errorf("missing configuration, initialize it: flow project init")
 	}
 
-	signerKeyIndex := signerAccount.Key().Index()
+	signerKeyIndex := signer.Key().Index()
 
 	tx, err := t.Build(
 		signer.Address(),


### PR DESCRIPTION
Closes #293 

## Description
Addressing the issue specifically on the API refactor.

Converting all service APIs to accept "typed" arguments and not "raw" string arguments. 
This will lead to better reusability of the flowkit package and easier testing.

Refactor also removes some code duplication since the API no longer takes the raw arguments we surface the argument preparation which leads to less complicated APIs as they are less granular.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
