### PR TITLE
use mixpanel tokens in cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,11 @@ jobs:
           go-version: '1.18'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          MIXPANEL_TRACK_URL: ${{ secrets.MIXPANEL_TRACK_URL }}
+          MIXPANEL_QUERY_URL: ${{ secrets.MIXPANEL_QUERY_URL }}
+          MIXPANEL_PROFILE_URL: ${{ secrets.MIXPANEL_PROFILE_URL }}
+          MIXPANEL_PROJECT_TOKEN: ${{ secrets.MIXPANEL_PROJECT_TOKEN }}
+          MIXPANEL_SERVICE_ACCOUNT_SECRET: ${{ secrets.MIXPANEL_SERVICE_ACCOUNT_SECRET }}
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Connected with https://github.com/onflow/flow-cli/pull/582, 
This PR updates github action so that it uses mixpanel tokens stored in repo secret 
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
