### PR TITLE
Fix for comma issue on --arg parameter value

### DIFF
--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -60,6 +60,8 @@ var ExecuteCommand = &command.Command{
 			return nil, fmt.Errorf("provide a valide filename command argument")
 		}
 
+		scriptFlags.Arg, _ = cmd.Flags().GetStringArray("arg")
+
 		if scriptFlags.Args != "" {
 			fmt.Println("⚠️  DEPRECATION WARNING: use arg flag in Type:Value format or args-json for JSON format")
 

--- a/internal/transactions/build.go
+++ b/internal/transactions/build.go
@@ -52,7 +52,7 @@ var BuildCommand = &command.Command{
 	) (command.Result, error) {
 
 		codeFilename := args[0]
-		buildFlags.Arg, _ = cmd.Flags().GetStringArray("arg")
+		buildFlags.Args, _ = cmd.Flags().GetStringArray("arg")
 
 		build, err := services.Transactions.Build(
 			buildFlags.Proposer,

--- a/internal/transactions/build.go
+++ b/internal/transactions/build.go
@@ -52,6 +52,7 @@ var BuildCommand = &command.Command{
 	) (command.Result, error) {
 
 		codeFilename := args[0]
+		buildFlags.Arg, _ = cmd.Flags().GetStringArray("arg")
 
 		build, err := services.Transactions.Build(
 			buildFlags.Proposer,

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -59,6 +59,8 @@ var SendCommand = &command.Command{
 			fmt.Println("⚠️  DEPRECATION WARNING: all transactions will provide results")
 		}
 
+		sendFlags.Arg, _ = cmd.Flags().GetStringArray("arg")
+
 		if sendFlags.Args != "" {
 			fmt.Println("⚠️  DEPRECATION WARNING: use arg flag in Type:Value format or arg-json for JSON format")
 


### PR DESCRIPTION
## Description

--arg parameters parsing values as CSV with cobra, this PR fixes that.

For example below example fails: 

`flow transactions send my_transaction.cdc --arg "String:arg1" --arg "Array:['arrArg1','arrArg2']"
`
______
For contributor use:

- [x] Targeted PR against `master` branch
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
