### PR TITLE
add view to transactions to allow user to see all parts of a transact…

### DIFF
--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -47,6 +47,7 @@ func init() {
 	SignCommand.AddToParent(Cmd)
 	BuildCommand.AddToParent(Cmd)
 	SendSignedCommand.AddToParent(Cmd)
+	ViewCommand.AddToParent(Cmd)
 }
 
 type TransactionResult struct {

--- a/internal/transactions/view.go
+++ b/internal/transactions/view.go
@@ -1,0 +1,71 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transactions
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-cli/pkg/flowkit"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+)
+
+type flagsView struct {
+	Include []string `default:"" flag:"include" info:"Fields to include in the output. Valid values: signatures, code, payload."`
+}
+
+var viewFlags = flagsView{}
+
+var ViewCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "view <transaction filename>",
+		Short:   "View transaction",
+		Example: "flow transactions view ./transaction.rlp",
+		Args:    cobra.ExactArgs(1),
+	},
+	Flags: &viewFlags,
+	RunS:  view,
+}
+
+func view(
+	args []string,
+	readerWriter flowkit.ReaderWriter,
+	globalFlags command.GlobalFlags,
+	services *services.Services,
+	state *flowkit.State,
+) (command.Result, error) {
+	filename := args[0]
+	payload, err := readerWriter.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read transaction from %s: %v", filename, err)
+	}
+
+	tx, err := flowkit.NewTransactionFromPayload(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TransactionResult{
+		tx:      tx.FlowTransaction(),
+		include: viewFlags.Include,
+	}, nil
+}


### PR DESCRIPTION
…ion RLP

Closes #???

## Description

Add `view` command to transactions to allow decoding transaction RLP to see code and signatures.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
