### PR TITLE
Fill in missing dev wallet config values

### DIFF
--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -64,12 +64,16 @@ func wallet(
 	key := service.Key().ToConfig()
 
 	conf := devWallet.Config{
-		Address:      fmt.Sprintf("0x%s", service.Address().String()),
-		PrivateKey:   strings.TrimPrefix(key.PrivateKey.String(), "0x"),
-		PublicKey:    strings.TrimPrefix(key.PrivateKey.PublicKey().String(), "0x"),
-		AccessNode:   walletFlags.Host,
-		AccountKeyID: "0",
-		BaseURL:      "http://localhost:8701",
+		Address:               fmt.Sprintf("0x%s", service.Address().String()),
+		PrivateKey:            strings.TrimPrefix(key.PrivateKey.String(), "0x"),
+		PublicKey:             strings.TrimPrefix(key.PrivateKey.PublicKey().String(), "0x"),
+		AccessNode:            walletFlags.Host,
+		AccountKeyID:          "0",
+		BaseURL:               "http://localhost:8701",
+		ContractFungibleToken: "0xee82856bf20e2aa6",
+		ContractFlowToken:     "0x0ae53cb6e3f42a79",
+		ContractFUSD:          "0xf8d6e0586b0a20c7",
+		ContractFCLCrypto:     "0xf8d6e0586b0a20c7",
 	}
 
 	srv, err := devWallet.NewHTTPServer(walletFlags.Port, &conf)


### PR DESCRIPTION
Closes #568 

Fills in missing dev wallet config values with 
```
		ContractFungibleToken: "0xee82856bf20e2aa6",
		ContractFlowToken:     "0x0ae53cb6e3f42a79",
		ContractFUSD:          "0xf8d6e0586b0a20c7",
		ContractFCLCrypto:     "0xf8d6e0586b0a20c7",
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
