### PR TITLE
Enable tracking by default if there is rate limit error from mixpanel

### DIFF
--- a/pkg/flowkit/util/mixpanel.go
+++ b/pkg/flowkit/util/mixpanel.go
@@ -160,6 +160,10 @@ func IsUserOptedIn() (bool, error) {
 		return false, err
 	}
 	if res.StatusCode >= 400 {
+		if res.StatusCode == 429 {
+			//tracking is enabled by default if there is rate limit error from mixpanel
+			return true, nil
+		}
 		return false, fmt.Errorf("invalid response status code %d for tracking command usage", res.StatusCode)
 	}
 	if len(queryResponse.Results) == 0 {


### PR DESCRIPTION
Currently we are querying mixpanel to see if users are opted in, which causes rate limit issues at scale. This PR enables tracking for users will be enabled by default if mixpanel returns 429. Users can disable tracking by running `flow config metrics disable`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
