### PR TITLE
Show more user-friendly error message if proposer key is missing

### DIFF
--- a/pkg/flowkit/services/accounts.go
+++ b/pkg/flowkit/services/accounts.go
@@ -428,8 +428,7 @@ func (a *Accounts) prepareTransaction(
 
 	tx.SetBlockReference(block)
 
-	tx, err = tx.SetProposer(proposer, account.Key().Index())
-	if err != nil {
+	if err = tx.SetProposer(proposer, account.Key().Index()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/flowkit/services/accounts.go
+++ b/pkg/flowkit/services/accounts.go
@@ -426,8 +426,12 @@ func (a *Accounts) prepareTransaction(
 		return nil, err
 	}
 
-	tx.SetBlockReference(block).
-		SetProposer(proposer, account.Key().Index())
+	tx.SetBlockReference(block)
+
+	tx, err = tx.SetProposer(proposer, account.Key().Index())
+	if err != nil {
+		return nil, err
+	}
 
 	tx, err = tx.Sign()
 	if err != nil {

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -207,8 +207,7 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 
 		tx.SetBlockReference(block)
 
-		tx, err = tx.SetProposer(targetAccountInfo, targetAccount.Key().Index())
-		if err != nil {
+		if err = tx.SetProposer(targetAccountInfo, targetAccount.Key().Index()); err != nil {
 			return nil, err
 		}
 

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -205,8 +205,12 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 			}
 		}
 
-		tx.SetBlockReference(block).
-			SetProposer(targetAccountInfo, targetAccount.Key().Index())
+		tx.SetBlockReference(block)
+
+		tx, err = tx.SetProposer(targetAccountInfo, targetAccount.Key().Index())
+		if err != nil {
+			return nil, err
+		}
 
 		tx, err = tx.Sign()
 		if err != nil {

--- a/pkg/flowkit/services/transactions.go
+++ b/pkg/flowkit/services/transactions.go
@@ -99,6 +99,10 @@ func (t *Transactions) Build(
 	if err != nil {
 		return nil, err
 	}
+	
+	if len(proposerAccount.Keys) <= proposerKeyIndex {
+		return nil, fmt.Errorf("failed to retrieve proposer key at index %d", proposerKeyIndex)
+	}	
 
 	tx := flowkit.NewTransaction().
 		SetPayer(payer).

--- a/pkg/flowkit/services/transactions.go
+++ b/pkg/flowkit/services/transactions.go
@@ -99,16 +99,16 @@ func (t *Transactions) Build(
 	if err != nil {
 		return nil, err
 	}
-	
-	if len(proposerAccount.Keys) <= proposerKeyIndex {
-		return nil, fmt.Errorf("failed to retrieve proposer key at index %d", proposerKeyIndex)
-	}	
 
-	tx := flowkit.NewTransaction().
+	rawTx := flowkit.NewTransaction().
 		SetPayer(payer).
-		SetProposer(proposerAccount, proposerKeyIndex).
 		SetGasLimit(gasLimit).
 		SetBlockReference(latestBlock)
+
+	tx, err := rawTx.SetProposer(proposerAccount, proposerKeyIndex)
+	if err != nil {
+		return nil, err
+	}
 
 	resolver, err := contracts.NewResolver(code)
 	if err != nil {

--- a/pkg/flowkit/services/transactions.go
+++ b/pkg/flowkit/services/transactions.go
@@ -100,13 +100,12 @@ func (t *Transactions) Build(
 		return nil, err
 	}
 
-	rawTx := flowkit.NewTransaction().
+	tx := flowkit.NewTransaction().
 		SetPayer(payer).
 		SetGasLimit(gasLimit).
 		SetBlockReference(latestBlock)
 
-	tx, err := rawTx.SetProposer(proposerAccount, proposerKeyIndex)
-	if err != nil {
+	if err := tx.SetProposer(proposerAccount, proposerKeyIndex); err != nil {
 		return nil, err
 	}
 

--- a/pkg/flowkit/transaction.go
+++ b/pkg/flowkit/transaction.go
@@ -232,9 +232,9 @@ func (t *Transaction) authorizersContains(address flow.Address) bool {
 }
 
 // SetProposer sets the proposer for transaction.
-func (t *Transaction) SetProposer(proposer *flow.Account, keyIndex int) (*Transaction, error) {
+func (t *Transaction) SetProposer(proposer *flow.Account, keyIndex int) error {
 	if len(proposer.Keys) <= keyIndex {
-		return nil, fmt.Errorf("failed to retrieve proposer key at index %d", keyIndex)
+		return fmt.Errorf("failed to retrieve proposer key at index %d", keyIndex)
 	}
 
 	t.proposer = proposer
@@ -246,7 +246,7 @@ func (t *Transaction) SetProposer(proposer *flow.Account, keyIndex int) (*Transa
 		proposerKey.SequenceNumber,
 	)
 
-	return t, nil
+	return nil
 }
 
 // SetPayer sets the payer for transaction.

--- a/pkg/flowkit/transaction.go
+++ b/pkg/flowkit/transaction.go
@@ -232,7 +232,11 @@ func (t *Transaction) authorizersContains(address flow.Address) bool {
 }
 
 // SetProposer sets the proposer for transaction.
-func (t *Transaction) SetProposer(proposer *flow.Account, keyIndex int) *Transaction {
+func (t *Transaction) SetProposer(proposer *flow.Account, keyIndex int) (*Transaction, error) {
+	if len(proposer.Keys) <= keyIndex {
+		return nil, fmt.Errorf("failed to retrieve proposer key at index %d", keyIndex)
+	}
+
 	t.proposer = proposer
 	proposerKey := proposer.Keys[keyIndex]
 
@@ -242,7 +246,7 @@ func (t *Transaction) SetProposer(proposer *flow.Account, keyIndex int) *Transac
 		proposerKey.SequenceNumber,
 	)
 
-	return t
+	return t, nil
 }
 
 // SetPayer sets the payer for transaction.


### PR DESCRIPTION
Closes #???

## Description

Hi guys,

Was playing around with Flow tutorial from [NFT School](https://nftschool.dev/tutorial/flow-nft-marketplace) and encountered an error when trying to override a signer using `--signer` flag:

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/onflow/flow-cli/pkg/flowkit.(*Transaction).SetProposer(0xc000174c00, 0xc0000e8428, 0xc0005d1928)
        github.com/onflow/flow-cli/pkg/flowkit/transaction.go:208 +0xb5
github.com/onflow/flow-cli/pkg/flowkit/services.(*Transactions).Build(0xc00032d7a0, {0x17, 0x9b, 0x6b, 0x1c, 0xb6, 0x75, 0x5e, 0x31}, {0xc0005d1a98, ...}, ...)
        github.com/onflow/flow-cli/pkg/flowkit/services/transactions.go:104 +0x1a5
github.com/onflow/flow-cli/pkg/flowkit/services.(*Transactions).Send(0xc00032d7a0, 0xc0000a2b68, {0xc0000d3800, 0x4ea, 0x6ea}, {0x7ffeefbff53f, 0x20}, 0xc000046218, {0x5b21430, 0x0, ...}, ...)
        github.com/onflow/flow-cli/pkg/flowkit/services/transactions.go:216 +0x1c6
github.com/onflow/flow-cli/internal/transactions.send({0xc00032cd20, 0x1, 0x3}, {0x51a4a88, 0xc0003346a0}, {{0x0, 0x0}, {0x4ecf009, 0x4}, {0x0, ...}, ...}, ...)
        github.com/onflow/flow-cli/internal/transactions/send.go:89 +0x312
github.com/onflow/flow-cli/internal/command.Command.AddToParent.func1(0x5add9c0, {0xc00032cd20, 0x1, 0x3})
        github.com/onflow/flow-cli/internal/command/command.go:116 +0x315
github.com/spf13/cobra.(*Command).execute(0x5add9c0, {0xc00003c210, 0x3, 0x3})
        github.com/spf13/cobra@v1.1.3/command.go:856 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001fd180)
        github.com/spf13/cobra@v1.1.3/command.go:960 +0x3ad
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
        github.com/onflow/flow-cli/cmd/flow/main.go:69 +0x319
```

Turns out I've created an account with public key which simply didn't exist in emulator keychain (a copy-paste miss). This minor change returns an error message in that case instead of generic panic dump:

```
➜  petstore git:(master) ✗ flow transactions send src/flow/transaction/MintToken.cdc '{"name": "Max", "breed": "Bulldog"}' --signer test-account

❌ Command Error: failed to retrieve proposer key at index 0
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
