### PR TITLE
master

### DIFF
--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -68,7 +68,7 @@ func execute(
 	if scriptFlags.ArgsJSON != "" || len(scriptFlags.Arg) != 0 {
 		scriptArgs, err = flowkit.ParseArguments(scriptFlags.Arg, scriptFlags.ArgsJSON)
 	} else {
-		scriptArgs, err = flowkit.ParseArgumentsWithoutType(code, args[1:])
+		scriptArgs, err = flowkit.ParseArgumentsWithoutType(filename, code, args[1:])
 	}
 
 	if err != nil {

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -79,7 +79,7 @@ func send(
 	if sendFlags.ArgsJSON != "" || len(sendFlags.Arg) != 0 {
 		transactionArgs, err = flowkit.ParseArguments(sendFlags.Arg, sendFlags.ArgsJSON)
 	} else {
-		transactionArgs, err = flowkit.ParseArgumentsWithoutType(code, args[1:])
+		transactionArgs, err = flowkit.ParseArgumentsWithoutType(codeFilename, code, args[1:])
 	}
 
 	if err != nil {

--- a/pkg/flowkit/arguments.go
+++ b/pkg/flowkit/arguments.go
@@ -120,12 +120,12 @@ func ParseArguments(args []string, argsJSON string) (scriptArgs []cadence.Value,
 	return
 }
 
-func ParseArgumentsWithoutType(code []byte, args []string) (scriptArgs []cadence.Value, err error) {
+func ParseArgumentsWithoutType(fileName string, code []byte, args []string) (scriptArgs []cadence.Value, err error) {
 
 	var resultArgs []cadence.Value = make([]cadence.Value, 0)
 
 	codes := map[common.LocationID]string{}
-	location := common.StringLocation("")
+	location := common.StringLocation(fileName)
 	program, must := cmd.PrepareProgram(string(code), location, codes)
 	checker, _ := cmd.PrepareChecker(program, location, codes, nil, must)
 

--- a/pkg/flowkit/arguments_test.go
+++ b/pkg/flowkit/arguments_test.go
@@ -50,6 +50,7 @@ func TestArguments(t *testing.T) {
 		var sampleType string = sample.Type().ID()
 
 		args, err := flowkit.ParseArgumentsWithoutType(
+			"",
 			[]byte(fmt.Sprintf(`
 			pub fun main(test: %s): Void {
 			}`, sampleType)),


### PR DESCRIPTION
- Parse arguments without type hint
- deprecation warning for --args
- move code check into ParseArgumentsWithoutType
- remove debug prints
- test for ParseArgumentsWithoutType
- test for ParseArgumentsWithoutType (typo fix)
- linted imports
- linted imports
- lint imports
- Use checker for EntryPointParameters
- Linter fix
- Arg Parsing local imports
