### PR TITLE
Fix gitignore method for interactive account creation

### DIFF
--- a/pkg/flowkit/util/utilities.go
+++ b/pkg/flowkit/util/utilities.go
@@ -171,7 +171,7 @@ func AddToGitIgnore(filename string, loader ReaderWriter) error {
 	gitIgnorePath := path.Join(currentWd, ".gitignore")
 	gitIgnoreFiles := ""
 
-	fileStat, err := os.Stat(gitIgnorePath)
+	_, err = os.Stat(gitIgnorePath)
 	if !os.IsNotExist(err) { // if gitignore exists
 		gitIgnoreFilesRaw, err := loader.ReadFile(gitIgnorePath)
 		if err != nil {
@@ -179,10 +179,9 @@ func AddToGitIgnore(filename string, loader ReaderWriter) error {
 		}
 		gitIgnoreFiles = string(gitIgnoreFilesRaw)
 	}
-
 	return loader.WriteFile(
 		gitIgnorePath,
 		[]byte(fmt.Sprintf("%s\n%s", gitIgnoreFiles, filename)),
-		fileStat.Mode().Perm(),
+		0644,
 	)
 }

--- a/pkg/flowkit/util/utilities.go
+++ b/pkg/flowkit/util/utilities.go
@@ -170,18 +170,20 @@ func AddToGitIgnore(filename string, loader ReaderWriter) error {
 	}
 	gitIgnorePath := path.Join(currentWd, ".gitignore")
 	gitIgnoreFiles := ""
+	filePermissions := os.FileMode(0644)
 
-	_, err = os.Stat(gitIgnorePath)
+	fileStat, err := os.Stat(gitIgnorePath)
 	if !os.IsNotExist(err) { // if gitignore exists
 		gitIgnoreFilesRaw, err := loader.ReadFile(gitIgnorePath)
 		if err != nil {
 			return err
 		}
 		gitIgnoreFiles = string(gitIgnoreFilesRaw)
+		filePermissions = fileStat.Mode().Perm()
 	}
 	return loader.WriteFile(
 		gitIgnorePath,
 		[]byte(fmt.Sprintf("%s\n%s", gitIgnoreFiles, filename)),
-		0644,
+		filePermissions,
 	)
 }


### PR DESCRIPTION
## Description

Fix for interactive account creation when gitignore doesn't initially exist.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
