### PR TITLE
Add faucet link on keys generate

### DIFF
--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -32,6 +32,8 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowkit/util"
 )
 
+const faucetHost = "https://testnet-faucet.onflow.org/"
+
 var Cmd = &cobra.Command{
 	Use:              "keys",
 	Short:            "Utilities to manage keys",
@@ -66,7 +68,7 @@ func (k *KeyResult) String() string {
 
 	if k.privateKey != nil {
 		// build the faucet link
-		link := fmt.Sprintf("https://testnet-faucet.onflow.org/?key=%x", k.publicKey.Encode())
+		link := fmt.Sprintf("%s?key=%x", faucetHost, k.publicKey.Encode())
 		if k.privateKey.Algorithm() != crypto.ECDSA_P256 {
 			link = fmt.Sprintf("%s&sig-algo=%s", link, k.privateKey.Algorithm().String())
 		}

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -65,6 +65,18 @@ func (k *KeyResult) String() string {
 	writer := util.CreateTabWriter(&b)
 
 	if k.privateKey != nil {
+		// build the faucet link
+		link := fmt.Sprintf("https://testnet-faucet.onflow.org/?key=%x", k.publicKey.Encode())
+		if k.privateKey.Algorithm() != crypto.ECDSA_P256 {
+			link = fmt.Sprintf("%s&sig-algo=%s", link, k.privateKey.Algorithm().String())
+		}
+
+		fmt.Printf(
+			"%s If you want to create an account on testnet with the generated keys use this link:\n%s \n\n",
+			output.TryEmoji(),
+			link,
+		)
+
 		_, _ = fmt.Fprintf(writer, "%s Store private key safely and don't share with anyone! \n", output.StopEmoji())
 		_, _ = fmt.Fprintf(writer, "Private Key \t %x \n", k.privateKey.Encode())
 	}


### PR DESCRIPTION
Closes #455 

## Description
Added faucet link generation, but I feel we can improve this with an issue @psiemens opened a while ago: https://github.com/onflow/flow-cli/issues/37

This would actually be a nice feature.

This is the current output
```
🙏 If you want to create an account on testnet with the generated keys use this link:
https://testnet-faucet.onflow.org/?key=4a17c84e40174f6456392b271468f482b3ca1cc36dd5954f52d925e30e7a6358b99ab3bead2d4dac743cd1ba9beeddc55b2a7b4722b1b6b42f 


🔴️ Store private key safely and don't share with anyone! 
Private Key 	 39d3bb9e1bea621eeee005e5165c741b60350ff35e32249a34a4f67a 
Public Key 	 4a17c84e40174f6456392b271468f482effae26dd5954f52d925e30e7a6358b99ab3bead2d4dac743cd1ba9beeddc55b2a7b4722b1b6b42f 


```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
