### PR TITLE
New signature command

### DIFF
--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"github.com/onflow/flow-cli/internal/signatures"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/accounts"
@@ -35,6 +34,7 @@ import (
 	"github.com/onflow/flow-cli/internal/project"
 	"github.com/onflow/flow-cli/internal/quick"
 	"github.com/onflow/flow-cli/internal/scripts"
+	"github.com/onflow/flow-cli/internal/signatures"
 	"github.com/onflow/flow-cli/internal/status"
 	"github.com/onflow/flow-cli/internal/transactions"
 	"github.com/onflow/flow-cli/internal/version"

--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"github.com/onflow/flow-cli/internal/signatures"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/accounts"
@@ -63,6 +64,7 @@ func main() {
 	cmd.AddCommand(collections.Cmd)
 	cmd.AddCommand(project.Cmd)
 	cmd.AddCommand(config.Cmd)
+	cmd.AddCommand(signatures.Cmd)
 
 	command.InitFlags(cmd)
 

--- a/docs/signature-generate.md
+++ b/docs/signature-generate.md
@@ -7,7 +7,7 @@ description: How to generate a new signature from the command line
 Generate a signature using the private key of the signer account.
 
 ```shell
-flow signatures generate <payload>  
+flow signatures generate <message>  
 ```
 
 ⚠️ _Make sure the account you want to use for signing is saved in the `flow.json` configuration. 
@@ -19,7 +19,7 @@ The address of the account is not important, just the private key._
 > flow signatures generate 'The quick brown fox jumps over the lazy dog' --signer alice
 
 Signature 		 b33eabfb05d374b...f09929da96f5beec167fd1f123ec
-Payload 		 The quick brown fox jumps over the lazy dog
+Message 		 The quick brown fox jumps over the lazy dog
 Public Key 		 0xc92a7c...042c4025d241fd430242368ce662d39636987
 Hash Algorithm 		 SHA3_256
 Signature Algorithm 	 ECDSA_P256
@@ -27,10 +27,10 @@ Signature Algorithm 	 ECDSA_P256
 
 ## Arguments
 
-### Payload
-- Name: `payload`
+### Message
+- Name: `message`
 
-Payload data used for signing.
+Message used for signing.
 
 ## Flags
 

--- a/docs/signature-generate.md
+++ b/docs/signature-generate.md
@@ -10,8 +10,8 @@ Generate a signature using the private key of the signer account.
 flow signatures generate <payload>  
 ```
 
-Make sure the account you want to use for signing is saved in the `flow.json` configuration. 
-The address of the account is not important, just the private key.
+⚠️ _Make sure the account you want to use for signing is saved in the `flow.json` configuration. 
+The address of the account is not important, just the private key._
 
 ## Example Usage
 
@@ -29,7 +29,8 @@ Signature Algorithm 	 ECDSA_P256
 
 ### Payload
 - Name: `payload`
-- Valid Input: Payload data used for signing
+
+Payload data used for signing.
 
 ## Flags
 

--- a/docs/signature-generate.md
+++ b/docs/signature-generate.md
@@ -1,0 +1,88 @@
+---
+title: Generate a Signature with the Flow CLI
+sidebar_title: Generate a Signature
+description: How to generate a new signature from the command line
+---
+
+Generate a signature using the private key of the signer account.
+
+```shell
+flow signatures generate <payload>  
+```
+
+Make sure the account you want to use for signing is saved in the `flow.json` configuration. 
+The address of the account is not important, just the private key.
+
+## Example Usage
+
+```shell
+> flow signatures generate 'The quick brown fox jumps over the lazy dog' --signer alice
+
+Signature 		 b33eabfb05d374b...f09929da96f5beec167fd1f123ec
+Payload 		 The quick brown fox jumps over the lazy dog
+Public Key 		 0xc92a7c...042c4025d241fd430242368ce662d39636987
+Hash Algorithm 		 SHA3_256
+Signature Algorithm 	 ECDSA_P256
+```
+
+## Arguments
+
+### Payload
+- Name: `payload`
+- Valid Input: Payload data used for signing
+
+## Flags
+
+### Signer
+
+- Flag: `--signer`
+- Valid inputs: the name of an account defined in the configuration (`flow.json`)
+
+Specify the name of the account that will be used to sign the transaction.
+
+### Filter
+
+- Flag: `--filter`
+- Short Flag: `-x`
+- Valid inputs: case-sensitive name of the result property.
+
+Specify any property name from the result you want to return as the only value.
+
+### Output
+
+- Flag: `--output`
+- Short Flag: `-o`
+- Valid inputs: `json`, `inline`
+
+Specify in which format you want to display the result.
+
+### Save
+
+- Flag: `--save`
+- Short Flag: `-s`
+- Valid inputs: valid filename
+
+Specify the filename where you want the result to be saved.
+
+### Log
+
+- Flag: `--log`
+- Short Flag: `-l`
+- Valid inputs: `none`, `error`, `debug`
+- Default: `info`
+
+Specify the log level. Control how much output you want to see while command execution.
+
+### Configuration
+
+- Flag: `--config-path`
+- Short Flag: `-f`
+- Valid inputs: valid filename
+
+Specify a filename for the configuration files, you can provide multiple configuration
+files by using `-f` flag multiple times.
+
+
+
+
+

--- a/docs/signature-verify.md
+++ b/docs/signature-verify.md
@@ -1,0 +1,100 @@
+---
+title: Verify a Signature with the Flow CLI
+sidebar_title: Verify Signature
+description: How to verify a signature from the command line 
+---
+
+Verify validity of a signature based on provided payload and public key of the signature creator.
+
+```shell
+flow signatures verify <payload> <signature> <public key>
+```
+
+## Example Usage
+
+```shell
+> flow signatures verify 
+  'The quick brown fox jumps over the lazy dog' 
+  b1c9eff5d829fdeaf2dad6308fc8033e3b8875bc185ef804ce5d0d980545ef5be0f98b47afc979d12272d257ce13c4b490e431bfcada485cb1d2e3f209be8d07 
+  0xc92a7c72a78f8f046a79f8a5fe1ef72424258a55eb869f13e6133301d64ad025d3362d5df9e7c82289637af1431042c4025d241fd430242368ce662d39636987
+
+Valid 			 true
+Payload 		 The quick brown fox jumps over the lazy dog
+Signature 		 b1c9eff5d829fdeaf2...7ce13c4b490eada485cb1d2e3f209be8d07
+Public Key 		 c92a7c72a78...1431042c4025d241fd430242368ce662d39636987
+Hash Algorithm 		 SHA3_256
+Signature Algorithm 	 ECDSA_P256
+```
+
+## Arguments
+
+### Payload
+- Name: `payload`
+
+Payload data used for creating the signature.
+
+### Signature
+- Name: `signature`
+
+Payload signature that will be verified.
+
+### Public Key
+- Name: `public key`
+
+Public key of the private key used for creating the signature. 
+
+## Flags
+
+### Public Key Signature Algorithm
+
+- Flag: `--sig-algo`
+- Valid inputs: `"ECDSA_P256", "ECDSA_secp256k1"`
+
+Specify the ECDSA signature algorithm of the key pair used for signing.
+
+Flow supports the secp256k1 and P-256 curves.
+
+### Public Key Hash Algorithm
+
+- Flag: `--hash-algo`
+- Valid inputs: `"SHA2_256", "SHA3_256"`
+- Default: `"SHA3_256"`
+
+Specify the hash algorithm of the key pair used for signing. 
+
+### Filter
+
+- Flag: `--filter`
+- Short Flag: `-x`
+- Valid inputs: case-sensitive name of the result property.
+
+Specify any property name from the result you want to return as the only value.
+
+### Output
+
+- Flag: `--output`
+- Short Flag: `-o`
+- Valid inputs: `json`, `inline`
+
+Specify in which format you want to display the result.
+
+### Save
+
+- Flag: `--save`
+- Short Flag: `-s`
+- Valid inputs: valid filename
+
+Specify the filename where you want the result to be saved.
+
+### Log
+
+- Flag: `--log`
+- Short Flag: `-l`
+- Valid inputs: `none`, `error`, `debug`
+- Default: `info`
+
+Specify the log level. Control how much output you want to see while command execution.
+
+
+
+

--- a/docs/signature-verify.md
+++ b/docs/signature-verify.md
@@ -4,10 +4,10 @@ sidebar_title: Verify Signature
 description: How to verify a signature from the command line 
 ---
 
-Verify validity of a signature based on provided payload and public key of the signature creator.
+Verify validity of a signature based on provided message and public key of the signature creator.
 
 ```shell
-flow signatures verify <payload> <signature> <public key>
+flow signatures verify <message> <signature> <public key>
 ```
 
 ## Example Usage
@@ -19,7 +19,7 @@ flow signatures verify <payload> <signature> <public key>
   0xc92a7c72a78f8f046a79f8a5fe1ef72424258a55eb869f13e6133301d64ad025d3362d5df9e7c82289637af1431042c4025d241fd430242368ce662d39636987
 
 Valid 			 true
-Payload 		 The quick brown fox jumps over the lazy dog
+Message 		 The quick brown fox jumps over the lazy dog
 Signature 		 b1c9eff5d829fdeaf2...7ce13c4b490eada485cb1d2e3f209be8d07
 Public Key 		 c92a7c72a78...1431042c4025d241fd430242368ce662d39636987
 Hash Algorithm 		 SHA3_256
@@ -28,15 +28,15 @@ Signature Algorithm 	 ECDSA_P256
 
 ## Arguments
 
-### Payload
-- Name: `payload`
+### Message
+- Name: `message`
 
-Payload data used for creating the signature.
+Message data used for creating the signature.
 
 ### Signature
 - Name: `signature`
 
-Payload signature that will be verified.
+Message signature that will be verified.
 
 ### Public Key
 - Name: `public key`

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-go-sdk/crypto"
-
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -10,20 +10,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type flagsSign struct {
+type flagsGenerate struct {
 	Signer string `default:"emulator-account" flag:"signer" info:"name of the account used to sign"`
 }
 
-var signFlags = flagsSign{}
+var generateFlags = flagsGenerate{}
 
-var SignCommand = &command.Command{
+var GenerateCommand = &command.Command{
 	Cmd: &cobra.Command{
-		Use:     "sign <payload>",
-		Short:   "Sign the payload data",
-		Example: "flow signatures sign 'The quick brown fox jumps over the lazy dog' --signer alice",
+		Use:     "generate <payload>",
+		Short:   "Generate the payload signature",
+		Example: "flow signatures generate 'The quick brown fox jumps over the lazy dog' --signer alice",
 		Args:    cobra.ExactArgs(1),
 	},
-	Flags: &signFlags,
+	Flags: &generateFlags,
 	RunS:  sign,
 }
 
@@ -35,7 +35,7 @@ func sign(
 	state *flowkit.State,
 ) (command.Result, error) {
 	payload := []byte(args[0])
-	accountName := signFlags.Signer
+	accountName := generateFlags.Signer
 	acc, err := state.Accounts().ByName(accountName)
 	if err != nil {
 		return nil, err
@@ -66,9 +66,9 @@ func (s *SignatureResult) JSON() interface{} {
 	}
 }
 func (s *SignatureResult) String() string {
-	return fmt.Sprintf("%x", s.result)
+	return fmt.Sprintf("signature: \t%x\n", s.result)
 }
 
 func (s *SignatureResult) Oneliner() string {
-	return fmt.Sprintf("%x", s.result)
+	return fmt.Sprintf("signature: %x", s.result)
 }

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -1,8 +1,11 @@
 package signatures
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+
+	"github.com/onflow/flow-cli/pkg/flowkit/util"
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
@@ -52,23 +55,54 @@ func sign(
 	}
 
 	return &SignatureResult{
-		result: string(signed),
+		result:  string(signed),
+		payload: string(payload),
+		key:     acc.Key(),
 	}, nil
 }
 
 type SignatureResult struct {
-	result string
+	result  string
+	payload string
+	key     flowkit.AccountKey
+}
+
+func (s *SignatureResult) pubKey() string {
+	pkey, err := s.key.PrivateKey()
+	if err == nil {
+		return (*pkey).PublicKey().String()
+	}
+
+	return "ERR"
 }
 
 func (s *SignatureResult) JSON() interface{} {
 	return map[string]string{
-		"result": fmt.Sprintf("%x", s.result),
+		"signature": fmt.Sprintf("%x", s.result),
+		"payload":   fmt.Sprintf("%s", s.payload),
+		"hashAlgo":  fmt.Sprintf("%s", s.key.HashAlgo()),
+		"sigAlgo":   fmt.Sprintf("%s", s.key.SigAlgo()),
+		"pubKey":    fmt.Sprintf("%s", s.pubKey()),
 	}
 }
 func (s *SignatureResult) String() string {
-	return fmt.Sprintf("signature: \t%x\n", s.result)
+	var b bytes.Buffer
+	writer := util.CreateTabWriter(&b)
+
+	_, _ = fmt.Fprintf(writer, "Signature \t %x\n", s.result)
+	_, _ = fmt.Fprintf(writer, "Payload \t %s\n", s.payload)
+	_, _ = fmt.Fprintf(writer, "Public Key \t %s\n", s.pubKey())
+	_, _ = fmt.Fprintf(writer, "Hash Algorithm \t %s\n", s.key.HashAlgo())
+	_, _ = fmt.Fprintf(writer, "Signature Algorithm \t %s\n", s.key.SigAlgo())
+
+	_ = writer.Flush()
+	return b.String()
 }
 
 func (s *SignatureResult) Oneliner() string {
-	return fmt.Sprintf("signature: %x", s.result)
+
+	return fmt.Sprintf(
+		"signature: %x, payload: %s, hashAlgo: %s, sigAlgo: %s, pubKey: %s",
+		s.result, s.payload, s.key.HashAlgo(), s.key.SigAlgo(), s.pubKey(),
+	)
 }

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -97,10 +97,10 @@ func (s *SignatureResult) pubKey() string {
 func (s *SignatureResult) JSON() interface{} {
 	return map[string]string{
 		"signature": fmt.Sprintf("%x", s.result),
-		"payload":   fmt.Sprintf("%s", s.payload),
-		"hashAlgo":  fmt.Sprintf("%s", s.key.HashAlgo()),
-		"sigAlgo":   fmt.Sprintf("%s", s.key.SigAlgo()),
-		"pubKey":    fmt.Sprintf("%s", s.pubKey()),
+		"payload":   s.payload,
+		"hashAlgo":  s.key.HashAlgo().String(),
+		"sigAlgo":   s.key.SigAlgo().String(),
+		"pubKey":    s.pubKey(),
 	}
 }
 func (s *SignatureResult) String() string {

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -1,3 +1,21 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package signatures
 
 import (
@@ -5,12 +23,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onflow/flow-cli/pkg/flowkit/util"
+	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-cli/pkg/flowkit/services"
-	"github.com/spf13/cobra"
+	"github.com/onflow/flow-cli/pkg/flowkit/util"
 )
 
 type flagsGenerate struct {

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -39,8 +39,8 @@ var generateFlags = flagsGenerate{}
 
 var GenerateCommand = &command.Command{
 	Cmd: &cobra.Command{
-		Use:     "generate <payload>",
-		Short:   "Generate the payload signature",
+		Use:     "generate <message>",
+		Short:   "Generate the message signature",
 		Example: "flow signatures generate 'The quick brown fox jumps over the lazy dog' --signer alice",
 		Args:    cobra.ExactArgs(1),
 	},
@@ -55,7 +55,7 @@ func sign(
 	_ *services.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
-	payload := []byte(args[0])
+	message := []byte(args[0])
 	accountName := generateFlags.Signer
 	acc, err := state.Accounts().ByName(accountName)
 	if err != nil {
@@ -67,21 +67,21 @@ func sign(
 		return nil, err
 	}
 
-	signed, err := s.Sign(payload)
+	signed, err := s.Sign(message)
 	if err != nil {
 		return nil, err
 	}
 
 	return &SignatureResult{
 		result:  string(signed),
-		payload: string(payload),
+		message: string(message),
 		key:     acc.Key(),
 	}, nil
 }
 
 type SignatureResult struct {
 	result  string
-	payload string
+	message string
 	key     flowkit.AccountKey
 }
 
@@ -97,7 +97,7 @@ func (s *SignatureResult) pubKey() string {
 func (s *SignatureResult) JSON() interface{} {
 	return map[string]string{
 		"signature": fmt.Sprintf("%x", s.result),
-		"payload":   s.payload,
+		"message":   s.message,
 		"hashAlgo":  s.key.HashAlgo().String(),
 		"sigAlgo":   s.key.SigAlgo().String(),
 		"pubKey":    s.pubKey(),
@@ -108,7 +108,7 @@ func (s *SignatureResult) String() string {
 	writer := util.CreateTabWriter(&b)
 
 	_, _ = fmt.Fprintf(writer, "Signature \t %x\n", s.result)
-	_, _ = fmt.Fprintf(writer, "Payload \t %s\n", s.payload)
+	_, _ = fmt.Fprintf(writer, "Message \t %s\n", s.message)
 	_, _ = fmt.Fprintf(writer, "Public Key \t %s\n", s.pubKey())
 	_, _ = fmt.Fprintf(writer, "Hash Algorithm \t %s\n", s.key.HashAlgo())
 	_, _ = fmt.Fprintf(writer, "Signature Algorithm \t %s\n", s.key.SigAlgo())
@@ -120,7 +120,7 @@ func (s *SignatureResult) String() string {
 func (s *SignatureResult) Oneliner() string {
 
 	return fmt.Sprintf(
-		"signature: %x, payload: %s, hashAlgo: %s, sigAlgo: %s, pubKey: %s",
-		s.result, s.payload, s.key.HashAlgo(), s.key.SigAlgo(), s.pubKey(),
+		"signature: %x, message: %s, hashAlgo: %s, sigAlgo: %s, pubKey: %s",
+		s.result, s.message, s.key.HashAlgo(), s.key.SigAlgo(), s.pubKey(),
 	)
 }

--- a/internal/signatures/sign.go
+++ b/internal/signatures/sign.go
@@ -2,6 +2,7 @@ package signatures
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
@@ -53,4 +54,21 @@ func sign(
 	return &SignatureResult{
 		result: string(signed),
 	}, nil
+}
+
+type SignatureResult struct {
+	result string
+}
+
+func (s *SignatureResult) JSON() interface{} {
+	return map[string]string{
+		"result": fmt.Sprintf("%x", s.result),
+	}
+}
+func (s *SignatureResult) String() string {
+	return fmt.Sprintf("%x", s.result)
+}
+
+func (s *SignatureResult) Oneliner() string {
+	return fmt.Sprintf("%x", s.result)
 }

--- a/internal/signatures/sign.go
+++ b/internal/signatures/sign.go
@@ -1,0 +1,56 @@
+package signatures
+
+import (
+	"context"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+	"github.com/spf13/cobra"
+)
+
+type flagsSign struct {
+	Signer string `default:"emulator-account" flag:"signer" info:"name of the account used to sign"`
+}
+
+var signFlags = flagsSign{}
+
+var SignCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "sign <payload>",
+		Short:   "Sign the payload data",
+		Example: "flow signatures sign 'The quick brown fox jumps over the lazy dog' --signer alice",
+		Args:    cobra.ExactArgs(1),
+	},
+	Flags: &signFlags,
+	RunS:  sign,
+}
+
+func sign(
+	args []string,
+	_ flowkit.ReaderWriter,
+	_ command.GlobalFlags,
+	_ *services.Services,
+	state *flowkit.State,
+) (command.Result, error) {
+	payload := []byte(args[0])
+	accountName := signFlags.Signer
+	acc, err := state.Accounts().ByName(accountName)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := acc.Key().Signer(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	signed, err := s.Sign(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignatureResult{
+		result: string(signed),
+	}, nil
+}

--- a/internal/signatures/signatures.go
+++ b/internal/signatures/signatures.go
@@ -11,6 +11,6 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	SignCommand.AddToParent(Cmd)
+	GenerateCommand.AddToParent(Cmd)
 	VerifyCommand.AddToParent(Cmd)
 }

--- a/internal/signatures/signatures.go
+++ b/internal/signatures/signatures.go
@@ -1,8 +1,6 @@
 package signatures
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -14,21 +12,5 @@ var Cmd = &cobra.Command{
 
 func init() {
 	SignCommand.AddToParent(Cmd)
-}
-
-type SignatureResult struct {
-	result string
-}
-
-func (s *SignatureResult) JSON() interface{} {
-	return map[string]string{
-		"result": fmt.Sprintf("%x", s.result),
-	}
-}
-func (s *SignatureResult) String() string {
-	return fmt.Sprintf("%x", s.result)
-}
-
-func (s *SignatureResult) Oneliner() string {
-	return fmt.Sprintf("%x", s.result)
+	VerifyCommand.AddToParent(Cmd)
 }

--- a/internal/signatures/signatures.go
+++ b/internal/signatures/signatures.go
@@ -1,3 +1,21 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package signatures
 
 import (

--- a/internal/signatures/signatures.go
+++ b/internal/signatures/signatures.go
@@ -1,0 +1,34 @@
+package signatures
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:              "signatures",
+	Short:            "Signature verification and creation",
+	TraverseChildren: true,
+}
+
+func init() {
+	SignCommand.AddToParent(Cmd)
+}
+
+type SignatureResult struct {
+	result string
+}
+
+func (s *SignatureResult) JSON() interface{} {
+	return map[string]string{
+		"result": fmt.Sprintf("%x", s.result),
+	}
+}
+func (s *SignatureResult) String() string {
+	return fmt.Sprintf("%x", s.result)
+}
+
+func (s *SignatureResult) Oneliner() string {
+	return fmt.Sprintf("%x", s.result)
+}

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -1,0 +1,1 @@
+package signatures

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -1,1 +1,103 @@
 package signatures
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/spf13/cobra"
+)
+
+type flagsVerify struct {
+	Key      string `flag:"key" info:"Public keys for signature verification"`
+	SigAlgo  string `flag:"sig-algo" default:"ECDSA_P256" info:"Signature algorithm used to create the public key"`
+	HashAlgo string `flag:"hash-algo" default:"SHA3_256" info:"Hashing algorithm used to create signature"`
+}
+
+var verifyFlags = flagsVerify{}
+
+var VerifyCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "verify <payload> <signature>",
+		Short:   "Verify the signature",
+		Example: "flow signatures verify 99fa...25b --key af3...52d",
+		Args:    cobra.ExactArgs(2),
+	},
+	Flags: &verifyFlags,
+	RunS:  verify,
+}
+
+func verify(
+	args []string,
+	_ flowkit.ReaderWriter,
+	_ command.GlobalFlags,
+	_ *services.Services,
+	state *flowkit.State,
+) (command.Result, error) {
+	payload := []byte(args[0])
+
+	sig, err := hex.DecodeString(strings.ReplaceAll(args[1], "0x", ""))
+	if err != nil {
+		return nil, fmt.Errorf("invalid payload signature: %w", err)
+	}
+
+	key, err := hex.DecodeString(strings.ReplaceAll(verifyFlags.Key, "0x", ""))
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key: %w", err)
+	}
+
+	sigAlgo := crypto.StringToSignatureAlgorithm(verifyFlags.SigAlgo)
+	hashAlgo := crypto.StringToHashAlgorithm(verifyFlags.HashAlgo)
+
+	pkey, err := crypto.DecodePublicKey(sigAlgo, key)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key: %w", err)
+	}
+
+	hasher, err := crypto.NewHasher(hashAlgo)
+	if err != nil {
+		return nil, err
+	}
+
+	valid, err := pkey.Verify(sig, payload, hasher)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VerificationResult{
+		valid:     valid,
+		payload:   payload,
+		signature: sig,
+	}, nil
+}
+
+type VerificationResult struct {
+	valid     bool
+	payload   []byte
+	signature []byte
+}
+
+func (s *VerificationResult) JSON() interface{} {
+	return map[string]string{
+		"valid":     fmt.Sprintf("%v", s.valid),
+		"payload":   fmt.Sprintf("%s", s.payload),
+		"signature": fmt.Sprintf("%s", s.signature),
+	}
+}
+func (s *VerificationResult) String() string {
+	return fmt.Sprintf(
+		"valid: \t\t%v\npayload: \t%s\nsignature: \t%x\n",
+		s.valid, s.payload, s.signature,
+	)
+}
+
+func (s *VerificationResult) Oneliner() string {
+	return fmt.Sprintf(
+		"valid: %v, payload: %s, signature: %x",
+		s.valid, s.payload, s.signature,
+	)
+}

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -43,7 +43,7 @@ var verifyFlags = flagsVerify{}
 
 var VerifyCommand = &command.Command{
 	Cmd: &cobra.Command{
-		Use:     "verify <payload> <signature> <public key>",
+		Use:     "verify <message> <signature> <public key>",
 		Short:   "Verify the signature",
 		Example: "flow signatures verify 'The quick brown fox jumps over the lazy dog' 99fa...25b af3...52d",
 		Args:    cobra.ExactArgs(3),
@@ -59,11 +59,11 @@ func verify(
 	_ *services.Services,
 	_ *flowkit.State,
 ) (command.Result, error) {
-	payload := []byte(args[0])
+	message := []byte(args[0])
 
 	sig, err := hex.DecodeString(strings.ReplaceAll(args[1], "0x", ""))
 	if err != nil {
-		return nil, fmt.Errorf("invalid payload signature: %w", err)
+		return nil, fmt.Errorf("invalid message signature: %w", err)
 	}
 
 	key, err := hex.DecodeString(strings.ReplaceAll(args[2], "0x", ""))
@@ -84,14 +84,14 @@ func verify(
 		return nil, err
 	}
 
-	valid, err := pkey.Verify(sig, payload, hasher)
+	valid, err := pkey.Verify(sig, message, hasher)
 	if err != nil {
 		return nil, err
 	}
 
 	return &VerificationResult{
 		valid:     valid,
-		payload:   payload,
+		message:   message,
 		signature: sig,
 		hashAlgo:  hashAlgo,
 		sigAlgo:   sigAlgo,
@@ -101,7 +101,7 @@ func verify(
 
 type VerificationResult struct {
 	valid     bool
-	payload   []byte
+	message   []byte
 	signature []byte
 	pubKey    []byte
 	sigAlgo   crypto.SignatureAlgorithm
@@ -111,7 +111,7 @@ type VerificationResult struct {
 func (s *VerificationResult) JSON() interface{} {
 	return map[string]string{
 		"valid":     fmt.Sprintf("%v", s.valid),
-		"payload":   string(s.payload),
+		"message":   string(s.message),
 		"signature": string(s.signature),
 		"hashAlgo":  s.hashAlgo.String(),
 		"sigAlgo":   s.sigAlgo.String(),
@@ -123,7 +123,7 @@ func (s *VerificationResult) String() string {
 	writer := util.CreateTabWriter(&b)
 
 	_, _ = fmt.Fprintf(writer, "Valid \t %v\n", s.valid)
-	_, _ = fmt.Fprintf(writer, "Payload \t %s\n", s.payload)
+	_, _ = fmt.Fprintf(writer, "Message \t %s\n", s.message)
 	_, _ = fmt.Fprintf(writer, "Signature \t %x\n", s.signature)
 	_, _ = fmt.Fprintf(writer, "Public Key \t %x\n", s.pubKey)
 	_, _ = fmt.Fprintf(writer, "Hash Algorithm \t %s\n", s.hashAlgo)
@@ -135,7 +135,7 @@ func (s *VerificationResult) String() string {
 
 func (s *VerificationResult) Oneliner() string {
 	return fmt.Sprintf(
-		"valid: %v, payload: %s, signature: %x, sigAlgo: %s, hashAlgo: %s, pubKey: %x",
-		s.valid, s.payload, s.signature, s.sigAlgo, s.hashAlgo, s.pubKey,
+		"valid: %v, message: %s, signature: %x, sigAlgo: %s, hashAlgo: %s, pubKey: %x",
+		s.valid, s.message, s.signature, s.sigAlgo, s.hashAlgo, s.pubKey,
 	)
 }

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -19,9 +19,12 @@
 package signatures
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"strings"
+
+	"github.com/onflow/flow-cli/pkg/flowkit/util"
 
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
@@ -90,6 +93,9 @@ func verify(
 		valid:     valid,
 		payload:   payload,
 		signature: sig,
+		hashAlgo:  hashAlgo,
+		sigAlgo:   sigAlgo,
+		pubKey:    key,
 	}, nil
 }
 
@@ -97,25 +103,39 @@ type VerificationResult struct {
 	valid     bool
 	payload   []byte
 	signature []byte
+	pubKey    []byte
+	sigAlgo   crypto.SignatureAlgorithm
+	hashAlgo  crypto.HashAlgorithm
 }
 
 func (s *VerificationResult) JSON() interface{} {
 	return map[string]string{
 		"valid":     fmt.Sprintf("%v", s.valid),
-		"payload":   fmt.Sprintf("%s", s.payload),
-		"signature": fmt.Sprintf("%s", s.signature),
+		"payload":   string(s.payload),
+		"signature": string(s.signature),
+		"hashAlgo":  s.hashAlgo.String(),
+		"sigAlgo":   s.sigAlgo.String(),
+		"pubKey":    fmt.Sprintf("%x", s.pubKey),
 	}
 }
 func (s *VerificationResult) String() string {
-	return fmt.Sprintf(
-		"valid: \t\t%v\npayload: \t%s\nsignature: \t%x\n",
-		s.valid, s.payload, s.signature,
-	)
+	var b bytes.Buffer
+	writer := util.CreateTabWriter(&b)
+
+	_, _ = fmt.Fprintf(writer, "Valid \t %v\n", s.valid)
+	_, _ = fmt.Fprintf(writer, "Payload \t %s\n", s.payload)
+	_, _ = fmt.Fprintf(writer, "Signature \t %x\n", s.signature)
+	_, _ = fmt.Fprintf(writer, "Public Key \t %x\n", s.pubKey)
+	_, _ = fmt.Fprintf(writer, "Hash Algorithm \t %s\n", s.hashAlgo)
+	_, _ = fmt.Fprintf(writer, "Signature Algorithm \t %s\n", s.sigAlgo)
+
+	_ = writer.Flush()
+	return b.String()
 }
 
 func (s *VerificationResult) Oneliner() string {
 	return fmt.Sprintf(
-		"valid: %v, payload: %s, signature: %x",
-		s.valid, s.payload, s.signature,
+		"valid: %v, payload: %s, signature: %x, sigAlgo: %s, hashAlgo: %s, pubKey: %x",
+		s.valid, s.payload, s.signature, s.sigAlgo, s.hashAlgo, s.pubKey,
 	)
 }

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -1,3 +1,21 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package signatures
 
 import (
@@ -5,11 +23,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/spf13/cobra"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-cli/pkg/flowkit/services"
-	"github.com/onflow/flow-go-sdk/crypto"
-	"github.com/spf13/cobra"
 )
 
 type flagsVerify struct {

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -32,7 +32,6 @@ import (
 )
 
 type flagsVerify struct {
-	Key      string `flag:"key" info:"Public keys for signature verification"`
 	SigAlgo  string `flag:"sig-algo" default:"ECDSA_P256" info:"Signature algorithm used to create the public key"`
 	HashAlgo string `flag:"hash-algo" default:"SHA3_256" info:"Hashing algorithm used to create signature"`
 }
@@ -41,10 +40,10 @@ var verifyFlags = flagsVerify{}
 
 var VerifyCommand = &command.Command{
 	Cmd: &cobra.Command{
-		Use:     "verify <payload> <signature>",
+		Use:     "verify <payload> <signature> <public key>",
 		Short:   "Verify the signature",
-		Example: "flow signatures verify 99fa...25b --key af3...52d",
-		Args:    cobra.ExactArgs(2),
+		Example: "flow signatures verify 'The quick brown fox jumps over the lazy dog' 99fa...25b af3...52d",
+		Args:    cobra.ExactArgs(3),
 	},
 	Flags: &verifyFlags,
 	RunS:  verify,
@@ -55,7 +54,7 @@ func verify(
 	_ flowkit.ReaderWriter,
 	_ command.GlobalFlags,
 	_ *services.Services,
-	state *flowkit.State,
+	_ *flowkit.State,
 ) (command.Result, error) {
 	payload := []byte(args[0])
 
@@ -64,7 +63,7 @@ func verify(
 		return nil, fmt.Errorf("invalid payload signature: %w", err)
 	}
 
-	key, err := hex.DecodeString(strings.ReplaceAll(verifyFlags.Key, "0x", ""))
+	key, err := hex.DecodeString(strings.ReplaceAll(args[2], "0x", ""))
 	if err != nil {
 		return nil, fmt.Errorf("invalid public key: %w", err)
 	}


### PR DESCRIPTION
Closes #385 

## Description

Added a new 'signatures' command, which allows developers to create signatures and verify them. 

Sign command allows you to provide a payload and reference a signer from the `flow.json` to be used for generating a signature.
```
flow signatures generate <payload> --signer alice
```

Verify command lets you provide the payload used to create a signature, specify the public key, signature algorithm, and hashing algorithm, and tells you whether the signature is valid for provided data.
```
flow signatures verify <payload> <signature>
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
