### PR TITLE
Feature/Enable host configuration for dev wallet

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -65,7 +65,11 @@ Port on which the emulator is listening on.
 Specify a filename for the configuration files, you can provide multiple configuration
 files by using `-f` flag multiple times.
 
+- Flag: `--config-path`
+- Short Flag: `-f`
+- Valid inputs: valid filename
 
-
+Specify a filename for the configuration files, you can provide multiple configuration
+files by using `-f` flag multiple times.
 
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -47,14 +47,15 @@ You can read more about setting up dev-wallet at [FCL Dev Wallet Project](https:
 - Valid inputs: Number
 - Default: `8701`
 
-Port on which the dev wallet server will listen on. 
+Port on which the dev wallet server will listen on.
 
-### Emulator Port
+### Emulator Host
 
-- Flag: `--emulator-port`
-- Valid inputs: Number
+- Flag: `--emulator-host`
+- Valid inputs: a hostname
+- Default: `http://localhost:8080`
 
-Port on which the emulator is listening on.
+Specifies the host configuration for dev wallet
 
 ### Configuration
 
@@ -64,10 +65,6 @@ Port on which the emulator is listening on.
 
 Specify a filename for the configuration files, you can provide multiple configuration
 files by using `-f` flag multiple times.
-
-- Flag: `--config-path`
-- Short Flag: `-f`
-- Valid inputs: valid filename
 
 Specify a filename for the configuration files, you can provide multiple configuration
 files by using `-f` flag multiple times.

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -32,13 +32,12 @@ import (
 )
 
 type flagsAddAccount struct {
-	Name       string `flag:"name" info:"Name for the account"`
-	Address    string `flag:"address" info:"Account address"`
-	KeyIndex   string `default:"0" flag:"key-index" info:"Account key index"`
-	SigAlgo    string `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm of this account key"`
-	HashAlgo   string `default:"SHA3_256" flag:"hash-algo" info:"Hash algorithm to pair with this account key"`
-	Key        string `flag:"private-key" info:"Account private key"`
-	SigAlgoNew string `default:"ECDSA_P256" flag:"sig-algo-new" info:"Signature algorithm of this account key"`
+	Name     string `flag:"name" info:"Name for the account"`
+	Address  string `flag:"address" info:"Account address"`
+	KeyIndex string `default:"0" flag:"key-index" info:"Account key index"`
+	SigAlgo  string `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm of this account key"`
+	HashAlgo string `default:"SHA3_256" flag:"hash-algo" info:"Hash algorithm to pair with this account key"`
+	Key      string `flag:"private-key" info:"Account private key"`
 }
 
 var addAccountFlags = flagsAddAccount{}

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -32,12 +32,13 @@ import (
 )
 
 type flagsAddAccount struct {
-	Name     string `flag:"name" info:"Name for the account"`
-	Address  string `flag:"address" info:"Account address"`
-	KeyIndex string `default:"0" flag:"key-index" info:"Account key index"`
-	SigAlgo  string `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm of this account key"`
-	HashAlgo string `default:"SHA3_256" flag:"hash-algo" info:"Hash algorithm to pair with this account key"`
-	Key      string `flag:"private-key" info:"Account private key"`
+	Name       string `flag:"name" info:"Name for the account"`
+	Address    string `flag:"address" info:"Account address"`
+	KeyIndex   string `default:"0" flag:"key-index" info:"Account key index"`
+	SigAlgo    string `default:"ECDSA_P256" flag:"sig-algo" info:"Signature algorithm of this account key"`
+	HashAlgo   string `default:"SHA3_256" flag:"hash-algo" info:"Hash algorithm to pair with this account key"`
+	Key        string `flag:"private-key" info:"Account private key"`
+	SigAlgoNew string `default:"ECDSA_P256" flag:"sig-algo-new" info:"Signature algorithm of this account key"`
 }
 
 var addAccountFlags = flagsAddAccount{}

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -69,6 +69,7 @@ func wallet(
 		PublicKey:  strings.TrimPrefix(key.PrivateKey.PublicKey().String(), "0x"),
 		AccessNode: walletFlags.Host,
 	}
+
 	srv, err := devWallet.NewHTTPServer(walletFlags.Port, &conf)
 	if err != nil {
 		return nil, err

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -33,7 +33,7 @@ import (
 
 type FlagsWallet struct {
 	Port uint   `default:"8701" flag:"port" info:"Dev wallet port to listen on"`
-	Host string `default:"http://localhost:8080" flag:"wallet-host" info:"Host for access node connection"`
+	Host string `default:"http://localhost:8080" flag:"emulator-host" info:"Host for access node connection"`
 }
 
 var walletFlags = FlagsWallet{}

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -33,7 +33,7 @@ import (
 
 type FlagsWallet struct {
 	Port uint   `default:"8701" flag:"port" info:"Dev wallet port to listen on"`
-	Host string `default:"http://localhost:8888" flag:"emulator-host" info:"Host for access node connection"`
+	Host string `default:"http://localhost:8080" flag:"emulator-host" info:"Host for access node connection"`
 }
 
 var walletFlags = FlagsWallet{}
@@ -69,7 +69,6 @@ func wallet(
 		PublicKey:  strings.TrimPrefix(key.PrivateKey.PublicKey().String(), "0x"),
 		AccessNode: walletFlags.Host,
 	}
-
 	srv, err := devWallet.NewHTTPServer(walletFlags.Port, &conf)
 	if err != nil {
 		return nil, err

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -33,7 +33,7 @@ import (
 
 type FlagsWallet struct {
 	Port uint   `default:"8701" flag:"port" info:"Dev wallet port to listen on"`
-	Host string `default:"http://localhost:8080" flag:"emulator-host" info:"Host for access node connection"`
+	Host string `default:"http://localhost:8888" flag:"emulator-host" info:"Host for access node connection"`
 }
 
 var walletFlags = FlagsWallet{}

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -32,7 +32,8 @@ import (
 )
 
 type FlagsWallet struct {
-	Port uint `default:"8701" flag:"port" info:"Dev wallet port to listen on"`
+	Port uint   `default:"8701" flag:"port" info:"Dev wallet port to listen on"`
+	Host string `default:"http://localhost:8080" flag:"wallet-host" info:"Host for access node connection"`
 }
 
 var walletFlags = FlagsWallet{}
@@ -61,11 +62,12 @@ func wallet(
 	}
 
 	key := service.Key().ToConfig()
+
 	conf := devWallet.Config{
 		Address:    fmt.Sprintf("0x%s", service.Address().String()),
 		PrivateKey: strings.TrimPrefix(key.PrivateKey.String(), "0x"),
 		PublicKey:  strings.TrimPrefix(key.PrivateKey.PublicKey().String(), "0x"),
-		AccessNode: "http://localhost:8080",
+		AccessNode: walletFlags.Host,
 	}
 
 	srv, err := devWallet.NewHTTPServer(walletFlags.Port, &conf)


### PR DESCRIPTION
Closes #515

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
This PR enable cli users to add custom configuration for dev-wallet host by adding the flag --wallet-host in dev-wallet command. Example of this command is flow dev-wallet --wallet-host "http://localhost:8081" (default value is http://localhost:8080)
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
