### PR TITLE
Add a command to print the config path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	InitCommand.AddToParent(Cmd)
+	PathCommand.AddToParent(Cmd)
 	Cmd.AddCommand(AddCmd)
 	Cmd.AddCommand(RemoveCmd)
 }

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -1,0 +1,67 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/config"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+)
+
+type flagsPath struct{}
+
+var pathFlags = flagsPath{}
+
+var PathCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:   "path",
+		Short: "Initialize a new configuration",
+	},
+	Flags: &pathFlags,
+	Run:   Path,
+}
+
+func Path(
+	_ []string,
+	_ flowkit.ReaderWriter,
+	globalFlags command.GlobalFlags,
+	_ *services.Services,
+) (command.Result, error) {
+
+	return PathResult(config.AnyExists(globalFlags.ConfigPaths)), nil
+}
+
+type PathResult string
+
+var _ command.Result = PathResult("")
+
+func (r PathResult) JSON() interface{} {
+	return r
+}
+
+func (r PathResult) String() string {
+	return string(r)
+}
+
+func (r PathResult) Oneliner() string {
+	return string(r)
+}

--- a/pkg/flowkit/config/config.go
+++ b/pkg/flowkit/config/config.go
@@ -116,7 +116,7 @@ func GlobalPath() string {
 // DefaultPaths determines default paths for configuration.
 func DefaultPaths() []string {
 	return []string{
-		GlobalPath(),
 		DefaultPath,
+		GlobalPath(),
 	}
 }

--- a/pkg/flowkit/config/loader.go
+++ b/pkg/flowkit/config/loader.go
@@ -37,6 +37,17 @@ func Exists(path string) bool {
 	return !info.IsDir()
 }
 
+// AnyExists checks if any of the project configuration exists
+// and returns it. If none of the files exists, returns "".
+func AnyExists(paths []string) string {
+	for _, path := range paths {
+		if Exists(path) {
+			return path
+		}
+	}
+	return ""
+}
+
 // Parser is interface for any configuration format parser to implement.
 type Parser interface {
 	Serialize(*Config) ([]byte, error)


### PR DESCRIPTION
## Description

For https://github.com/onflow/vscode-cadence/pull/79
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
