### PR TITLE
Add `--include` flag to `transaction sign` command

### DIFF
--- a/docs/sign-transaction.md
+++ b/docs/sign-transaction.md
@@ -73,6 +73,13 @@ To be used with the `flow transaction build` command.
 
 ## Flags
 
+### Include Fields
+
+- Flag: `--include`
+- Valid inputs: `code`, `payload`, `signatures`
+
+Specify fields to include in the result output. Applies only to the text output.
+
 ### Signer
 
 - Flag: `--signer`

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -30,7 +30,8 @@ import (
 )
 
 type flagsSign struct {
-	Signer string `default:"emulator-account" flag:"signer" info:"name of the account used to sign"`
+	Signer  string   `default:"emulator-account" flag:"signer" info:"name of the account used to sign"`
+	Include []string `default:"" flag:"include" info:"Fields to include in the output"`
 }
 
 var signFlags = flagsSign{}
@@ -70,6 +71,7 @@ func sign(
 	}
 
 	return &TransactionResult{
-		tx: signed.FlowTransaction(),
+		tx:      signed.FlowTransaction(),
+		include: signFlags.Include,
 	}, nil
 }


### PR DESCRIPTION
## Description

Transaction signer command suppresses output fields by default, but
instructs to use `--include` flag to explicitly show suppressed fields.

The `--include` flag was missing though and therefore it failed.

This change adds support for that flag.

### Without `--include` flag

```
$ ./cmd/flow/flow transactions sign  ./built.rlp -y 

ID              <tx id>
Payer           <addr>
Authorizers     [<addr>]

Proposal Key:
    Address     <addr>
    Index       0
    Sequence    123

No Payload Signatures

Envelope Signature 0: <addr>
Signatures (minimized, use --include signatures)

Code (hidden, use --include code)

Payload (hidden, use --include payload)
```

### With `--include` flag **before**

```
$ ./cmd/flow/flow transactions sign  ./built.rlp -y --include signatures
Error: unknown flag: --include
Usage:
  flow transactions sign <built transaction filename> [flags]

Examples:
flow transactions sign ./built.rlp --signer alice

Flags:
  -h, --help            help for sign
      --signer string   name of the account used to sign (default "emulator-account")

Global Flags:
  -f, --config-path strings   Path to flow configuration file (default [/home/tuommaki/flow.json,flow.json])
  -x, --filter string         Filter result values by property name
      --host string           Flow Access API host address
  -l, --log string            Log level, options: "debug", "info", "error", "none" (default "info")
  -n, --network string        Network from configuration file (default "emulator")
  -o, --output string         Output format, options: "text", "json", "inline" (default "text")
  -s, --save string           Save result to a filename
  -y, --yes                   Approve any prompts

unknown flag: --include
```

### With `--include` flag **after**

```
$ ./cmd/flow/flow transactions sign  ./built.rlp -y --include signatures

ID              <tx id>
Payer           <addr>
Authorizers     [<addr>]

Proposal Key:
    Address     <addr>
    Index       0
    Sequence    123

No Payload Signatures

Envelope Signature 0:
    Address     <addr>
    Signature   <signature>
    Key Index   0


Code (hidden, use --include code)

Payload (hidden, use --include payload)

```


______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
