### PR TITLE
Bugfix/deploy account with name

### DIFF
--- a/pkg/flowkit/account.go
+++ b/pkg/flowkit/account.go
@@ -152,17 +152,6 @@ func (a *Accounts) Remove(name string) error {
 	return nil
 }
 
-// ByAddress get an account by address.
-func (a Accounts) ByAddress(address flow.Address) (*Account, error) {
-	for i := range a {
-		if a[i].address == address {
-			return &a[i], nil
-		}
-	}
-
-	return nil, fmt.Errorf("could not find account with address %s in the configuration", address)
-}
-
 // ByName get an account by name or returns and error if no account found
 func (a Accounts) ByName(name string) (*Account, error) {
 	for i := range a {

--- a/pkg/flowkit/account.go
+++ b/pkg/flowkit/account.go
@@ -163,17 +163,6 @@ func (a Accounts) ByAddress(address flow.Address) (*Account, error) {
 	return nil, fmt.Errorf("could not find account with address %s in the configuration", address)
 }
 
-// ByAddress get an account by address.
-func (a Accounts) ByAddressAndAccountName(address flow.Address, accountName string) (*Account, error) {
-	for i := range a {
-		if a[i].address == address && a[i].name == accountName {
-			return &a[i], nil
-		}
-	}
-
-	return nil, fmt.Errorf("could not find account with address %s in the configuration", address)
-}
-
 // ByName get an account by name or returns and error if no account found
 func (a Accounts) ByName(name string) (*Account, error) {
 	for i := range a {

--- a/pkg/flowkit/account.go
+++ b/pkg/flowkit/account.go
@@ -152,6 +152,17 @@ func (a *Accounts) Remove(name string) error {
 	return nil
 }
 
+// ByAddress get an account by address.
+func (a Accounts) ByAddress(address flow.Address) (*Account, error) {
+	for i := range a {
+		if a[i].address == address {
+			return &a[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find account with address %s in the configuration", address)
+}
+
 // ByName get an account by name or returns and error if no account found
 func (a Accounts) ByName(name string) (*Account, error) {
 	for i := range a {

--- a/pkg/flowkit/account.go
+++ b/pkg/flowkit/account.go
@@ -163,6 +163,17 @@ func (a Accounts) ByAddress(address flow.Address) (*Account, error) {
 	return nil, fmt.Errorf("could not find account with address %s in the configuration", address)
 }
 
+// ByAddress get an account by address.
+func (a Accounts) ByAddressAndAccountName(address flow.Address, accountName string) (*Account, error) {
+	for i := range a {
+		if a[i].address == address && a[i].name == accountName {
+			return &a[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find account with address %s in the configuration", address)
+}
+
 // ByName get an account by name or returns and error if no account found
 func (a Accounts) ByName(name string) (*Account, error) {
 	for i := range a {

--- a/pkg/flowkit/contracts/contracts.go
+++ b/pkg/flowkit/contracts/contracts.go
@@ -39,6 +39,7 @@ type Contract struct {
 	name         string
 	source       string
 	target       flow.Address
+	accountName  string
 	code         string
 	args         []cadence.Value
 	program      *ast.Program
@@ -52,6 +53,7 @@ func newContract(
 	contractSource,
 	contractCode string,
 	target flow.Address,
+	accountName string,
 	args []cadence.Value,
 ) (*Contract, error) {
 	program, err := parser2.ParseProgram(contractCode)
@@ -64,6 +66,7 @@ func newContract(
 		name:         contractName,
 		source:       contractSource,
 		target:       target,
+		accountName:  accountName,
 		code:         contractCode,
 		program:      program,
 		args:         args,
@@ -111,7 +114,9 @@ func (c *Contract) TranspiledCode() string {
 
 	return code
 }
-
+func (c *Contract) AccountName() string {
+	return c.accountName
+}
 func (c *Contract) Target() flow.Address {
 	return c.target
 }

--- a/pkg/flowkit/contracts/contracts.go
+++ b/pkg/flowkit/contracts/contracts.go
@@ -35,16 +35,16 @@ import (
 )
 
 type Contract struct {
-	index        int64
-	name         string
-	source       string
-	target       flow.Address
-	accountName  string
-	code         string
-	args         []cadence.Value
-	program      *ast.Program
-	dependencies map[string]*Contract
-	aliases      map[string]flow.Address
+	index          int64
+	name           string
+	source         string
+	accountAddress flow.Address
+	accountName    string
+	code           string
+	args           []cadence.Value
+	program        *ast.Program
+	dependencies   map[string]*Contract
+	aliases        map[string]flow.Address
 }
 
 func newContract(
@@ -52,7 +52,7 @@ func newContract(
 	contractName,
 	contractSource,
 	contractCode string,
-	target flow.Address,
+	accountAddress flow.Address,
 	accountName string,
 	args []cadence.Value,
 ) (*Contract, error) {
@@ -62,16 +62,16 @@ func newContract(
 	}
 
 	return &Contract{
-		index:        int64(index),
-		name:         contractName,
-		source:       contractSource,
-		target:       target,
-		accountName:  accountName,
-		code:         contractCode,
-		program:      program,
-		args:         args,
-		dependencies: make(map[string]*Contract),
-		aliases:      make(map[string]flow.Address),
+		index:          int64(index),
+		name:           contractName,
+		source:         contractSource,
+		accountAddress: accountAddress,
+		accountName:    accountName,
+		code:           contractCode,
+		program:        program,
+		args:           args,
+		dependencies:   make(map[string]*Contract),
+		aliases:        make(map[string]flow.Address),
 	}, nil
 }
 
@@ -118,7 +118,7 @@ func (c *Contract) AccountName() string {
 	return c.accountName
 }
 func (c *Contract) Target() flow.Address {
-	return c.target
+	return c.accountAddress
 }
 
 func (c *Contract) Dependencies() map[string]*Contract {

--- a/pkg/flowkit/contracts/contracts_test.go
+++ b/pkg/flowkit/contracts/contracts_test.go
@@ -38,6 +38,7 @@ type testContract struct {
 	source               string
 	code                 []byte
 	target               flow.Address
+	accountName          string
 	expectedDependencies []testContract
 }
 
@@ -230,6 +231,7 @@ func TestResolveImports(t *testing.T) {
 					contract.name,
 					contract.source,
 					contract.target,
+					contract.accountName,
 					[]cadence.Value{nil},
 				)
 				assert.NoError(t, err)
@@ -279,6 +281,7 @@ func TestContractDeploymentOrder(t *testing.T) {
 					contract.name,
 					contract.source,
 					contract.target,
+					contract.accountName,
 					[]cadence.Value{nil},
 				)
 				assert.NoError(t, err)

--- a/pkg/flowkit/contracts/contracts_test.go
+++ b/pkg/flowkit/contracts/contracts_test.go
@@ -37,7 +37,7 @@ type testContract struct {
 	name                 string
 	source               string
 	code                 []byte
-	target               flow.Address
+	accountAddress       flow.Address
 	accountName          string
 	expectedDependencies []testContract
 }
@@ -48,7 +48,7 @@ var testContractA = testContract{
 	name:                 "ContractA",
 	source:               "ContractA.cdc",
 	code:                 []byte(`pub contract ContractA {}`),
-	target:               addresses.New(),
+	accountAddress:       addresses.New(),
 	expectedDependencies: nil,
 }
 
@@ -56,7 +56,7 @@ var testContractB = testContract{
 	name:                 "ContractB",
 	source:               "ContractB.cdc",
 	code:                 []byte(`pub contract ContractB {}`),
-	target:               addresses.New(),
+	accountAddress:       addresses.New(),
 	expectedDependencies: nil,
 }
 
@@ -68,7 +68,7 @@ var testContractC = testContract{
     
         pub contract ContractC {}
     `),
-	target:               addresses.New(),
+	accountAddress:       addresses.New(),
 	expectedDependencies: []testContract{testContractA},
 }
 
@@ -80,7 +80,7 @@ var testContractD = testContract{
 
         pub contract ContractD {}
     `),
-	target:               addresses.New(),
+	accountAddress:       addresses.New(),
 	expectedDependencies: []testContract{testContractC},
 }
 
@@ -102,7 +102,7 @@ var testContractF = testContract{
 
         pub contract ContractF {}
     `),
-	target: addresses.New(),
+	accountAddress: addresses.New(),
 }
 
 func init() {
@@ -120,7 +120,7 @@ var testContractG = testContract{
 
         pub contract ContractG {}
     `),
-	target:               addresses.New(),
+	accountAddress:       addresses.New(),
 	expectedDependencies: []testContract{testContractA, testContractB},
 }
 
@@ -132,7 +132,7 @@ var testContractH = testContract{
 
         pub contract ContractH {}
     `),
-	target:               addresses.New(),
+	accountAddress:       addresses.New(),
 	expectedDependencies: nil,
 }
 
@@ -230,7 +230,7 @@ func TestResolveImports(t *testing.T) {
 				err := p.AddContractSource(
 					contract.name,
 					contract.source,
-					contract.target,
+					contract.accountAddress,
 					contract.accountName,
 					[]cadence.Value{nil},
 				)
@@ -262,7 +262,7 @@ func TestResolveImports(t *testing.T) {
 
 					assert.Equal(t, contract.Dependencies()[dependency.source], contractDependency)
 
-					assert.Contains(t, contract.TranspiledCode(), dependency.target.Hex())
+					assert.Contains(t, contract.TranspiledCode(), dependency.accountAddress.Hex())
 				}
 			}
 		})
@@ -280,7 +280,7 @@ func TestContractDeploymentOrder(t *testing.T) {
 				err := p.AddContractSource(
 					contract.name,
 					contract.source,
-					contract.target,
+					contract.accountAddress,
 					contract.accountName,
 					[]cadence.Value{nil},
 				)

--- a/pkg/flowkit/contracts/preprocessor.go
+++ b/pkg/flowkit/contracts/preprocessor.go
@@ -49,6 +49,7 @@ func (p *Preprocessor) AddContractSource(
 	contractName,
 	contractSource string,
 	target flow.Address,
+	accountName string,
 	args []cadence.Value,
 ) error {
 	contractCode, err := p.loader.Load(contractSource)
@@ -62,6 +63,7 @@ func (p *Preprocessor) AddContractSource(
 		contractSource,
 		string(contractCode),
 		target,
+		accountName,
 		args,
 	)
 	if err != nil {

--- a/pkg/flowkit/contracts/preprocessor.go
+++ b/pkg/flowkit/contracts/preprocessor.go
@@ -48,7 +48,7 @@ func NewPreprocessor(loader Loader, aliases map[string]string) *Preprocessor {
 func (p *Preprocessor) AddContractSource(
 	contractName,
 	contractSource string,
-	target flow.Address,
+	accountAddress flow.Address,
 	accountName string,
 	args []cadence.Value,
 ) error {
@@ -62,7 +62,7 @@ func (p *Preprocessor) AddContractSource(
 		contractName,
 		contractSource,
 		string(contractCode),
-		target,
+		accountAddress,
 		accountName,
 		args,
 	)

--- a/pkg/flowkit/contracts/resolver.go
+++ b/pkg/flowkit/contracts/resolver.go
@@ -92,7 +92,7 @@ func (r *Resolver) getSourceTarget(
 ) map[string]string {
 	sourceTarget := make(map[string]string)
 	for _, contract := range contracts {
-		sourceTarget[path.Clean(contract.Source)] = contract.Target.String()
+		sourceTarget[path.Clean(contract.Source)] = contract.AccountAddress.String()
 	}
 
 	for source, target := range aliases {

--- a/pkg/flowkit/contracts/resolver_test.go
+++ b/pkg/flowkit/contracts/resolver_test.go
@@ -36,13 +36,13 @@ func cleanCode(code []byte) string {
 func TestResolver(t *testing.T) {
 
 	contracts := []flowkit.Contract{{
-		Name:   "Kibble",
-		Source: "./tests/Kibble.cdc",
-		Target: flow.HexToAddress("0x1"),
+		Name:           "Kibble",
+		Source:         "./tests/Kibble.cdc",
+		AccountAddress: flow.HexToAddress("0x1"),
 	}, {
-		Name:   "FT",
-		Source: "./tests/FT.cdc",
-		Target: flow.HexToAddress("0x2"),
+		Name:           "FT",
+		Source:         "./tests/FT.cdc",
+		AccountAddress: flow.HexToAddress("0x2"),
 	}}
 
 	aliases := map[string]string{

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -95,7 +95,7 @@ func (p *Project) Init(
 //
 // Retrieve all the contracts for specified network, sort them for deployment
 // deploy one by one and replace the imports in the contract source so it corresponds
-// to the account address the contract was deployed to.
+// to the account name the contract was deployed to.
 func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, error) {
 	if p.state == nil {
 		return nil, config.ErrDoesNotExist

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -161,7 +161,7 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 			return nil, err
 		}
 
-		targetAccount, err := p.state.Accounts().ByAddressAndAccountName(contract.Target(), contract.AccountName())
+		targetAccount, err := p.state.Accounts().ByName(contract.AccountName())
 
 		if err != nil {
 			return nil, fmt.Errorf("target account for deploying contract not found in configuration")

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -126,7 +126,7 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 		err := processor.AddContractSource(
 			contract.Name,
 			contract.Source,
-			contract.Target,
+			contract.AccountAddress,
 			contract.AccountName,
 			contract.Args,
 		)

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -127,6 +127,7 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 			contract.Name,
 			contract.Source,
 			contract.Target,
+			contract.AccountName,
 			contract.Args,
 		)
 		if err != nil {
@@ -160,7 +161,7 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 			return nil, err
 		}
 
-		targetAccount, err := p.state.Accounts().ByAddress(contract.Target())
+		targetAccount, err := p.state.Accounts().ByAddressAndAccountName(contract.Target(), contract.AccountName())
 
 		if err != nil {
 			return nil, fmt.Errorf("target account for deploying contract not found in configuration")

--- a/pkg/flowkit/state.go
+++ b/pkg/flowkit/state.go
@@ -42,10 +42,11 @@ type ReaderWriter interface {
 
 // Contract is a Cadence contract definition for a project.
 type Contract struct {
-	Name   string
-	Source string
-	Target flow.Address
-	Args   []cadence.Value
+	Name        string
+	Source      string
+	Target      flow.Address
+	AccountName string
+	Args        []cadence.Value
 }
 
 // State manages the state for a Flow project.
@@ -192,10 +193,11 @@ func (p *State) DeploymentContractsByNetwork(network string) ([]Contract, error)
 			}
 
 			contract := Contract{
-				Name:   c.Name,
-				Source: path.Clean(c.Source),
-				Target: account.address,
-				Args:   deploymentContract.Args,
+				Name:        c.Name,
+				Source:      path.Clean(c.Source),
+				Target:      account.address,
+				AccountName: account.name,
+				Args:        deploymentContract.Args,
 			}
 
 			contracts = append(contracts, contract)

--- a/pkg/flowkit/state.go
+++ b/pkg/flowkit/state.go
@@ -42,11 +42,11 @@ type ReaderWriter interface {
 
 // Contract is a Cadence contract definition for a project.
 type Contract struct {
-	Name        string
-	Source      string
-	Target      flow.Address
-	AccountName string
-	Args        []cadence.Value
+	Name           string
+	Source         string
+	AccountAddress flow.Address
+	AccountName    string
+	Args           []cadence.Value
 }
 
 // State manages the state for a Flow project.
@@ -193,11 +193,11 @@ func (p *State) DeploymentContractsByNetwork(network string) ([]Contract, error)
 			}
 
 			contract := Contract{
-				Name:        c.Name,
-				Source:      path.Clean(c.Source),
-				Target:      account.address,
-				AccountName: account.name,
-				Args:        deploymentContract.Args,
+				Name:           c.Name,
+				Source:         path.Clean(c.Source),
+				AccountAddress: account.address,
+				AccountName:    account.name,
+				Args:           deploymentContract.Args,
 			}
 
 			contracts = append(contracts, contract)

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -151,7 +151,109 @@ func generateComplexProject() State {
 
 	return *p
 }
+func generateComplexProjectSameAddress() State {
+	config := config.Config{
+		Emulators: config.Emulators{{
+			Name:           "default",
+			Port:           9000,
+			ServiceAccount: "emulator-account",
+		}},
+		Contracts: config.Contracts{{
+			Name:    "NonFungibleToken",
+			Source:  "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
+			Network: "emulator",
+		}, {
+			Name:    "FungibleToken",
+			Source:  "../hungry-kitties/cadence/contracts/FungibleToken.cdc",
+			Network: "emulator",
+		}, {
+			Name:    "Kibble",
+			Source:  "./cadence/kibble/contracts/Kibble.cdc",
+			Network: "emulator",
+		}, {
+			Name:    "KittyItems",
+			Source:  "./cadence/kittyItems/contracts/KittyItems.cdc",
+			Network: "emulator",
+		}, {
+			Name:    "KittyItemsMarket",
+			Source:  "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc",
+			Network: "emulator",
+		}, {
+			Name:    "KittyItemsMarket",
+			Source:  "0x123123123",
+			Network: "testnet",
+		}},
+		Deployments: config.Deployments{{
+			Network: "emulator",
+			Account: "emulator-account",
+			Contracts: []config.ContractDeployment{
+				{Name: "KittyItems", Args: nil},
+				{Name: "KittyItemsMarket", Args: nil},
+			},
+		}, {
+			Network: "emulator",
+			Account: "account-4",
+			Contracts: []config.ContractDeployment{
+				{Name: "FungibleToken", Args: nil},
+				{Name: "NonFungibleToken", Args: nil},
+				{Name: "Kibble", Args: nil},
+				{Name: "KittyItems", Args: nil},
+				{Name: "KittyItemsMarket", Args: nil},
+			},
+		}, {
+			Network: "testnet",
+			Account: "testnet-account",
+			Contracts: []config.ContractDeployment{
+				{Name: "FungibleToken", Args: nil},
+				{Name: "NonFungibleToken", Args: nil},
+				{Name: "Kibble", Args: nil},
+				{Name: "KittyItems", Args: nil},
+			},
+		}},
+		Accounts: config.Accounts{{
+			Name:    "emulator-account",
+			Address: flow.HexToAddress("f8d6e0586b0a20c7"),
+			Key: config.AccountKey{
+				Type:       config.KeyTypeHex,
+				Index:      0,
+				SigAlgo:    crypto.ECDSA_P256,
+				HashAlgo:   crypto.SHA3_256,
+				PrivateKey: keys()[0],
+			},
+		}, {
+			Name:    "emulator-account-2",
+			Address: flow.HexToAddress("4ada5fbd7073699b"),
+			Key: config.AccountKey{
+				Type:       config.KeyTypeHex,
+				Index:      0,
+				SigAlgo:    crypto.ECDSA_P256,
+				HashAlgo:   crypto.SHA3_256,
+				PrivateKey: keys()[1],
+			},
+		}, {
+			Name:    "testnet-account",
+			Address: flow.HexToAddress("4ada5fbd7073699b"),
+			Key: config.AccountKey{
+				Type:       config.KeyTypeHex,
+				Index:      0,
+				SigAlgo:    crypto.ECDSA_P256,
+				HashAlgo:   crypto.SHA3_256,
+				PrivateKey: keys()[2],
+			},
+		}},
+		Networks: config.Networks{{
+			Name: "emulator",
+			Host: "127.0.0.1.3569",
+		}},
+	}
 
+	p, err := newProject(&config, composer, af)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return *p
+}
 func generateSimpleProject() State {
 	config := config.Config{
 		Emulators: config.Emulators{{
@@ -351,7 +453,12 @@ func Test_AccountByAddressSimple(t *testing.T) {
 
 	assert.Equal(t, acc.name, "emulator-account")
 }
+func Test_AccountByAddressAndNameSimple(t *testing.T) {
+	p := generateSimpleProject()
+	acc, _ := p.Accounts().ByAddressAndAccountName(flow.ServiceAddress("flow-emulator"), "emulator-account")
 
+	assert.Equal(t, acc.name, "emulator-account")
+}
 func Test_AccountByNameSimple(t *testing.T) {
 	p := generateSimpleProject()
 	acc, _ := p.Accounts().ByName("emulator-account")
@@ -436,7 +543,17 @@ func Test_AccountByAddressComplex(t *testing.T) {
 	assert.Equal(t, acc1.name, "account-4")
 	assert.Equal(t, acc2.name, "account-2")
 }
+func Test_AccountByAddressAndAccountNameComplex(t *testing.T) {
+	p := generateComplexProjectSameAddress()
+	acc1, err := p.Accounts().ByAddressAndAccountName(flow.HexToAddress("f8d6e0586b0a20c7"), "emulator-account")
 
+	assert.NoError(t, err)
+	acc2, err := p.Accounts().ByAddressAndAccountName(flow.HexToAddress("4ada5fbd7073699b"), "testnet-account")
+	assert.NoError(t, err)
+
+	assert.Equal(t, acc1.name, "emulator-account")
+	assert.Equal(t, acc2.name, "testnet-account")
+}
 func Test_AccountByNameComplex(t *testing.T) {
 	p := generateComplexProject()
 	acc, _ := p.Accounts().ByName("account-2")
@@ -526,7 +643,7 @@ func Test_ChangingState(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, (*pkey).String(), pk.String())
 
-	bar, err := p.Accounts().ByAddress(flow.HexToAddress("0x1"))
+	bar, err := p.Accounts().ByAddressAndAccountName(flow.HexToAddress("0x1"), "foo")
 	assert.NoError(t, err)
 	bar.SetName("zoo")
 	zoo, err := p.Accounts().ByName("zoo")

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -137,98 +137,15 @@ func generateComplexProject() State {
 				HashAlgo:   crypto.SHA3_256,
 				PrivateKey: keys()[2],
 			},
-		}},
-		Networks: config.Networks{{
-			Name: "emulator",
-			Host: "127.0.0.1.3569",
-		}},
-	}
-
-	p, err := newProject(&config, composer, af)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	return *p
-}
-func generateComplexProjectSameAddress() State {
-	config := config.Config{
-		Emulators: config.Emulators{{
-			Name:           "default",
-			Port:           9000,
-			ServiceAccount: "emulator-account",
-		}},
-		Contracts: config.Contracts{{
-			Name:    "NonFungibleToken",
-			Source:  "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
-			Network: "emulator",
-		}, {
-			Name:    "FungibleToken",
-			Source:  "../hungry-kitties/cadence/contracts/FungibleToken.cdc",
-			Network: "emulator",
-		}, {
-			Name:    "Kibble",
-			Source:  "./cadence/kibble/contracts/Kibble.cdc",
-			Network: "emulator",
-		}, {
-			Name:    "KittyItems",
-			Source:  "./cadence/kittyItems/contracts/KittyItems.cdc",
-			Network: "emulator",
-		}, {
-			Name:    "KittyItemsMarket",
-			Source:  "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc",
-			Network: "emulator",
-		}, {
-			Name:    "KittyItemsMarket",
-			Source:  "0x123123123",
-			Network: "testnet",
-		}},
-		Deployments: config.Deployments{{
-			Network: "emulator",
-			Account: "emulator-account",
-			Contracts: []config.ContractDeployment{
-				{Name: "KittyItems", Args: nil},
-				{Name: "KittyItemsMarket", Args: nil},
-			},
-		}, {
-			Network: "testnet",
-			Account: "testnet-account",
-			Contracts: []config.ContractDeployment{
-				{Name: "FungibleToken", Args: nil},
-				{Name: "NonFungibleToken", Args: nil},
-				{Name: "Kibble", Args: nil},
-				{Name: "KittyItems", Args: nil},
-			},
-		}},
-		Accounts: config.Accounts{{
-			Name:    "emulator-account",
-			Address: flow.HexToAddress("f8d6e0586b0a20c7"),
-			Key: config.AccountKey{
-				Type:       config.KeyTypeHex,
-				Index:      0,
-				SigAlgo:    crypto.ECDSA_P256,
-				HashAlgo:   crypto.SHA3_256,
-				PrivateKey: keys()[0],
-			},
 		}, {
 			Name:    "emulator-account-2",
-			Address: flow.HexToAddress("4ada5fbd7073699b"),
+			Address: flow.HexToAddress("2c1162386b0a245f"),
 			Key: config.AccountKey{
 				Type:       config.KeyTypeHex,
 				Index:      0,
 				SigAlgo:    crypto.ECDSA_P256,
 				HashAlgo:   crypto.SHA3_256,
 				PrivateKey: keys()[1],
-			},
-		}, {
-			Name:    "testnet-account",
-			Address: flow.HexToAddress("4ada5fbd7073699b"),
-			Key: config.AccountKey{
-				Type:       config.KeyTypeHex,
-				Index:      0,
-				SigAlgo:    crypto.ECDSA_P256,
-				HashAlgo:   crypto.SHA3_256,
-				PrivateKey: keys()[2],
 			},
 		}},
 		Networks: config.Networks{{
@@ -436,13 +353,6 @@ func Test_EmulatorConfigSimple(t *testing.T) {
 	assert.Equal(t, emulatorServiceAccount.key.ToConfig().PrivateKey, keys()[0])
 	assert.Equal(t, flow.ServiceAddress("flow-emulator"), emulatorServiceAccount.Address())
 }
-
-func Test_AccountByAddressSimple(t *testing.T) {
-	p := generateSimpleProject()
-	acc, _ := p.Accounts().ByAddress(flow.ServiceAddress("flow-emulator"))
-
-	assert.Equal(t, acc.name, "emulator-account")
-}
 func Test_AccountByNameSimple(t *testing.T) {
 	p := generateSimpleProject()
 	acc, _ := p.Accounts().ByName("emulator-account")
@@ -515,28 +425,16 @@ func Test_EmulatorConfigComplex(t *testing.T) {
 	assert.Equal(t, emulatorServiceAccount.key.ToConfig().PrivateKey, keys()[0])
 	assert.Equal(t, emulatorServiceAccount.Address(), flow.ServiceAddress("flow-emulator"))
 }
-
-func Test_AccountByAddressComplex(t *testing.T) {
-	p := generateComplexProject()
-	acc1, err := p.Accounts().ByAddress(flow.HexToAddress("f8d6e0586b0a20c1"))
-
-	assert.NoError(t, err)
-	acc2, err := p.Accounts().ByAddress(flow.HexToAddress("0x2c1162386b0a245f"))
-	assert.NoError(t, err)
-
-	assert.Equal(t, acc1.name, "account-4")
-	assert.Equal(t, acc2.name, "account-2")
-}
 func Test_AccountByNameWithDuplicateAddress(t *testing.T) {
-	p := generateComplexProjectSameAddress()
+	p := generateComplexProject()
 	acc1, err := p.Accounts().ByName("emulator-account")
 
 	assert.NoError(t, err)
-	acc2, err := p.Accounts().ByName("testnet-account")
+	acc2, err := p.Accounts().ByName("emulator-account-2")
 	assert.NoError(t, err)
 
 	assert.Equal(t, acc1.name, "emulator-account")
-	assert.Equal(t, acc2.name, "testnet-account")
+	assert.Equal(t, acc2.name, "emulator-account-2")
 }
 func Test_AccountByNameComplex(t *testing.T) {
 	p := generateComplexProject()

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -353,6 +353,14 @@ func Test_EmulatorConfigSimple(t *testing.T) {
 	assert.Equal(t, emulatorServiceAccount.key.ToConfig().PrivateKey, keys()[0])
 	assert.Equal(t, flow.ServiceAddress("flow-emulator"), emulatorServiceAccount.Address())
 }
+
+func Test_AccountByAddressSimple(t *testing.T) {
+	p := generateSimpleProject()
+	acc, _ := p.Accounts().ByAddress(flow.ServiceAddress("flow-emulator"))
+
+	assert.Equal(t, acc.name, "emulator-account")
+}
+
 func Test_AccountByNameSimple(t *testing.T) {
 	p := generateSimpleProject()
 	acc, _ := p.Accounts().ByName("emulator-account")

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -455,7 +455,7 @@ func Test_AccountByAddressSimple(t *testing.T) {
 }
 func Test_AccountByAddressAndNameSimple(t *testing.T) {
 	p := generateSimpleProject()
-	acc, _ := p.Accounts().ByAddressAndAccountName(flow.ServiceAddress("flow-emulator"), "emulator-account")
+	acc, _ := p.Accounts().ByName("emulator-account")
 
 	assert.Equal(t, acc.name, "emulator-account")
 }
@@ -545,10 +545,10 @@ func Test_AccountByAddressComplex(t *testing.T) {
 }
 func Test_AccountByAddressAndAccountNameComplex(t *testing.T) {
 	p := generateComplexProjectSameAddress()
-	acc1, err := p.Accounts().ByAddressAndAccountName(flow.HexToAddress("f8d6e0586b0a20c7"), "emulator-account")
+	acc1, err := p.Accounts().ByName("emulator-account")
 
 	assert.NoError(t, err)
-	acc2, err := p.Accounts().ByAddressAndAccountName(flow.HexToAddress("4ada5fbd7073699b"), "testnet-account")
+	acc2, err := p.Accounts().ByName("testnet-account")
 	assert.NoError(t, err)
 
 	assert.Equal(t, acc1.name, "emulator-account")
@@ -643,7 +643,7 @@ func Test_ChangingState(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, (*pkey).String(), pk.String())
 
-	bar, err := p.Accounts().ByAddressAndAccountName(flow.HexToAddress("0x1"), "foo")
+	bar, err := p.Accounts().ByName("foo")
 	assert.NoError(t, err)
 	bar.SetName("zoo")
 	zoo, err := p.Accounts().ByName("zoo")

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -191,16 +191,6 @@ func generateComplexProjectSameAddress() State {
 				{Name: "KittyItemsMarket", Args: nil},
 			},
 		}, {
-			Network: "emulator",
-			Account: "account-4",
-			Contracts: []config.ContractDeployment{
-				{Name: "FungibleToken", Args: nil},
-				{Name: "NonFungibleToken", Args: nil},
-				{Name: "Kibble", Args: nil},
-				{Name: "KittyItems", Args: nil},
-				{Name: "KittyItemsMarket", Args: nil},
-			},
-		}, {
 			Network: "testnet",
 			Account: "testnet-account",
 			Contracts: []config.ContractDeployment{
@@ -435,7 +425,7 @@ func Test_GetContractsByNameSimple(t *testing.T) {
 	assert.Len(t, contracts, 1)
 	assert.Equal(t, contracts[0].Name, "NonFungibleToken")
 	assert.Equal(t, contracts[0].Source, "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc")
-	assert.Equal(t, account.Address, contracts[0].Target)
+	assert.Equal(t, account.Address, contracts[0].AccountAddress)
 }
 
 func Test_EmulatorConfigSimple(t *testing.T) {
@@ -450,12 +440,6 @@ func Test_EmulatorConfigSimple(t *testing.T) {
 func Test_AccountByAddressSimple(t *testing.T) {
 	p := generateSimpleProject()
 	acc, _ := p.Accounts().ByAddress(flow.ServiceAddress("flow-emulator"))
-
-	assert.Equal(t, acc.name, "emulator-account")
-}
-func Test_AccountByAddressAndNameSimple(t *testing.T) {
-	p := generateSimpleProject()
-	acc, _ := p.Accounts().ByName("emulator-account")
 
 	assert.Equal(t, acc.name, "emulator-account")
 }
@@ -494,7 +478,7 @@ func Test_GetContractsByNameComplex(t *testing.T) {
 	sort.Strings(sources)
 
 	targets := funk.Map(contracts, func(c Contract) string {
-		return c.Target.String()
+		return c.AccountAddress.String()
 	}).([]string)
 	sort.Strings(targets)
 
@@ -543,7 +527,7 @@ func Test_AccountByAddressComplex(t *testing.T) {
 	assert.Equal(t, acc1.name, "account-4")
 	assert.Equal(t, acc2.name, "account-2")
 }
-func Test_AccountByAddressAndAccountNameComplex(t *testing.T) {
+func Test_AccountByNameWithDuplicateAddress(t *testing.T) {
 	p := generateComplexProjectSameAddress()
 	acc1, err := p.Accounts().ByName("emulator-account")
 

--- a/tests/resources.go
+++ b/tests/resources.go
@@ -274,7 +274,9 @@ func Bob() *flowkit.Account {
 func Charlie() *flowkit.Account {
 	return newAccount("Charlie", "0x3", "seedseedseedseedseedseedseedseedseedseedseedseedCharlie")
 }
-
+func Donald() *flowkit.Account {
+	return newAccount("Donald", "0x3", "seedseedseedseedseedseedseedseedseedseedseedseedDonald")
+}
 func newAccount(name string, address string, seed string) *flowkit.Account {
 	a := &flowkit.Account{}
 	a.SetAddress(flow.HexToAddress(address))


### PR DESCRIPTION
Closes #487 

## Description
This PR changes how the account is found in flow configuration through account name instead of existing method of filtering by account address.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
