### PR TITLE
Revert "use relative path in documents"

### DIFF
--- a/docs/build-transactions.md
+++ b/docs/build-transactions.md
@@ -81,7 +81,7 @@ transaction to be executed.
   matching argument type in transaction code.
 
 Input arguments values matching corresponding types in the source code and passed in the same order.
-For passing complex argument values see [send transaction](send-transactions.md#example-usage) document. 
+For passing complex argument values see [send transaction](https://docs.onflow.org/flow-cli/send-transactions/#example-usage) document. 
 
 ## Flags
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,8 +11,8 @@ Flow configuration (`flow.json`) file will contain the following properties:
 - A `networks` list pre-populated with the Flow emulator, testnet and mainnet connection configuration.
 - An `accounts` list pre-populated with the Flow Emulator service account.
 - An `emulators` list pre-populated with Flow Emulator configuration.
-- A `deployments` empty object where all [deployment targets](project-contracts.md) can be defined. 
-- A `contracts` empty object where you [define contracts](project-contracts.md) you wish to deploy.
+- A `deployments` empty object where all [deployment targets](https://docs.onflow.org/flow-cli/project-contracts/) can be defined. 
+- A `contracts` empty object where you [define contracts](https://docs.onflow.org/flow-cli/project-contracts/) you wish to deploy.
 
 ## Example Project Configuration
 

--- a/docs/deploy-project-contracts.md
+++ b/docs/deploy-project-contracts.md
@@ -12,7 +12,7 @@ This command automatically deploys your project's contracts based on the
 configuration defined in your `flow.json` file.
 
 Before using this command, read about how to 
-[configure project contracts and deployment targets](project-contracts.md).
+[configure project contracts and deployment targets](https://docs.onflow.org/flow-cli/project-contracts/).
 
 ## Example Usage
 
@@ -88,7 +88,7 @@ used during the deployment. Example:
 
 
 ⚠️ Warning: before proceeding, 
-we recommend reading the [Flow CLI security guidelines](security.md)
+we recommend reading the [Flow CLI security guidelines](https://docs.onflow.org/flow-cli/security/)
 to learn about the best practices for private key storage.
 
 ## Dependency Resolution

--- a/docs/developer-updates/release-notes-v17.md
+++ b/docs/developer-updates/release-notes-v17.md
@@ -1,6 +1,6 @@
 ## ⬆️ Install or Upgrade
 
-Follow the [Flow CLI installation guide](../install.md) for instructions on how to install or upgrade the CLI.
+Follow the [Flow CLI installation guide](https://docs.onflow.org/flow-cli/install/) for instructions on how to install or upgrade the CLI.
 
 ## 💥 Breaking Changes
 
@@ -12,7 +12,7 @@ The new format is not backwards compatible with the old format.
 
 If needed, you can generate a new configuration file with the `flow init` command.
 
-Read more about the new configuration format in the [documentation](../configuration.md).
+Read more about the new configuration format in the [documentation](https://docs.onflow.org/flow-cli/configuration).
 
 ### Updated: `flow blocks get`
 
@@ -31,7 +31,7 @@ flow blocks get 6bb0e0fceef9225a3cf9ceb6df9a31bd0063e6ee8e8dd7fdd93b831783243cd3
 flow blocks get 28329914
 ```
 
-Read more about this change in the [documentation](../get-blocks.md).
+Read more about this change in the [documentation](https://docs.onflow.org/flow-cli/get-blocks).
 
 ### Removed: `flow keys decode`
 
@@ -102,7 +102,7 @@ more about them in the documentation on each command:
 - Filter: `--filter` Specify any property name from the result you want to return as the only value.
 
 All the flags and their allowed values are specified 
-for each command in the [documentation](../index.md).
+for each command in the [documentation](https://docs.onflow.org/flow-cli/).
 
 Changed output for fetching account.
 ```
@@ -146,7 +146,7 @@ to be reused.
 ### Account Staking Info Command
 
 New command to fetch staking info from the account was added. Read more about it in the
-[documentation](../account-staking-info.md).
+[documentation](https://docs.onflow.org/flow-cli/staking-info).
 
 ```shell
 > accounts staking-info 535b975637fb6bee --host access.testnet.nodes.onflow.org:9000

--- a/docs/developer-updates/release-notes-v18.md
+++ b/docs/developer-updates/release-notes-v18.md
@@ -1,6 +1,6 @@
 ## ⬆️ Install or Upgrade
 
-Follow the [Flow CLI installation guide](../install.md) for instructions on how to install or upgrade the CLI.
+Follow the [Flow CLI installation guide](https://docs.onflow.org/flow-cli/install/) for instructions on how to install or upgrade the CLI.
 
 ## ⭐ Features
 
@@ -43,7 +43,7 @@ or address. Example:
 flow transactions build ./transaction.cdc --proposer alice --payer bob --authorizer bob --filter payload --save payload1.rlp
 ```
 
-Check more about [this functionality in docs](../build-transactions.md).
+Check more about [this functionality in docs](https://docs.onflow.org/flow-cli/build-transactions/).
 
 #### Sign Transaction
 After using build command and saving payload to a file you should sign the transaction 
@@ -66,7 +66,7 @@ Automatically checks if a new version exists and outputs a warning in case there
 is a newer version. Example:
 ```
 ⚠️  Version Warning: New version v0.18.0 of Flow CLI is available.
-Follow the Flow [CLI installation guide](../install.md) for instructions on how to install or upgrade the CLI
+Follow the Flow CLI installation guide for instructions on how to install or upgrade the CLI: https://docs.onflow.org/flow-cli/install
 ```
 
 

--- a/docs/developer-updates/release-notes-v19.md
+++ b/docs/developer-updates/release-notes-v19.md
@@ -1,6 +1,6 @@
 ## ⬆️ Install or Upgrade
 
-Follow the [Flow CLI installation guide](../install.md) for instructions on how to install or upgrade the CLI.
+Follow the [Flow CLI installation guide](https://docs.onflow.org/flow-cli/install/) for instructions on how to install or upgrade the CLI.
 
 ## ⭐ Features
 
@@ -51,7 +51,7 @@ Global flow configuration is saved as:
 - Linux: `~/flow.json`
 - Windows: `C:\Users\$USER\flow.json`
 
-You can read more about it in [the docs](../initialize-configuration.md).
+You can read more about it in [the docs](https://docs.onflow.org/flow-cli/initialize-configuration/).
 
 ### Environment File Support
 

--- a/docs/developer-updates/release-notes-v21.md
+++ b/docs/developer-updates/release-notes-v21.md
@@ -1,6 +1,6 @@
 ## ⬆️ Install or Upgrade
 
-Follow the [Flow CLI installation guide](../install.md) for instructions on how to install or upgrade the CLI.
+Follow the [Flow CLI installation guide](https://docs.onflow.org/flow-cli/install/) for instructions on how to install or upgrade the CLI.
 
 
 ## 💥 Breaking Changes

--- a/docs/developer-updates/release-notes-v24.md
+++ b/docs/developer-updates/release-notes-v24.md
@@ -1,6 +1,6 @@
 ## ⬆️ Install or Upgrade
 
-Follow the [Flow CLI installation guide](../install.md) for instructions on how to install or upgrade the CLI.
+Follow the [Flow CLI installation guide](https://docs.onflow.org/flow-cli/install/) for instructions on how to install or upgrade the CLI.
 
 ## 💥 Breaking Changes
 

--- a/docs/execute-scripts.md
+++ b/docs/execute-scripts.md
@@ -54,7 +54,7 @@ Input arguments values matching corresponding types in the source code and passe
 Arguments passed to the Cadence script in `Type:Value` format. 
 The `Type` must be the same as type in the script source code for that argument.  
 
-For passing complex argument values see [send transaction](send-transactions.md#example-usage) document. 
+For passing complex argument values see [send transaction](https://docs.onflow.org/flow-cli/send-transactions/#example-usage) document. 
 
 ⚠️  Deprecated: use command arguments instead.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,5 +9,5 @@ or sending transactions. It also includes the [Flow Emulator](https://docs.onflo
 
 ## Installation
 
-Follow [these steps](./install.md) to install the Flow CLI on 
+Follow [these steps](https://docs.onflow.org/flow-cli/install) to install the Flow CLI on 
 macOS, Linux, and Windows.

--- a/docs/initialize-configuration.md
+++ b/docs/initialize-configuration.md
@@ -6,7 +6,7 @@ description: How to initialize Flow configuration using CLI
 
 Flow CLI uses a state to operate which is called configuration (usually `flow.json` file). 
 Before using commands that require this configuration we must initialize the project by 
-using the init command. Read more about [state configuration here](configuration.md).
+using the init command. Read more about [state configuration here](https://docs.onflow.org/flow-cli/configuration/).
 
 ```shell
 flow init

--- a/docs/start-emulator.md
+++ b/docs/start-emulator.md
@@ -11,7 +11,7 @@ The Flow Emulator is a lightweight tool that emulates the behaviour of the real 
 flow emulator
 ```
 
-⚠️ The emulator command expects configuration to be initialized. See [flow init](initialize-configuration.md) command.
+⚠️ The emulator command expects configuration to be initialized. See [flow init](https://docs.onflow.org/flow-cli/initialize-configuration/) command.
 
 
 ## Example Usage


### PR DESCRIPTION
This reverts commit ab5996a51abcd5f89aec33824b438965dfd309a5.

## Description

The PR was accidentally merged in, which breaks Flow doc site page https://docs.onflow.org/flow-cli/ 
Will re-merge in this change once the [relative path issue](https://github.com/onflow/flow/issues/704) is addressed

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
