### PR TITLE
Change default assignee to myself

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,7 @@ name: Reporting a Problem/Bug
 about: Reporting a Problem/Bug
 title: ''
 labels: bug, Feedback
-assignees: psiemens
+assignees: sideninja
 
 ---
 ### Instructions

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: Requesting a Feature or Improvement
 about: "For feature requests. Please search for existing issues first. Also see CONTRIBUTING.md"
 title: ''
 labels: Feedback, Feature
-assignees: psiemens
+assignees: sideninja
 
 ---
 


### PR DESCRIPTION
## Description
Since the majority of issues/feature requests are handled by me I'm changing the default assignee to myself to not spam @psiemens inbox with them.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
