### PR TITLE
Bugfix/ use emulator service account defined in flow.json for signing default

### DIFF
--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -21,6 +21,8 @@ package transactions
 import (
 	"fmt"
 
+	"github.com/onflow/flow-cli/pkg/flowkit/config"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/cadence"
@@ -64,8 +66,7 @@ func send(
 	// if user has not specified signer in flag, we will use service account of default emulator as specified
 	// in flow.json
 	transactionSigner := sendFlags.Signer
-	if sendFlags.Signer == "emulator-account" {
-		fmt.Printf("signing info has default ")
+	if sendFlags.Signer == config.DefaultEmulatorServiceAccountName {
 		transactionSigner = state.Config().Emulators.Default().ServiceAccount
 	}
 	signer, err := state.Accounts().ByName(transactionSigner)

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -60,8 +60,15 @@ func send(
 	state *flowkit.State,
 ) (command.Result, error) {
 	codeFilename := args[0]
-
-	signer, err := state.Accounts().ByName(sendFlags.Signer)
+	// if sendFlags.Signer != emulator-account, this means that user has specified a signer in command flag
+	// if user has not specified signer in flag, we will use service account of default emulator as specified
+	// in flow.json
+	transactionSigner := sendFlags.Signer
+	if sendFlags.Signer == "emulator-account" {
+		fmt.Printf("signing info has default ")
+		transactionSigner = state.Config().Emulators.Default().ServiceAccount
+	}
+	signer, err := state.Accounts().ByName(transactionSigner)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #346

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR uses the emulator service account defined in emulator part of flow.json to sign transactions when there is no signer defined in the signer flag for sending transaction command
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
