### PR TITLE
make loader accept the latest valid flow json in path

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -831,7 +831,6 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0 h1:2v10ZSCE4e3TyeD
 github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0/go.mod h1:fLJbjGUHrlHdrjaeRDgKG9nZJ6spiCScc+Q5SARgH38=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.6.0/go.mod h1:fLJbjGUHrlHdrjaeRDgKG9nZJ6spiCScc+Q5SARgH38=
 github.com/onflow/flow-emulator v0.19.0/go.mod h1:k5un51XlFJavboagCqTxd6x8Gle7lxWlXdUepoNB5fA=
-github.com/onflow/flow-emulator v0.21.0 h1:gvy7OZK+FxroyQEeqQDbxovu83W9qfgGRA3+N0SGjL0=
 github.com/onflow/flow-emulator v0.21.0/go.mod h1:/2dNG6K4fKtpZsazdIeK8Fs0IWXUzqvO3qK5467pYsc=
 github.com/onflow/flow-emulator v0.22.0 h1:K+OvKLOPxJjWC+rgrl0zVuLpg72E3Sjp+wS8Vg2X8XQ=
 github.com/onflow/flow-emulator v0.22.0/go.mod h1:zDnU3NLgB/jzvLZykaldmuX2tTImivu5G4in8ntAUTY=
@@ -840,13 +839,11 @@ github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWK
 github.com/onflow/flow-go v0.16.3-0.20210427194927-6050c2a3ae42/go.mod h1:9GUEbBhOGDVf91ZJB6QWqVNQkrM3INEudNyDtIttOu0=
 github.com/onflow/flow-go v0.17.1/go.mod h1:j8zCo01+2pJL00qpOnwdOqU7spTgOLHFRUp9gsamyNA=
 github.com/onflow/flow-go v0.18.0/go.mod h1:cQpvFoqth9PR7tarWDa36R/dDOqUK5QYfeYzCdXPLII=
-github.com/onflow/flow-go v0.18.2-canary h1:hq7qST4RELlQHJy2vvmSBJbpvNyBhbad369MFODRANI=
 github.com/onflow/flow-go v0.18.2-canary/go.mod h1:mGzTPbzG1YrckrFQfjCw6NzfflP1o3TjRxI9LRWZbpc=
 github.com/onflow/flow-go v0.18.4 h1:2VHCT+e8oo5jrAYyYLdHga6in8FcbXd6tqiQjg9YPz0=
 github.com/onflow/flow-go v0.18.4/go.mod h1:ytSpiDTsY5dg+2jyiJR9iGiMsH0cDxISPRal7fYGnpI=
 github.com/onflow/flow-go-sdk v0.18.0/go.mod h1:AjXHdxguP/PK5P8tWKHH4jR6oLISTgLoXXQrbQsHY+E=
 github.com/onflow/flow-go-sdk v0.19.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
-github.com/onflow/flow-go-sdk v0.20.0-alpha.1 h1:zy5viTpSQsfKgaoj9PgDOhoklLkG0Fze4okGFZ21Mus=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.20.1-0.20210623043139-533a95abf071 h1:Ytzw/EZl32II4Y9dwbYvUeT19Tl/a2bNR6AfNGwfvbw=
 github.com/onflow/flow-go-sdk v0.20.1-0.20210623043139-533a95abf071/go.mod h1:eTbMbxgmC5CAc4sSFsD2RfpVnt0vOLwWtGfnMppjvNM=
@@ -1189,7 +1186,6 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -1408,7 +1404,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201020161133-226fd2f889ca/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.4 h1:cVngSRcfgyZCzys3KYOpCFa+4dqX/Oub9tAq00ttGVs=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -62,7 +62,7 @@ func addAccount(
 ) (command.Result, error) {
 
 	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
-		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+		return nil, fmt.Errorf("specifying multiple paths to -f is not supported when updating configuration")
 	}
 
 	if state == nil {

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -56,10 +56,15 @@ var AddAccountCommand = &command.Command{
 func addAccount(
 	_ []string,
 	_ flowkit.ReaderWriter,
-	_ command.GlobalFlags,
+	globalFlags command.GlobalFlags,
 	_ *services.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
+
+	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
+		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+	}
+
 	if state == nil {
 		return nil, config.ErrDoesNotExist
 	}

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -55,10 +55,15 @@ var AddContractCommand = &command.Command{
 func addContract(
 	_ []string,
 	_ flowkit.ReaderWriter,
-	_ command.GlobalFlags,
+	globalFlags command.GlobalFlags,
 	_ *services.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
+
+	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
+		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+	}
+
 	if state == nil {
 		return nil, config.ErrDoesNotExist
 	}

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -61,7 +61,7 @@ func addContract(
 ) (command.Result, error) {
 
 	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
-		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+		return nil, fmt.Errorf("specifying multiple paths to -f is not supported when updating configuration")
 	}
 
 	if state == nil {

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -53,10 +53,15 @@ var AddDeploymentCommand = &command.Command{
 func addDeployment(
 	_ []string,
 	_ flowkit.ReaderWriter,
-	_ command.GlobalFlags,
+	globalFlags command.GlobalFlags,
 	_ *services.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
+
+	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
+		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+	}
+
 	if state == nil {
 		return nil, config.ErrDoesNotExist
 	}

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -59,7 +59,7 @@ func addDeployment(
 ) (command.Result, error) {
 
 	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
-		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+		return nil, fmt.Errorf("specifying multiple paths to -f is not supported when updating configuration")
 	}
 
 	if state == nil {

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -59,7 +59,7 @@ func addNetwork(
 ) (command.Result, error) {
 
 	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
-		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+		return nil, fmt.Errorf("specifying multiple paths to -f is not supported when updating configuration")
 	}
 
 	if state == nil {

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -53,10 +53,15 @@ var AddNetworkCommand = &command.Command{
 func addNetwork(
 	_ []string,
 	_ flowkit.ReaderWriter,
-	_ command.GlobalFlags,
+	globalFlags command.GlobalFlags,
 	_ *services.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
+
+	if !config.IsGlobalPath(globalFlags.ConfigPaths) && len(globalFlags.ConfigPaths) > 1 {
+		return nil, fmt.Errorf("specifing multiple paths to -f is not supported when updating configuration")
+	}
+
 	if state == nil {
 		return nil, config.ErrDoesNotExist
 	}

--- a/pkg/flowkit/config/config.go
+++ b/pkg/flowkit/config/config.go
@@ -94,6 +94,10 @@ var ErrOutdatedFormat = errors.New("you are using old configuration format")
 
 const DefaultPath = "flow.json"
 
+func IsGlobalPath(paths []string) bool {
+	return len(paths) == 2 && paths[0] == GlobalPath() && paths[1] == DefaultPath
+}
+
 // GlobalPath gets global path based on home dir.
 func GlobalPath() string {
 	dirname, err := os.UserHomeDir()

--- a/pkg/flowkit/config/loader_test.go
+++ b/pkg/flowkit/config/loader_test.go
@@ -65,6 +65,81 @@ func Test_JSONSimple(t *testing.T) {
 	assert.Equal(t, "0x21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Key.PrivateKey.String())
 }
 
+func Test_ErrorWhenMissingBothDefaultJsonFiles(t *testing.T) {
+	composer := config.NewLoader(afero.Afero{Fs: mockFS})
+	composer.AddConfigParser(json.NewParser())
+
+	_, loadErr := composer.Load(config.DefaultPaths())
+
+	assert.Error(t, loadErr)
+	assert.Contains(t, loadErr.Error(), "missing configuration")
+}
+
+func Test_AllowMissingocalJson(t *testing.T) {
+	b := []byte(`{
+		"accounts": {
+			"emulator-account": {
+				"address": "f8d6e0586b0a20c7",
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+			}
+		}
+	}`)
+
+	mockFS := afero.NewMemMapFs()
+	err := afero.WriteFile(mockFS, config.GlobalPath(), b, 0644)
+
+	assert.NoError(t, err)
+
+	composer := config.NewLoader(afero.Afero{Fs: mockFS})
+	composer.AddConfigParser(json.NewParser())
+
+	conf, loadErr := composer.Load(config.DefaultPaths())
+
+	assert.NoError(t, loadErr)
+	assert.Equal(t, 1, len(conf.Accounts))
+	assert.Equal(t, "0x21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
+		conf.Accounts.ByName("emulator-account").Key.PrivateKey.String(),
+	)
+}
+
+func Test_PreferLocalJson(t *testing.T) {
+	b := []byte(`{
+		"accounts": {
+			"emulator-account": {
+				"address": "f8d6e0586b0a20c7",
+				"key": "21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+			}
+		}
+	}`)
+
+	b2 := []byte(`{
+		 "accounts":{
+				"emulator-account":{
+					 "address":"f1d6e0586b0a20c7",
+					 "key":"3335dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
+				}
+		 }
+	}`)
+
+	mockFS := afero.NewMemMapFs()
+	err := afero.WriteFile(mockFS, "flow.json", b, 0644)
+	err2 := afero.WriteFile(mockFS, config.GlobalPath(), b2, 0644)
+
+	assert.NoError(t, err)
+	assert.NoError(t, err2)
+
+	composer := config.NewLoader(afero.Afero{Fs: mockFS})
+	composer.AddConfigParser(json.NewParser())
+
+	conf, loadErr := composer.Load(config.DefaultPaths())
+
+	assert.NoError(t, loadErr)
+	assert.Equal(t, 1, len(conf.Accounts))
+	assert.Equal(t, "0x21c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7",
+		conf.Accounts.ByName("emulator-account").Key.PrivateKey.String(),
+	)
+}
+
 func Test_ComposeJSON(t *testing.T) {
 	b := []byte(`{
 		"accounts": {

--- a/pkg/flowkit/config/loader_test.go
+++ b/pkg/flowkit/config/loader_test.go
@@ -75,7 +75,7 @@ func Test_ErrorWhenMissingBothDefaultJsonFiles(t *testing.T) {
 	assert.Contains(t, loadErr.Error(), "missing configuration")
 }
 
-func Test_AllowMissingocalJson(t *testing.T) {
+func Test_AllowMissingLocalJson(t *testing.T) {
 	b := []byte(`{
 		"accounts": {
 			"emulator-account": {


### PR DESCRIPTION
Closes #335 

## Description

Rewrites the loader logic so that it will always accept the latest valid flow.json in the path sent in. So first global flow.json then local flow.json

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
