### PR TITLE
feature/default emulator now not printed on flow.json

### DIFF
--- a/pkg/flowkit/config/json/config.go
+++ b/pkg/flowkit/config/json/config.go
@@ -73,7 +73,6 @@ func (j *jsonConfig) transformToConfig() (*config.Config, error) {
 
 func transformConfigToJSON(config *config.Config) jsonConfig {
 	return jsonConfig{
-		Emulators:   transformEmulatorsToJSON(config.Emulators),
 		Contracts:   transformContractsToJSON(config.Contracts),
 		Networks:    transformNetworksToJSON(config.Networks),
 		Accounts:    transformAccountsToJSON(config.Accounts),


### PR DESCRIPTION
Closes #400 

## Description

This PR prevents default emulator settings from being printed on flow.json during project initialization. User should still be able to change emulator settings by adding emulator field configuration in flow.json.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
