### PR TITLE
Add CLI Feature: Hot commands

### DIFF
--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -49,7 +49,7 @@ func main() {
 	// quick commands
 	quick.InitCommand.AddToParent(cmd)
 	quick.DeployCommand.AddToParent(cmd)
-	cmd.AddCommand(quick.RunCommand)
+	quick.RunCommand.AddToParent(cmd)
 	status.Command.AddToParent(cmd)
 
 	// structured commands
@@ -68,7 +68,7 @@ func main() {
 
 	command.InitFlags(cmd)
 	// Set usage template to custom template
-	cmd.SetUsageTemplate("Usage:{{if .Runnable}}\n{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}\n{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}\n\nAliases:\n{{.NameAndAliases}}{{end}}{{if .HasExample}}\n\nExamples:\n{{.Example}}{{end}}{{if .HasAvailableSubCommands}}\n\nHot Commands:\n{{range .Commands}}{{if (and (.IsAvailableCommand)  (index .Annotations \"HotCommand\") )}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nAvailable Commands:\n{{range .Commands}}{{if (and (or .IsAvailableCommand (eq .Name \"help\")) (not (index .Annotations \"HotCommand\")))}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nFlags:\n{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\n\nGlobal Flags:\n{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}\n\nAdditional help topics:\n{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}\nUse \"{{.CommandPath}} [command] --help\" for more information about a command.{{end}}\n")
+	cmd.SetUsageTemplate("Usage:{{if .Runnable}}\n{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}\n{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}\n\nAliases:\n{{.NameAndAliases}}{{end}}{{if .HasExample}}\n\nExamples:\n{{.Example}}{{end}}{{if .HasAvailableSubCommands}}\n\n{{if (eq .Name \"flow\")}}Hot Commands:\n{{range .Commands}}{{if (and (.IsAvailableCommand)  (index .Annotations \"HotCommand\") )}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\n{{end}}Available Commands:\n{{range .Commands}}{{if (and (or .IsAvailableCommand (eq .Name \"help\")) (not (index .Annotations \"HotCommand\")))}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nFlags:\n{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\n\nGlobal Flags:\n{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}\n\nAdditional help topics:\n{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}\nUse \"{{.CommandPath}} [command] --help\" for more information about a command.{{end}}\n")
 	if err := cmd.Execute(); err != nil {
 		util.Exit(1, err.Error())
 	}

--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -67,7 +67,7 @@ func main() {
 	cmd.AddCommand(config.Cmd)
 
 	command.InitFlags(cmd)
-
+	cmd.SetUsageTemplate("Usage:{{if .Runnable}}\n{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}\n{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}\n\nAliases:\n{{.NameAndAliases}}{{end}}{{if .HasExample}}\n\nExamples:\n{{.Example}}{{end}}{{if .HasAvailableSubCommands}}\n\nHot Commands:\n{{range .Commands}}{{if (and (.IsAvailableCommand)  (index .Annotations \"HotCommand\") )}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nAvailable Commands:\n{{range .Commands}}{{if (and (or .IsAvailableCommand (eq .Name \"help\")) (not (index .Annotations \"HotCommand\")))}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nFlags:\n{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\n\nGlobal Flags:\n{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}\n\nAdditional help topics:\n{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}\nUse \"{{.CommandPath}} [command] --help\" for more information about a command.{{end}}\n")
 	if err := cmd.Execute(); err != nil {
 		util.Exit(1, err.Error())
 	}

--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -48,6 +48,8 @@ func main() {
 
 	// quick commands
 	quick.InitCommand.AddToParent(cmd)
+	quick.DeployCommand.AddToParent(cmd)
+	cmd.AddCommand(quick.RunCommand)
 	status.Command.AddToParent(cmd)
 
 	// structured commands

--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -67,6 +67,7 @@ func main() {
 	cmd.AddCommand(config.Cmd)
 
 	command.InitFlags(cmd)
+	// Set usage template to custom template
 	cmd.SetUsageTemplate("Usage:{{if .Runnable}}\n{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}\n{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}\n\nAliases:\n{{.NameAndAliases}}{{end}}{{if .HasExample}}\n\nExamples:\n{{.Example}}{{end}}{{if .HasAvailableSubCommands}}\n\nHot Commands:\n{{range .Commands}}{{if (and (.IsAvailableCommand)  (index .Annotations \"HotCommand\") )}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nAvailable Commands:\n{{range .Commands}}{{if (and (or .IsAvailableCommand (eq .Name \"help\")) (not (index .Annotations \"HotCommand\")))}}\n{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\n\nFlags:\n{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\n\nGlobal Flags:\n{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}\n\nAdditional help topics:\n{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}\nUse \"{{.CommandPath}} [command] --help\" for more information about a command.{{end}}\n")
 	if err := cmd.Execute(); err != nil {
 		util.Exit(1, err.Error())

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -14,15 +14,15 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
+ */
 
 package quick
 
 import (
-	 "github.com/spf13/cobra"
- 
-	 "github.com/onflow/flow-cli/internal/command"
-	 "github.com/onflow/flow-cli/internal/project"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/project"
 )
 
 var DeployCommand = &command.Command{
@@ -30,11 +30,10 @@ var DeployCommand = &command.Command{
 		Use:     "deploy",
 		Short:   "Deploy contracts",
 		Example: "flow deploy",
-		Annotations : map[string]string{
-			"HotCommand" : "true",
+		Annotations: map[string]string{
+			"HotCommand": "true",
 		},
 	},
-	Flags : project.DeployCommand.Flags,
-	RunS : project.DeployCommand.RunS,
+	Flags: project.DeployCommand.Flags,
+	RunS:  project.DeployCommand.RunS,
 }
-

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/project"
 )
-
+// add deploy command
 var DeployCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "deploy",

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -28,7 +28,7 @@ import (
 var DeployCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "deploy",
-		Short:   "Deploy contracts",
+		Short:   "Deploy all contracts",
 		Example: "flow deploy",
 		Annotations: map[string]string{
 			"HotCommand": "true",

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -1,0 +1,37 @@
+/*
+* Flow CLI
+*
+* Copyright 2019-2021 Dapper Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package quick
+
+import (
+	 "github.com/spf13/cobra"
+ 
+	 "github.com/onflow/flow-cli/internal/command"
+	 "github.com/onflow/flow-cli/internal/project"
+)
+
+var DeployCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "deploy",
+		Short:   "Deploy contracts",
+		Example: "flow deploy",
+	},
+	Flags : project.DeployCommand.Flags,
+	RunS : project.DeployCommand.RunS,
+}
+

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -30,6 +30,9 @@ var DeployCommand = &command.Command{
 		Use:     "deploy",
 		Short:   "Deploy contracts",
 		Example: "flow deploy",
+		Annotations : map[string]string{
+			"HotCommand" : "true",
+		},
 	},
 	Flags : project.DeployCommand.Flags,
 	RunS : project.DeployCommand.RunS,

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -29,7 +29,7 @@ import (
 var DeployCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "deploy",
-		Short:   "Deploy all contracts",
+		Short:   "Deploy all project contracts",
 		Example: "flow deploy",
 		Annotations: map[string]string{
 			"HotCommand": "true",

--- a/internal/quick/deploy.go
+++ b/internal/quick/deploy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/project"
 )
+
 // add deploy command
 var DeployCommand = &command.Command{
 	Cmd: &cobra.Command{

--- a/internal/quick/init.go
+++ b/internal/quick/init.go
@@ -32,6 +32,9 @@ var InitCommand = &command.Command{
 		Use:     "init",
 		Short:   "Initialize a new configuration",
 		Example: "flow project init",
+		Annotations : map[string]string{
+			"HotCommand" : "true",
+		},
 	},
 	Flags: &config.InitFlag,
 	Run:   config.Initialise, // TODO(sideninja) workaround - init needed to be copied in order to work else there is flag duplicate error

--- a/internal/quick/init.go
+++ b/internal/quick/init.go
@@ -32,8 +32,8 @@ var InitCommand = &command.Command{
 		Use:     "init",
 		Short:   "Initialize a new configuration",
 		Example: "flow project init",
-		Annotations : map[string]string{
-			"HotCommand" : "true",
+		Annotations: map[string]string{
+			"HotCommand": "true",
 		},
 	},
 	Flags: &config.InitFlag,

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -28,6 +28,9 @@ var RunCommand = &cobra.Command{
 		Use:     "run",
 		Short:   "Start emulator and deploy contracts",
 		Example: "flow run",
+		Annotations : map[string]string{
+			"HotCommand" : "true",
+		},
 		Run: func(cmd *cobra.Command, args []string){
 			project.DeployCommand.Cmd.Run(cmd, args)
 			emulator.Cmd.Run(cmd, args)

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onflow/flow-cli/internal/project"
 	"github.com/spf13/cobra"
 )
-
+// add run command
 var RunCommand = &cobra.Command{
 	Use:     "run",
 	Short:   "Start emulator and deploy contracts",

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -58,7 +58,7 @@ func EmulatorHelper(args []string, globalFlags command.GlobalFlags, services *se
 var RunCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "run",
-		Short:   "Start emulator and deploy all contracts",
+		Short:   "Start emulator and deploy all project contracts",
 		Example: "flow run",
 		Annotations: map[string]string{
 			"HotCommand": "true",

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -28,6 +28,10 @@ import (
 	"sync"
 )
 
+type flagsRun struct {
+}
+
+var runFlags = flagsRun{}
 func DeployHelper(args []string, globalFlags command.GlobalFlags, services *services.Services, wg *sync.WaitGroup) {
 
 	for true {
@@ -60,6 +64,7 @@ var RunCommand = &command.Command{
 			"HotCommand": "true",
 		},
 	},
+	Flags: &runFlags,
 	Run: func(
 		args []string,
 		_ flowkit.ReaderWriter,

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -1,0 +1,38 @@
+/*
+* Flow CLI
+*
+* Copyright 2019-2021 Dapper Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package quick
+
+import (
+	 "github.com/spf13/cobra"
+	 "github.com/onflow/flow-cli/internal/emulator"
+	 "github.com/onflow/flow-cli/internal/project"
+)
+
+var RunCommand = &cobra.Command{
+		Use:     "run",
+		Short:   "Start emulator and deploy contracts",
+		Example: "flow run",
+		Run: func(cmd *cobra.Command, args []string){
+			project.DeployCommand.Cmd.Run(cmd, args)
+			emulator.Cmd.Run(cmd, args)
+		},
+}
+
+
+

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -14,28 +14,25 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
+ */
 
 package quick
 
 import (
-	 "github.com/spf13/cobra"
-	 "github.com/onflow/flow-cli/internal/emulator"
-	 "github.com/onflow/flow-cli/internal/project"
+	"github.com/onflow/flow-cli/internal/emulator"
+	"github.com/onflow/flow-cli/internal/project"
+	"github.com/spf13/cobra"
 )
 
 var RunCommand = &cobra.Command{
-		Use:     "run",
-		Short:   "Start emulator and deploy contracts",
-		Example: "flow run",
-		Annotations : map[string]string{
-			"HotCommand" : "true",
-		},
-		Run: func(cmd *cobra.Command, args []string){
-			project.DeployCommand.Cmd.Run(cmd, args)
-			emulator.Cmd.Run(cmd, args)
-		},
+	Use:     "run",
+	Short:   "Start emulator and deploy contracts",
+	Example: "flow run",
+	Annotations: map[string]string{
+		"HotCommand": "true",
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		project.DeployCommand.Cmd.Run(cmd, args)
+		emulator.Cmd.Run(cmd, args)
+	},
 }
-
-
-

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -19,40 +19,39 @@
 package quick
 
 import (
+	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/emulator"
 	"github.com/onflow/flow-cli/internal/project"
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-cli/pkg/flowkit/services"
 	"github.com/spf13/cobra"
 	"sync"
 )
 
-func DeployHelper(args []string, globalFlags command.GlobalFlags, services *services.Services, wg *sync.WaitGroup){
+func DeployHelper(args []string, globalFlags command.GlobalFlags, services *services.Services, wg *sync.WaitGroup) {
 
 	for true {
 		//check if the server has started
 		_, err := services.Status.Ping(globalFlags.Network)
 		if err == nil {
 			// if the emulator is running run the deploy command
-			project.DeployCommand.Cmd.Run(project.DeployCommand.Cmd,args)
-			break;
+			project.DeployCommand.Cmd.Run(project.DeployCommand.Cmd, args)
+			break
 		}
 	}
 
 	wg.Done()
-	
+
 }
 
-func EmulatorHelper(args []string, globalFlags command.GlobalFlags, services *services.Services, wg *sync.WaitGroup){
+func EmulatorHelper(args []string, globalFlags command.GlobalFlags, services *services.Services, wg *sync.WaitGroup) {
 	// run the emulator
 	emulator.Cmd.Run(emulator.Cmd, args)
 	wg.Done()
 }
 
-
 // This command will act as an alias for running the emulator and deploying the contracts
-var RunCommand = &command.Command{ 
+var RunCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "run",
 		Short:   "Start emulator and deploy all contracts",
@@ -66,17 +65,17 @@ var RunCommand = &command.Command{
 		_ flowkit.ReaderWriter,
 		globalFlags command.GlobalFlags,
 		services *services.Services,
-	)(command.Result, error){
-		var waitGroup sync.WaitGroup 
-		// set number of goroutines 
-		waitGroup.Add(2) 
+	) (command.Result, error) {
+		var waitGroup sync.WaitGroup
+		// set number of goroutines
+		waitGroup.Add(2)
 		go EmulatorHelper(args, globalFlags, services, &waitGroup)
 		go DeployHelper(args, globalFlags, services, &waitGroup)
 		// wait until completion of the goroutines
-		waitGroup.Wait() 
+		waitGroup.Wait()
 
 		emulator.Cmd.Run(emulator.Cmd, args)
-		return &RunResult{},nil
+		return &RunResult{}, nil
 	},
 }
 


### PR DESCRIPTION
This PR is for https://github.com/onflow/flip-fest/issues/14

## Description

- Customised the help screen to display commands classified into 2 types.
- Added 2 new "Hot Commands"- deploy and run.
- Used Annotation field in the cobra.Command class to classify the commands.
- Now help screen looks as shown below
![Screenshot from 2021-10-30 17-43-00](https://user-images.githubusercontent.com/44064539/139532505-62983772-fe0c-4b85-9de4-d5b9ee9750fd.png)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
