### PR TITLE
Fix example code and typos in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ contracts](https://docs.onflow.org/core-contracts) that have already been deploy
 
 ⚠️ If we use an alias for the contract we should not specify it in the `deployment` section for that network. 
 
-Our example bellow should not include `FungibleToken` in  `deployment` section for testnet and emulator network.
+Our example below should not include `FungibleToken` in  `deployment` section for testnet and emulator network.
 
 ```json
 ...

--- a/docs/deploy-project-contracts.md
+++ b/docs/deploy-project-contracts.md
@@ -110,12 +110,12 @@ source file location.
 The rewritten versions are then deployed to their respective targets,
 leaving the original contract files unchanged.
 
-In the example above, the `Bar` contract would be rewritten like this:
+In the example above, the `KittyItems` contract would be rewritten like this:
 
-```cadence:title=Bar.cdc
-import Foo from 0xf8d6e0586b0a20c7
+```cadence:title=KittyItems.cdc
+import NonFungibleToken from 0xf8d6e0586b0a20c7
 
-pub contract Bar { 
+pub contract KittyItems { 
   // ...
 }
 ```

--- a/docs/initialize-configuration.md
+++ b/docs/initialize-configuration.md
@@ -27,8 +27,8 @@ Reset configuration using: 'flow init --reset'
 
 ### Error Handling
 
-Existing configuration will cause the error bellow. 
-You should initialize in an empty folder or reset configuration using `--reset` flag 
+Existing configuration will cause the error below.
+You should initialize in an empty folder or reset configuration using `--reset` flag
 or by removing the configuration file first.
 ```shell
 ❌ Command Error: configuration already exists at: flow.json, if you want to reset configuration use the reset flag


### PR DESCRIPTION
## Description

This PR ... 
- ... fixes the spelling of the word `bellow` in the docs
- ... updates the referenced contract code in `docs/deploy-project-contracts.md`. The example uses a `Foo` and a `Bar` contract but references `"the example above"`. The example above uses the `NonFungibleToken` and `KittyItems` contract which is misleading when you are reading the docs.

I'm happy to rebase (and/or squash) the PR if you'd like to merge this.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
