### PR TITLE
added new multisig sign command 

### DIFF
--- a/docs/sign-transaction.md
+++ b/docs/sign-transaction.md
@@ -65,13 +65,13 @@ f90184f...a199bfd9b837a11a0885f9104b54014750f5e3e5bfe4a5795968b0df86769dd54c0
 ## Arguments
 
 ### Built Transaction Filename or Remote Server URL
-- Name: `built transaction filename | --remote-server-url <url>`
-- Valid inputs: Any filename and path valid on the system or fully qualified remote server url.
+- Name: `built transaction filename | --from-remote-url <url>`
+- Valid inputs: Any filename and path valid on the system or --from-remote-url flag and fully qualified remote server url.
 
 Specify the filename containing valid transaction payload that will be used for signing.
 To be used with the `flow transaction build` command.
 
-When --from-remote-url flag is used the argument needs to be a fully qualified url to transaction RLP
+When --from-remote-url flag is used the value needs to be a fully qualified url to transaction RLP
 Example: `flow transaction sign --from-remote-url https://fully/qualified/url --signer alice`
 ## Flags
 
@@ -80,7 +80,7 @@ Example: `flow transaction sign --from-remote-url https://fully/qualified/url --
 - Valid input: `http(s)://fully/qualified/server/url`
 
 Specify this flag with a fully qualified url to transaction RLP. The RLP will be fetched from server then signed. The resulting signed RLP is then posted to the remote url. This feature is to support protocol level multiple signature transaction coordination between multiple signers.
-Note: --yes flag is not supported and will fail `sign` command when this flag is used. 
+Note: --yes flag is not supported and will fail `sign` command when this flag is used. This forces the user to verify the cadence code.
 
 ### Include Fields
 

--- a/docs/sign-transaction.md
+++ b/docs/sign-transaction.md
@@ -64,14 +64,23 @@ f90184f...a199bfd9b837a11a0885f9104b54014750f5e3e5bfe4a5795968b0df86769dd54c0
 
 ## Arguments
 
-### Built Transaction Filename
-- Name: `built transaction filename`
-- Valid inputs: Any filename and path valid on the system.
+### Built Transaction Filename or Remote Server URL
+- Name: `built transaction filename | --remote-server-url <url>`
+- Valid inputs: Any filename and path valid on the system or fully qualified remote server url.
 
 Specify the filename containing valid transaction payload that will be used for signing.
 To be used with the `flow transaction build` command.
 
+When --from-remote-url flag is used the argument needs to be a fully qualified url to transaction RLP
+Example: `flow transaction sign --from-remote-url https://fully/qualified/url --signer alice`
 ## Flags
+
+### From Remote Url
+- Flag: `--from-remote-url`
+- Valid input: `http(s)://fully/qualified/server/url`
+
+Specify this flag with a fully qualified url to transaction RLP. The RLP will be fetched from server then signed. The resulting signed RLP is then posted to the remote url. This feature is to support protocol level multiple signature transaction coordination between multiple signers.
+Note: --yes flag is not supported and will fail `sign` command when this flag is used. 
 
 ### Include Fields
 

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -60,6 +60,10 @@ func sign(
 	var err error
 	var filenameOrUrl string
 
+	if signFlags.FromRemoteUrl != "" && len(args) > 0 {
+		return nil, fmt.Errorf("only use one, filename argument or --from-remote-url <url>")
+	}
+
 	if signFlags.FromRemoteUrl != "" {
 		if globalFlags.Yes {
 			return nil, fmt.Errorf("--yes is not supported with this flag")


### PR DESCRIPTION
Added new flag `--from-remote-url` to indicate the argument passed into transactions sign command is a fully qualified url to transaction RLP. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
