### PR TITLE
update install guide to mention delay in Brew

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,6 +13,8 @@ The Flow CLI can be installed on macOS, Windows (7 or greater) and most Linux sy
 brew install flow-cli
 ```
 
+Note: it could take up to one hour for a new version to be propagated to Brew. In case you want to use the latest version immediately, follow the [instrcutions](#from-a-pre-built-binary) in the section below.
+
 ### From a pre-built binary
 
 _This installation method only works on x86-64._


### PR DESCRIPTION
## Description
Call out the fact that release to Brew would take some time, and direct users to follow "from a pre-built binary" section in case they need the new version immediately

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
