### PR TITLE
Don't overflow on last bigger than end

### DIFF
--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -109,7 +109,11 @@ func get(
 			return nil, err
 		}
 
-		start = end - last
+		if last > end {
+			start = 0
+		} else {
+			start = end - last
+		}
 	} else if start == 0 || end == 0 {
 		return nil, fmt.Errorf("please provide either both start and end for range or only last flag")
 	}


### PR DESCRIPTION
## Description
When running locally if fewer blocks were created than the last flag specified then it overflowed the range.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
