### PR TITLE
Block include transaction IDs flag

### DIFF
--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -63,5 +63,6 @@ func get(
 		block:       block,
 		events:      events,
 		collections: collections,
+		included:    blockFlags.Include,
 	}, nil
 }


### PR DESCRIPTION
Closes #357 

## Description
Transaction IDs were no longer included in the block when using `--include transactions` flag. This is due to regression happening at some point. The mistake was that the flag was not passed to result object.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
