### PR TITLE
add accounts list command to list all account names in flow config file

### DIFF
--- a/docs/list-accounts.md
+++ b/docs/list-accounts.md
@@ -1,0 +1,52 @@
+---
+title: List all Account names
+sidebar_title: List Accounts
+description: How to list all Flow accounts from the command line
+---
+
+The Flow CLI provides a command to list all account names in flow configuration file.
+
+```shell
+flow accounts list
+```
+
+## Example Usage
+
+```shell
+flow accounts list
+```
+
+### Example response
+```shell
+account1,account2,flow-account3
+
+```
+
+## Arguments
+none
+
+## Flags
+
+### Sort Names
+
+- Flag: `--sort`
+
+Sorts account names the result output. 
+
+
+### Output
+
+- Flag: `--output`
+- Short Flag: `-o`
+- Valid inputs: `json`, `inline`
+
+Specify the format of the command results.
+
+### Save
+
+- Flag: `--save`
+- Short Flag: `-s`
+- Valid inputs: a path in the current filesystem.
+
+Specify the filename where you want the result to be saved
+

--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -44,6 +44,7 @@ func init() {
 	CreateCommand.AddToParent(Cmd)
 	StakingCommand.AddToParent(Cmd)
 	GetCommand.AddToParent(Cmd)
+	ListCommand.AddToParent(Cmd)
 }
 
 // AccountResult represent result from all account commands.

--- a/internal/accounts/list.go
+++ b/internal/accounts/list.go
@@ -1,0 +1,92 @@
+/*
+ * Flow CLI
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accounts
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/services"
+	"github.com/onflow/flow-cli/pkg/flowkit/util"
+)
+
+type flagsList struct {
+	Sort bool `default:"false" flag:"sort" info:"Sort account names"`
+}
+
+var listFlags = flagsList{
+	Sort: false,
+}
+
+type ListResult struct {
+	accounts []string
+}
+
+var ListCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "list",
+		Short:   "Lists all accounts",
+		Example: "flow accounts list",
+		Args:    cobra.ExactArgs(0),
+	},
+	Flags: &listFlags,
+	Run:   list,
+}
+
+func list(
+	args []string,
+	_ flowkit.ReaderWriter,
+	_ command.GlobalFlags,
+	services *services.Services,
+) (command.Result, error) {
+	accounts := services.Accounts.List()
+
+	return &ListResult{accounts}, nil
+}
+
+func (r *ListResult) JSON() interface{} {
+	result := make(map[string]interface{})
+	result["accounts"] = r.accounts
+
+	return result
+}
+
+func (r *ListResult) String() string {
+	var b bytes.Buffer
+	writer := util.CreateTabWriter(&b)
+
+	if listFlags.Sort {
+		sort.Strings(r.accounts)
+	}
+	accounts := strings.Join(r.accounts[:], ",")
+	fmt.Fprintf(writer, "%v", accounts)
+
+	writer.Flush()
+	return b.String()
+}
+
+func (r *ListResult) Oneliner() string {
+	return r.String()
+}

--- a/pkg/flowkit/services/accounts.go
+++ b/pkg/flowkit/services/accounts.go
@@ -67,6 +67,17 @@ func (a *Accounts) Get(address flow.Address) (*flow.Account, error) {
 	return account, err
 }
 
+// Get returns an account by on address.
+func (a *Accounts) List() []string {
+	var accts []string
+	accounts := a.state.Accounts()
+	for _, a := range *accounts {
+		accts = append(accts, a.Name())
+	}
+
+	return accts
+}
+
 // StakingInfo returns the staking and delegation information for an account.
 func (a *Accounts) StakingInfo(address flow.Address) ([]map[string]interface{}, []map[string]interface{}, error) {
 	a.logger.StartProgress(fmt.Sprintf("Fetching info for %s...", address.String()))


### PR DESCRIPTION

## Description

<!--
Add ability for user to list all account names in flow config
`flow accounts list` has one new flag `--sort`
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
