### PR TITLE
Update linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.29.0
+          version: 'latest'
           args: --timeout=3m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.18'
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: v1.47.2
           args: --timeout=3m
-          go-version: '1.18'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           version: v1.47.2
           args: --timeout=3m
+          go-version: '1.18'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: 'latest'
+          version: v1.47.2
           args: --timeout=3m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,16 +2,12 @@ linters:
   disable-all: true
   enable:
     - govet
-    - gosimple
     - errcheck
-    - staticcheck
-    - structcheck
     - varcheck
     - ineffassign
     - typecheck
     - misspell
     - goimports
-    - unused
 linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party package

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ clean:
 
 .PHONY: install-linter
 install-linter:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.29.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.47.2
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
## Description
Update Github actions golangci-lint linter. Add go set up as part of the steps as that is no longer supported by golangci https://github.com/golangci/golangci-lint-action/issues/442#issuecomment-1093445612

It also removes actions that were deprecated with Go1.18

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
