### PR TITLE
Use flow cli repo version.txt in install.sh

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -32,10 +32,11 @@ Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1
 
 $ErrorActionPreference = "Stop"
 
-$baseURL = "https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt"
+$baseURL = "https://storage.googleapis.com/flow-cli"
+$versionURL ="https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt"
 
 if (!$version) {
-    $version = (Invoke-WebRequest -Uri "$baseURL/version.txt" -UseBasicParsing).Content.Trim()
+    $version = (Invoke-WebRequest -Uri "$versionURL" -UseBasicParsing).Content.Trim()
 }
 
 Write-Output("Installing version {0} ..." -f $version)

--- a/install.ps1
+++ b/install.ps1
@@ -32,7 +32,7 @@ Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1
 
 $ErrorActionPreference = "Stop"
 
-$baseURL = "https://storage.googleapis.com/flow-cli"
+$baseURL = "https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt"
 
 if (!$version) {
     $version = (Invoke-WebRequest -Uri "$baseURL/version.txt" -UseBasicParsing).Content.Trim()

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Exit as soon as any command fails
 set -e
 
-BASE_URL="https://storage.googleapis.com/flow-cli"
+BASE_URL="https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt"
 # The version to download, set by get_version (defaults to args[1])
 VERSION="$1"
 # The architecture string, set by get_architecture

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@
 # Exit as soon as any command fails
 set -e
 
-BASE_URL="https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt"
+BASE_URL="https://storage.googleapis.com/flow-cli"
+CLI_GIT_URL="https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt"
 # The version to download, set by get_version (defaults to args[1])
 VERSION="$1"
 # The architecture string, set by get_architecture
@@ -55,7 +56,7 @@ get_architecture() {
 get_version() {
   if [ -z "$VERSION" ]
   then
-    VERSION=$(curl -s "$BASE_URL/version.txt")
+    VERSION=$(curl -s "$CLI_GIT_URL")
   fi
 }
 


### PR DESCRIPTION
Closes #602 

This PR changes version checking from google cloud version.txt to flow cli repo version.txt in install.sh and install.ps1
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
