### PR TITLE
Support common transaction and script templates

### DIFF
--- a/docs/execute-template-scripts.md
+++ b/docs/execute-template-scripts.md
@@ -1,0 +1,125 @@
+---
+title: Execute a Script Template with the Flow CLI
+sidebar_title: Execute a Script Template
+description: How to execute a template Cadence script on Flow from the command line
+---
+
+The Flow CLI provides a command to execute a template Cadence script on the Flow execution state with any Flow Access API.
+
+```shell
+flow scripts execute-template <template name> [<argument> <argument>...] [flags]
+```
+
+## Example Usage
+
+```shell
+> flow scripts execute-template 0x01cf0e2f2f715450
+
+1000.0
+```
+
+## Arguments
+
+### Template Name
+- Name: `template name`
+- Valid inputs:
+  - `fusd-balance` [source](https://github.com/onflow/fusd/blob/main/transactions/scripts/get_fusd_balance.cdc)
+  
+### Arguments
+- Name: `argument`
+- Valid inputs: valid [cadence values](https://docs.onflow.org/cadence/json-cadence-spec/)
+  matching argument type in script code.
+
+Input arguments values matching corresponding types in the source code and passed in the same order.
+
+## Flags
+
+### Arguments
+
+- Flag: `--arg`
+- Valid inputs: argument in `Type:Value` format.
+
+Arguments passed to the Cadence script in `Type:Value` format. 
+The `Type` must be the same as type in the script source code for that argument.  
+
+For passing complex argument values see [send transaction](https://docs.onflow.org/flow-cli/send-transactions/#example-usage) document. 
+
+⚠️  Deprecated: use command arguments instead.
+
+### Arguments JSON
+
+- Flag: `--args-json`
+- Valid inputs: arguments in JSON-Cadence form.
+
+Arguments passed to the Cadence script in the Cadence JSON format.
+Cadence JSON format contains `type` and `value` keys and is 
+[documented here](https://docs.onflow.org/cadence/json-cadence-spec/).
+
+### Code
+
+- Flag: `--code`
+
+⚠️  No longer supported: use filename argument.
+
+### Host
+
+- Flag: `--host`
+- Valid inputs: an IP address or hostname.
+- Default: `127.0.0.1:3569` (Flow Emulator)
+
+Specify the hostname of the Access API that will be
+used to execute the command. This flag overrides
+any host defined by the `--network` flag.
+
+### Network
+
+- Flag: `--network`
+- Short Flag: `-n`
+- Valid inputs: the name of a network defined in the configuration (`flow.json`)
+- Default: `emulator`
+
+Specify which network you want the command to use for execution.
+
+### Filter
+
+- Flag: `--filter`
+- Short Flag: `-x`
+- Valid inputs: a case-sensitive name of the result property.
+
+Specify any property name from the result you want to return as the only value.
+
+### Output
+
+- Flag: `--output`
+- Short Flag: `-o`
+- Valid inputs: `json`, `inline`
+
+Specify the format of the command results.
+
+### Save
+
+- Flag: `--save`
+- Short Flag: `-s`
+- Valid inputs: a path in the current filesystem.
+
+Specify the filename where you want the result to be saved
+
+### Log
+
+- Flag: `--log`
+- Short Flag: `-l`
+- Valid inputs: `none`, `error`, `debug`
+- Default: `info`
+
+Specify the log level. Control how much output you want to see during command execution.
+
+### Configuration
+
+- Flag: `--config-path`
+- Short Flag: `-f`
+- Valid inputs: a path in the current filesystem.
+- Default: `flow.json`
+
+Specify the path to the `flow.json` configuration file.
+You can use the `-f` flag multiple times to merge
+several configuration files.

--- a/docs/send-transactions-template.md
+++ b/docs/send-transactions-template.md
@@ -1,0 +1,179 @@
+---
+title: Send a Transaction template with the Flow CLI
+sidebar_title: Send a Transaction Template
+description: How to send a Flow transaction template from the command line
+---
+
+The Flow CLI provides a command to send common transaction templates to any Flow Access API.
+
+```shell
+flow transactions send-template <template name> [<argument> <argument>...] [flags]
+```
+
+## Example Usage
+
+```shell
+> flow transactions send-template fusd-transfer 10.0 0x01cf0e2f2f715450
+    
+Status		✅ SEALED
+ID		b04b6bcc3164f5ee6b77fa502c3a682e0db57fc47e5b8a8ef3b56aae50ad49c8
+Payer		f8d6e0586b0a20c7
+Authorizers	[f8d6e0586b0a20c7]
+
+Proposal Key:	
+    Address	f8d6e0586b0a20c7
+    Index	0
+    Sequence	0
+
+No Payload Signatures
+
+Envelope Signature 0: f8d6e0586b0a20c7
+Signatures (minimized, use --include signatures)
+
+Events:	 None
+
+Code (hidden, use --include code)
+
+Payload (hidden, use --include payload)
+
+```
+
+## Arguments
+
+### Template Name
+- Name: `template name`
+- Valid inputs:
+  - `fusd-transfer` [source](https://github.com/onflow/fusd/blob/main/transactions/transfer_fusd.cdc)
+  - `fusd-setup` [source](https://github.com/onflow/fusd/blob/main/transactions/setup_fusd_vault.cdc)
+
+### Arguments
+- Name: `argument`
+- Valid inputs: valid [cadence values](https://docs.onflow.org/cadence/json-cadence-spec/) 
+  matching argument type in transaction code.
+
+Input arguments values matching corresponding types in the source code and passed in the same order.
+
+## Flags
+
+### Include Fields
+
+- Flag: `--include`
+- Valid inputs: `code`, `payload`
+
+Specify fields to include in the result output. Applies only to the text output.
+
+### Code
+
+- Flag: `--code`
+
+⚠️  No longer supported: use filename argument.
+
+### Results
+
+- Flag: `--results`
+
+⚠️  No longer supported: all transactions will provide result.
+
+### Exclude Fields
+
+- Flag: `--exclude`
+- Valid inputs: `events`
+
+Specify fields to exclude from the result output. Applies only to the text output.
+
+### Signer
+
+- Flag: `--signer`
+- Valid inputs: the name of an account defined in the configuration (`flow.json`)
+
+Specify the name of the account that will be used to sign the transaction.
+
+### Arguments
+
+- Flag: `--arg`
+- Valid inputs: argument in `Type:Value` format.
+
+Arguments passed to the Cadence transaction in `Type:Value` format.
+The `Type` must be the same as type in the transaction source code for that argument.
+
+⚠️  Deprecated: use command arguments instead.
+
+### Arguments JSON
+
+- Flag: `--args-json`
+- Valid inputs: arguments in JSON-Cadence form.
+
+Arguments passed to the Cadence transaction in Cadence JSON format.
+Cadence JSON format contains `type` and `value` keys and is 
+[documented here](https://docs.onflow.org/cadence/json-cadence-spec/).
+
+### Gas Limit
+
+- Flag: `--gas-limit`
+- Valid inputs: an integer greater than zero.
+- Default: `1000`
+
+Specify the gas limit for this transaction.
+
+### Host
+
+- Flag: `--host`
+- Valid inputs: an IP address or hostname.
+- Default: `127.0.0.1:3569` (Flow Emulator)
+
+Specify the hostname of the Access API that will be
+used to execute the command. This flag overrides
+any host defined by the `--network` flag.
+
+### Network
+
+- Flag: `--network`
+- Short Flag: `-n`
+- Valid inputs: the name of a network defined in the configuration (`flow.json`)
+- Default: `emulator`
+
+Specify which network you want the command to use for execution.
+
+### Filter
+
+- Flag: `--filter`
+- Short Flag: `-x`
+- Valid inputs: a case-sensitive name of the result property.
+
+Specify any property name from the result you want to return as the only value.
+
+### Output
+
+- Flag: `--output`
+- Short Flag: `-o`
+- Valid inputs: `json`, `inline`
+
+Specify the format of the command results.
+
+### Save
+
+- Flag: `--save`
+- Short Flag: `-s`
+- Valid inputs: a path in the current filesystem.
+
+Specify the filename where you want the result to be saved
+
+### Log
+
+- Flag: `--log`
+- Short Flag: `-l`
+- Valid inputs: `none`, `error`, `debug`
+- Default: `info`
+
+Specify the log level. Control how much output you want to see during command execution.
+
+### Configuration
+
+- Flag: `--config-path`
+- Short Flag: `-f`
+- Valid inputs: a path in the current filesystem.
+- Default: `flow.json`
+
+Specify the path to the `flow.json` configuration file.
+You can use the `-f` flag multiple times to merge
+several configuration files.

--- a/internal/scripts/execute-template.go
+++ b/internal/scripts/execute-template.go
@@ -41,7 +41,7 @@ var ExecuteTemplateCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "execute-template <template name> [<argument> <argument> ...]",
 		Short:   "Execute a script template",
-		Example: `flow scripts execute-template fusd-balance 0x1`,
+		Example: `flow scripts execute-template fusd-balance 0x01cf0e2f2f715450`,
 		Args:    cobra.MinimumNArgs(1),
 	},
 	Flags: &templateFlags,

--- a/internal/scripts/execute-template.go
+++ b/internal/scripts/execute-template.go
@@ -1,0 +1,90 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scripts
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-cli/pkg/flowkit/templates"
+
+	"github.com/onflow/cadence"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+)
+
+type flagsTemplate struct {
+	ArgsJSON string `default:"" flag:"args-json" info:"arguments in JSON-Cadence format"`
+}
+
+var templateFlags = flagsTemplate{}
+
+var ExecuteTemplateCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "execute-template <template name> [<argument> <argument> ...]",
+		Short:   "Execute a script template",
+		Example: `flow scripts execute-template fusd-balance 0x1`,
+		Args:    cobra.MinimumNArgs(1),
+	},
+	Flags: &templateFlags,
+	Run:   executeTemplate,
+}
+
+func executeTemplate(
+	args []string,
+	_ flowkit.ReaderWriter,
+	globalFlags command.GlobalFlags,
+	services *services.Services,
+) (command.Result, error) {
+	templateName := args[0]
+	template, err := templates.ScriptByName(templateName)
+	if err != nil {
+		return nil, err
+	}
+
+	source, err := template.Source(globalFlags.Network)
+	if err != nil {
+		return nil, err
+	}
+
+	var scriptArgs []cadence.Value
+	if templateFlags.ArgsJSON != "" {
+		scriptArgs, err = flowkit.ParseArgumentsJSON(templateFlags.ArgsJSON)
+	} else {
+		scriptArgs, err = flowkit.ParseArgumentsWithoutType("", source, args[1:])
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error parsing script arguments: %w", err)
+	}
+
+	value, err := services.Scripts.Execute(
+		source,
+		scriptArgs,
+		"",
+		globalFlags.Network,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ScriptResult{value}, nil
+}

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	ExecuteCommand.AddToParent(Cmd)
+	ExecuteTemplateCommand.AddToParent(Cmd)
 }
 
 type ScriptResult struct {

--- a/internal/transactions/send-template.go
+++ b/internal/transactions/send-template.go
@@ -41,7 +41,7 @@ func sendTemplate(
 	state *flowkit.State,
 ) (command.Result, error) {
 	templateName := args[0]
-	template, err := templates.ByName(templateName)
+	template, err := templates.TransactionByName(templateName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transactions/send-template.go
+++ b/internal/transactions/send-template.go
@@ -35,7 +35,7 @@ var SendTemplateCommand = &command.Command{
 
 func sendTemplate(
 	args []string,
-	readerWriter flowkit.ReaderWriter,
+	_ flowkit.ReaderWriter,
 	globalFlags command.GlobalFlags,
 	services *services.Services,
 	state *flowkit.State,

--- a/internal/transactions/send-template.go
+++ b/internal/transactions/send-template.go
@@ -27,7 +27,7 @@ var SendTemplateCommand = &command.Command{
 		Use:     "send-template <template name> [<argument> <argument> ...]",
 		Short:   "Send a template transaction",
 		Args:    cobra.MinimumNArgs(1),
-		Example: `flow transactions send-template transfer 10 0x1`,
+		Example: `flow transactions send-template fusd-transfer 10 0x01cf0e2f2f715450`,
 	},
 	Flags: &templateFlags,
 	RunS:  sendTemplate,

--- a/internal/transactions/send-template.go
+++ b/internal/transactions/send-template.go
@@ -1,0 +1,89 @@
+package transactions
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-cli/pkg/flowkit/templates"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+	"github.com/spf13/cobra"
+)
+
+type flagsTemplate struct {
+	ArgsJSON string   `default:"" flag:"args-json" info:"arguments in JSON-Cadence format"`
+	Signer   string   `default:"emulator-account" flag:"signer" info:"Account name from configuration used to sign the transaction"`
+	GasLimit uint64   `default:"1000" flag:"gas-limit" info:"transaction gas limit"`
+	Include  []string `default:"" flag:"include" info:"Fields to include in the output"`
+	Exclude  []string `default:"" flag:"exclude" info:"Fields to exclude from the output (events)"`
+}
+
+var templateFlags = flagsTemplate{}
+
+var SendTemplateCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "send-template <template name> [<argument> <argument> ...]",
+		Short:   "Send a template transaction",
+		Args:    cobra.MinimumNArgs(1),
+		Example: `flow transactions send-template transfer 10 0x1`,
+	},
+	Flags: &templateFlags,
+	RunS:  sendTemplate,
+}
+
+func sendTemplate(
+	args []string,
+	readerWriter flowkit.ReaderWriter,
+	globalFlags command.GlobalFlags,
+	services *services.Services,
+	state *flowkit.State,
+) (command.Result, error) {
+	templateName := args[0]
+	template, err := templates.ByName(templateName)
+	if err != nil {
+		return nil, err
+	}
+
+	source, err := template.Source(globalFlags.Network)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := state.Accounts().ByName(templateFlags.Signer)
+	if err != nil {
+		return nil, err
+	}
+
+	var transactionArgs []cadence.Value
+	if templateFlags.ArgsJSON != "" {
+		transactionArgs, err = flowkit.ParseArgumentsJSON(templateFlags.ArgsJSON)
+	} else {
+		transactionArgs, err = flowkit.ParseArgumentsWithoutType("", source, args[1:])
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error parsing transaction arguments: %w", err)
+	}
+
+	tx, result, err := services.Transactions.Send(
+		signer,
+		source,
+		"",
+		templateFlags.GasLimit,
+		transactionArgs,
+		globalFlags.Network,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &TransactionResult{
+		result:  result,
+		tx:      tx,
+		include: templateFlags.Include,
+		exclude: templateFlags.Exclude,
+	}, nil
+}

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -47,6 +47,7 @@ func init() {
 	SignCommand.AddToParent(Cmd)
 	BuildCommand.AddToParent(Cmd)
 	SendSignedCommand.AddToParent(Cmd)
+	SendTemplateCommand.AddToParent(Cmd)
 }
 
 type TransactionResult struct {

--- a/pkg/flowkit/templates/templates.go
+++ b/pkg/flowkit/templates/templates.go
@@ -7,13 +7,9 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowkit/config"
 )
 
-var emulator = config.DefaultMainnetNetwork().Name
-var testnet = config.DefaultMainnetNetwork().Name
+var emulator = config.DefaultEmulatorNetwork().Name
+var testnet = config.DefaultTestnetNetwork().Name
 var mainnet = config.DefaultMainnetNetwork().Name
-
-func isValidNetwork(network string) bool {
-	return network == emulator || network == testnet || network == mainnet
-}
 
 type template struct {
 	name   string
@@ -27,11 +23,12 @@ func (t *template) Name() string {
 }
 
 func (t *template) Source(network string) ([]byte, error) {
-	if !isValidNetwork(network) {
+	imports := t.imports[network]
+
+	if len(imports) == 0 {
 		return nil, fmt.Errorf("invalid network")
 	}
 
-	imports := t.imports[network]
 	// converting each value since array conversion doesn't work
 	replace := make([]interface{}, len(imports))
 	for i, im := range imports {
@@ -43,7 +40,7 @@ func (t *template) Source(network string) ([]byte, error) {
 
 func ByName(name string) (*template, error) {
 	for _, c := range collection {
-		if c.name == strings.ToLower(name) {
+		if strings.ToLower(c.name) == strings.ToLower(name) {
 			return c, nil
 		}
 	}
@@ -52,41 +49,41 @@ func ByName(name string) (*template, error) {
 }
 
 var collection = []*template{{
-	name:   "transferFUSD",
-	source: transferFUSDSource,
+	name: "transferFUSD",
 	imports: map[string][]string{
 		testnet: {"0x9a0766d93b6608b7", "0xe223d8a629e49c68"},
 		mainnet: {"0xf233dcee88fe0abe", "0x3c5959b568896393"},
+		// todo(sideninja): add emulator network, but first add fusd to emulator bootstrap procedure
 	},
+	// source: https://github.com/onflow/fusd
+	source: `
+		import FungibleToken from %s
+		import FUSD from %s
+		
+		transaction(amount: UFix64, to: Address) {
+		
+			// The Vault resource that holds the tokens that are being transferred
+			let sentVault: @FungibleToken.Vault
+		
+			prepare(signer: AuthAccount) {
+				// Get a reference to the signer's stored vault
+				let vaultRef = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)
+					?? panic("Could not borrow reference to the owner's Vault!")
+		
+				// Withdraw tokens from the signer's stored vault
+				self.sentVault <- vaultRef.withdraw(amount: amount)
+			}
+		
+			execute {
+				// Get the recipient's public account object
+				let recipient = getAccount(to)
+		
+				// Get a reference to the recipient's Receiver
+				let receiverRef = recipient.getCapability(/public/fusdReceiver)!.borrow<&{FungibleToken.Receiver}>()
+					?? panic("Could not borrow receiver reference to the recipient's Vault")
+		
+				// Deposit the withdrawn tokens in the recipient's receiver
+				receiverRef.deposit(from: <-self.sentVault)
+			}
+		}`,
 }}
-
-var transferFUSDSource = `
-import FungibleToken from %s
-import FUSD from %s
-
-transaction(amount: UFix64, to: Address) {
-
-    // The Vault resource that holds the tokens that are being transferred
-    let sentVault: @FungibleToken.Vault
-
-    prepare(signer: AuthAccount) {
-        // Get a reference to the signer's stored vault
-        let vaultRef = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)
-            ?? panic("Could not borrow reference to the owner's Vault!")
-
-        // Withdraw tokens from the signer's stored vault
-        self.sentVault <- vaultRef.withdraw(amount: amount)
-    }
-
-    execute {
-        // Get the recipient's public account object
-        let recipient = getAccount(to)
-
-        // Get a reference to the recipient's Receiver
-        let receiverRef = recipient.getCapability(/public/fusdReceiver)!.borrow<&{FungibleToken.Receiver}>()
-            ?? panic("Could not borrow receiver reference to the recipient's Vault")
-
-        // Deposit the withdrawn tokens in the recipient's receiver
-        receiverRef.deposit(from: <-self.sentVault)
-    }
-}`

--- a/pkg/flowkit/templates/templates.go
+++ b/pkg/flowkit/templates/templates.go
@@ -113,8 +113,8 @@ var collection = []*template{{
 	},
 	// source: https://github.com/onflow/fusd
 	source: `
-		import FungibleToken from 0xFUNGIBLETOKENADDRESS
-		import FUSD from 0xFUSDADDRESS
+		import FungibleToken from %s
+		import FUSD from %s
 		
 		transaction {
 		
@@ -153,8 +153,8 @@ var collection = []*template{{
 	},
 	// source: https://github.com/onflow/fusd
 	source: `
-		import FungibleToken from 0xFUNGIBLETOKENADDRESS
-		import FUSD from 0xFUSDADDRESS
+		import FungibleToken from %s
+		import FUSD from %s
 		
 		pub fun main(address: Address): UFix64 {
 			let account = getAccount(address)

--- a/pkg/flowkit/templates/templates.go
+++ b/pkg/flowkit/templates/templates.go
@@ -11,9 +11,17 @@ var emulator = config.DefaultEmulatorNetwork().Name
 var testnet = config.DefaultTestnetNetwork().Name
 var mainnet = config.DefaultMainnetNetwork().Name
 
+type templateKind uint8
+
+const (
+	tx templateKind = iota
+	script
+)
+
 type template struct {
 	name   string
 	source string
+	kind   templateKind
 	// imports matching order of imports in script
 	imports map[string][]string
 }
@@ -38,9 +46,9 @@ func (t *template) Source(network string) ([]byte, error) {
 	return []byte(fmt.Sprintf(t.source, replace...)), nil
 }
 
-func ByName(name string) (*template, error) {
+func byNameAndType(name string, kind templateKind) (*template, error) {
 	for _, c := range collection {
-		if strings.ToLower(c.name) == strings.ToLower(name) {
+		if strings.ToLower(c.name) == strings.ToLower(name) && c.kind == kind {
 			return c, nil
 		}
 	}
@@ -48,8 +56,17 @@ func ByName(name string) (*template, error) {
 	return nil, fmt.Errorf("template not found by name")
 }
 
+func TransactionByName(name string) (*template, error) {
+	return byNameAndType(name, tx)
+}
+
+func ScriptByName(name string) (*template, error) {
+	return byNameAndType(name, script)
+}
+
 var collection = []*template{{
-	name: "transferFUSD",
+	name: "fusd-transfer",
+	kind: tx,
 	imports: map[string][]string{
 		testnet: {"0x9a0766d93b6608b7", "0xe223d8a629e49c68"},
 		mainnet: {"0xf233dcee88fe0abe", "0x3c5959b568896393"},
@@ -87,7 +104,8 @@ var collection = []*template{{
 			}
 		}`,
 }, {
-	name: "setupFUSD",
+	name: "fusd-setup",
+	kind: tx,
 	imports: map[string][]string{
 		testnet: {"0x9a0766d93b6608b7", "0xe223d8a629e49c68"},
 		mainnet: {"0xf233dcee88fe0abe", "0x3c5959b568896393"},
@@ -124,5 +142,27 @@ var collection = []*template{{
 					target: /storage/fusdVault
 				)
 			}
+		}`,
+}, {
+	name: "fusd-balance",
+	kind: script,
+	imports: map[string][]string{
+		testnet: {"0x9a0766d93b6608b7", "0xe223d8a629e49c68"},
+		mainnet: {"0xf233dcee88fe0abe", "0x3c5959b568896393"},
+		// todo(sideninja): add emulator network, but first add fusd to emulator bootstrap procedure
+	},
+	// source: https://github.com/onflow/fusd
+	source: `
+		import FungibleToken from 0xFUNGIBLETOKENADDRESS
+		import FUSD from 0xFUSDADDRESS
+		
+		pub fun main(address: Address): UFix64 {
+			let account = getAccount(address)
+		
+			let vaultRef = account.getCapability(/public/fusdBalance)!
+				.borrow<&FUSD.Vault{FungibleToken.Balance}>()
+				?? panic("Could not borrow Balance reference to the Vault")
+		
+			return vaultRef.balance
 		}`,
 }}

--- a/pkg/flowkit/templates/templates.go
+++ b/pkg/flowkit/templates/templates.go
@@ -1,0 +1,92 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onflow/flow-cli/pkg/flowkit/config"
+)
+
+var emulator = config.DefaultMainnetNetwork().Name
+var testnet = config.DefaultMainnetNetwork().Name
+var mainnet = config.DefaultMainnetNetwork().Name
+
+func isValidNetwork(network string) bool {
+	return network == emulator || network == testnet || network == mainnet
+}
+
+type template struct {
+	name   string
+	source string
+	// imports matching order of imports in script
+	imports map[string][]string
+}
+
+func (t *template) Name() string {
+	return t.name
+}
+
+func (t *template) Source(network string) ([]byte, error) {
+	if !isValidNetwork(network) {
+		return nil, fmt.Errorf("invalid network")
+	}
+
+	imports := t.imports[network]
+	// converting each value since array conversion doesn't work
+	replace := make([]interface{}, len(imports))
+	for i, im := range imports {
+		replace[i] = im
+	}
+
+	return []byte(fmt.Sprintf(t.source, replace...)), nil
+}
+
+func ByName(name string) (*template, error) {
+	for _, c := range collection {
+		if c.name == strings.ToLower(name) {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("template not found by name")
+}
+
+var collection = []*template{{
+	name:   "transferFUSD",
+	source: transferFUSDSource,
+	imports: map[string][]string{
+		testnet: {"0x9a0766d93b6608b7", "0xe223d8a629e49c68"},
+		mainnet: {"0xf233dcee88fe0abe", "0x3c5959b568896393"},
+	},
+}}
+
+var transferFUSDSource = `
+import FungibleToken from %s
+import FUSD from %s
+
+transaction(amount: UFix64, to: Address) {
+
+    // The Vault resource that holds the tokens that are being transferred
+    let sentVault: @FungibleToken.Vault
+
+    prepare(signer: AuthAccount) {
+        // Get a reference to the signer's stored vault
+        let vaultRef = signer.borrow<&FUSD.Vault>(from: /storage/fusdVault)
+            ?? panic("Could not borrow reference to the owner's Vault!")
+
+        // Withdraw tokens from the signer's stored vault
+        self.sentVault <- vaultRef.withdraw(amount: amount)
+    }
+
+    execute {
+        // Get the recipient's public account object
+        let recipient = getAccount(to)
+
+        // Get a reference to the recipient's Receiver
+        let receiverRef = recipient.getCapability(/public/fusdReceiver)!.borrow<&{FungibleToken.Receiver}>()
+            ?? panic("Could not borrow receiver reference to the recipient's Vault")
+
+        // Deposit the withdrawn tokens in the recipient's receiver
+        receiverRef.deposit(from: <-self.sentVault)
+    }
+}`

--- a/pkg/flowkit/templates/templates_test.go
+++ b/pkg/flowkit/templates/templates_test.go
@@ -9,14 +9,20 @@ import (
 
 func TestTemplateCollection(t *testing.T) {
 
-	t.Run("Get by name", func(t *testing.T) {
-		tmp, err := ByName(collection[0].name)
+	t.Run("Get by name transaction", func(t *testing.T) {
+		tmp, err := TransactionByName(collection[0].name)
 		assert.NoError(t, err)
 		assert.Equal(t, tmp.Name(), collection[0].name)
 	})
 
+	t.Run("Get by name script", func(t *testing.T) {
+		tmp, err := ScriptByName(collection[2].name)
+		assert.NoError(t, err)
+		assert.Equal(t, tmp.Name(), collection[2].name)
+	})
+
 	t.Run("Get by name invalid", func(t *testing.T) {
-		tmp, err := ByName(collection[0].name + "invalid")
+		tmp, err := TransactionByName(collection[0].name + "invalid")
 		assert.EqualError(t, err, "template not found by name")
 		assert.Nil(t, tmp)
 	})
@@ -26,7 +32,7 @@ func TestTemplates(t *testing.T) {
 
 	t.Run("Template by name for network", func(t *testing.T) {
 		otmp := collection[0]
-		tmp, err := ByName(otmp.name)
+		tmp, err := TransactionByName(otmp.name)
 		assert.NoError(t, err)
 
 		for _, n := range []string{testnet, mainnet} {
@@ -41,7 +47,7 @@ func TestTemplates(t *testing.T) {
 
 	t.Run("Template by name for invalid network", func(t *testing.T) {
 		otmp := collection[0]
-		tmp, err := ByName(otmp.name)
+		tmp, err := TransactionByName(otmp.name)
 		assert.NoError(t, err)
 
 		src, err := tmp.Source("foo")

--- a/pkg/flowkit/templates/templates_test.go
+++ b/pkg/flowkit/templates/templates_test.go
@@ -1,0 +1,52 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateCollection(t *testing.T) {
+
+	t.Run("Get by name", func(t *testing.T) {
+		tmp, err := ByName(collection[0].name)
+		assert.NoError(t, err)
+		assert.Equal(t, tmp.Name(), collection[0].name)
+	})
+
+	t.Run("Get by name invalid", func(t *testing.T) {
+		tmp, err := ByName(collection[0].name + "invalid")
+		assert.EqualError(t, err, "template not found by name")
+		assert.Nil(t, tmp)
+	})
+}
+
+func TestTemplates(t *testing.T) {
+
+	t.Run("Template by name for network", func(t *testing.T) {
+		otmp := collection[0]
+		tmp, err := ByName(otmp.name)
+		assert.NoError(t, err)
+
+		for _, n := range []string{testnet, mainnet} {
+			src, err := tmp.Source(n)
+			assert.NoError(t, err)
+
+			for _, i := range otmp.imports[n] {
+				assert.True(t, strings.Index(string(src), i) > 0)
+			}
+		}
+	})
+
+	t.Run("Template by name for invalid network", func(t *testing.T) {
+		otmp := collection[0]
+		tmp, err := ByName(otmp.name)
+		assert.NoError(t, err)
+
+		src, err := tmp.Source("foo")
+		assert.Nil(t, src)
+		assert.EqualError(t, err, "invalid network")
+	})
+
+}

--- a/pkg/flowkit/templates/templates_test.go
+++ b/pkg/flowkit/templates/templates_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -31,16 +32,24 @@ func TestTemplateCollection(t *testing.T) {
 func TestTemplates(t *testing.T) {
 
 	t.Run("Template by name for network", func(t *testing.T) {
-		otmp := collection[0]
-		tmp, err := TransactionByName(otmp.name)
-		assert.NoError(t, err)
+		for _, c := range collection {
+			var tmp *template
+			var err error
+			if c.kind == tx {
+				tmp, err = TransactionByName(c.name)
+			} else if c.kind == script {
+				tmp, err = ScriptByName(c.name)
+			}
 
-		for _, n := range []string{testnet, mainnet} {
-			src, err := tmp.Source(n)
 			assert.NoError(t, err)
 
-			for _, i := range otmp.imports[n] {
-				assert.True(t, strings.Index(string(src), i) > 0)
+			for _, n := range []string{testnet, mainnet} {
+				src, err := tmp.Source(n)
+				assert.NoError(t, err)
+
+				for _, i := range c.imports[n] {
+					assert.True(t, strings.Index(string(src), fmt.Sprintf("from %s", i)) > 0, string(src))
+				}
 			}
 		}
 	})


### PR DESCRIPTION
Closes #303 

## Description
A new feature offering common transaction and script templates to be used within the CLI. All you need to do is execute the new command with supplied parameters like:
```
flow transactions send-template <template name> [<argument> <argument> ...]
or
flow scripts execute-template <template name> [<argument> <argument> ...]
```
The template name must match an existing supported template, which will be listed in the docs.

UPDATE:
It would be a good idea to load those transactions and scripts from a single source repo, my thinking is that core-contracts repo could be a good choice. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
