### PR TITLE
Change default events for Batch to 25 from 250

### DIFF
--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -34,7 +34,7 @@ type flagsEvents struct {
 	End     uint64 `flag:"end" info:"End block height"`
 	Last    uint64 `default:"10" flag:"last" info:"Fetch number of blocks relative to the last block. Ignored if the start flag is set. Used as a default if no flags are provided"`
 	Workers int    `default:"10" flag:"workers" info:"Number of workers to use when fetching events in parallel"`
-	Batch   uint64 `default:"250" flag:"batch" info:"Number of blocks each worker will fetch"`
+	Batch   uint64 `default:"25" flag:"batch" info:"Number of blocks each worker will fetch"`
 }
 
 var eventsFlags = flagsEvents{}


### PR DESCRIPTION
Closes #???

## Description

Changes number of blocks a worker will fetch.

The maximum block range was recently changed from 250 to 25. This fix addresses that by changing the default value for the number of blocks each worker will fetch from 250 to 25.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
