### PR TITLE
update install documentation for specific version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -25,6 +25,7 @@ sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
 
 To update, simply re-run the installation command above.
 
+Currently, there is no ability to install an earlier version of flow-cli on Homebrew.
 ## Linux
 
 ### From a pre-built binary
@@ -38,6 +39,12 @@ sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
 ```
 
 To update, simply re-run the installation command above.
+
+To install a specific version of flow-cli, the command below can be used (example below is to install flow-cli version v0.33.3):
+
+```sh
+sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)" -- v0.33.3
+```
 
 ## Windows
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,7 @@ sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
 
 To update, simply re-run the installation command above.
 
-Currently, there is no ability to install an earlier version of flow-cli on Homebrew.
+It is currently not possible to install earlier versions of the Flow CLI with Homebrew.
 ## Linux
 
 ### From a pre-built binary

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,7 +40,9 @@ sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)"
 
 To update, simply re-run the installation command above.
 
-To install a specific version of flow-cli, the command below can be used (example below is to install flow-cli version v0.33.3):
+### Install a specific version
+
+To install a specific version of Flow CLI, append the version tag to the command (e.g. the command below installs CLI version v0.33.3).
 
 ```sh
 sh -ci "$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)" -- v0.33.3


### PR DESCRIPTION
Updates install documentation to let users know how to revert flow cli to an earlier version. This is only for bash method of installing flow-cli, not homebrew.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
