### PR TITLE
Fix broken links in cli docs

### DIFF
--- a/docs/complex-transactions.md
+++ b/docs/complex-transactions.md
@@ -7,7 +7,7 @@ description: How to build and send a complex Flow transaction from the command l
 **Simple Transactions**
 
 Sending a transaction using the Flow CLI can simply be 
-achieved by using the [send command documented here](https://developers.flow.com/tools/flow-cli/send-transactions).
+achieved by using the [send command documented here](/tools/flow-cli/send-transactions).
 
 **Complex Transactions**
 
@@ -16,14 +16,14 @@ commands to build, sign and send transactions allowing you to specify different
 authorizers, signers and proposers.  
 
 The process of sending a complex transactions includes three steps:
-1. [build a transaction](https://developers.flow.com/tools/flow-cli/build-transactions)
-2. [sign the built transaction](https://developers.flow.com/tools/flow-cli/sign-transaction)
-3. [send signed transaction](https://developers.flow.com/tools/flow-cli/send-signed-transaction)
+1. [build a transaction](/tools/flow-cli/build-transactions)
+2. [sign the built transaction](/tools/flow-cli/sign-transaction)
+3. [send signed transaction](/tools/flow-cli/send-signed-transaction)
 
 Read more about each command flags and arguments in the above links.
 
 ## Examples
-We will describe common examples for complex transactions. All examples are using an [example configuration](https://developers.flow.com/tools/flow-cli/complex-transactions#configuration).
+We will describe common examples for complex transactions. All examples are using an [example configuration](/tools/flow-cli/complex-transactions#configuration).
 
 ### Single payer, proposer and authorizer
 The simplest Flow transaction declares a single account as the proposer, payer and authorizer.

--- a/docs/complex-transactions.md
+++ b/docs/complex-transactions.md
@@ -7,7 +7,7 @@ description: How to build and send a complex Flow transaction from the command l
 **Simple Transactions**
 
 Sending a transaction using the Flow CLI can simply be 
-achieved by using the [send command documented here](/flow-cli/send-transactions/).
+achieved by using the [send command documented here](https://developers.flow.com/tools/flow-cli/send-transactions).
 
 **Complex Transactions**
 
@@ -16,14 +16,14 @@ commands to build, sign and send transactions allowing you to specify different
 authorizers, signers and proposers.  
 
 The process of sending a complex transactions includes three steps:
-1. [build a transaction](/flow-cli/build-transactions/)
-2. [sign the built transaction](/flow-cli/sign-transaction/)
-3. [send signed transaction](/flow-cli/send-signed-transactions/)
+1. [build a transaction](https://developers.flow.com/tools/flow-cli/build-transactions)
+2. [sign the built transaction](https://developers.flow.com/tools/flow-cli/sign-transaction)
+3. [send signed transaction](https://developers.flow.com/tools/flow-cli/send-signed-transaction)
 
 Read more about each command flags and arguments in the above links.
 
 ## Examples
-We will describe common examples for complex transactions. All examples are using an [example configuration](#configuration).
+We will describe common examples for complex transactions. All examples are using an [example configuration](https://developers.flow.com/tools/flow-cli/complex-transactions#configuration).
 
 ### Single payer, proposer and authorizer
 The simplest Flow transaction declares a single account as the proposer, payer and authorizer.
@@ -48,7 +48,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    preapre(signer: AuthAccount) {}
+    prepare(signer: AuthAccount) {}
     execute { ... }
 }
 ```
@@ -86,7 +86,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    preapre(bob: AuthAccount, charlie: AuthAccount) {}
+    prepare(bob: AuthAccount, charlie: AuthAccount) {}
     execute { ... }
 }
 ```
@@ -125,7 +125,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    preapre(charlie: AuthAccount) {}
+    prepare(charlie: AuthAccount) {}
     execute { ... }
 }
 ```
@@ -159,7 +159,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    preapre(signer: AuthAccount) {}
+    prepare(signer: AuthAccount) {}
     execute { ... }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,8 @@ Flow configuration (`flow.json`) file will contain the following properties:
 
 - A `networks` list pre-populated with the Flow emulator, testnet and mainnet connection configuration.
 - An `accounts` list pre-populated with the Flow Emulator service account.
-- A `deployments` empty object where all [deployment targets](project-contracts.md) can be defined. 
-- A `contracts` empty object where you [define contracts](project-contracts.md) you wish to deploy.
+- A `deployments` empty object where all [deployment targets](https://developers.flow.com/tools/flow-cli/project-contracts#define-contract-deployment-targets) can be defined. 
+- A `contracts` empty object where you [define contracts](https://developers.flow.com/tools/flow-cli/project-contracts#add-a-contract) you wish to deploy.
 
 ## Example Project Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,8 @@ Flow configuration (`flow.json`) file will contain the following properties:
 
 - A `networks` list pre-populated with the Flow emulator, testnet and mainnet connection configuration.
 - An `accounts` list pre-populated with the Flow Emulator service account.
-- A `deployments` empty object where all [deployment targets](https://developers.flow.com/tools/flow-cli/project-contracts#define-contract-deployment-targets) can be defined. 
-- A `contracts` empty object where you [define contracts](https://developers.flow.com/tools/flow-cli/project-contracts#add-a-contract) you wish to deploy.
+- A `deployments` empty object where all [deployment targets](/tools/flow-cli/project-contracts#define-contract-deployment-targets) can be defined. 
+- A `contracts` empty object where you [define contracts](/tools/flow-cli/project-contracts#add-a-contract) you wish to deploy.
 
 ## Example Project Configuration
 

--- a/docs/deploy-project-contracts.md
+++ b/docs/deploy-project-contracts.md
@@ -12,7 +12,7 @@ This command automatically deploys your project's contracts based on the
 configuration defined in your `flow.json` file.
 
 Before using this command, read about how to 
-[configure project contracts and deployment targets](https://developers.flow.com/tools/flow-cli/project-contracts).
+[configure project contracts and deployment targets](/tools/flow-cli/project-contracts).
 
 ## Example Usage
 

--- a/docs/deploy-project-contracts.md
+++ b/docs/deploy-project-contracts.md
@@ -12,7 +12,7 @@ This command automatically deploys your project's contracts based on the
 configuration defined in your `flow.json` file.
 
 Before using this command, read about how to 
-[configure project contracts and deployment targets](project-contracts.md).
+[configure project contracts and deployment targets](https://developers.flow.com/tools/flow-cli/project-contracts).
 
 ## Example Usage
 

--- a/docs/get-collections.md
+++ b/docs/get-collections.md
@@ -1,5 +1,5 @@
 ---
-title: Get Block with the Flow CLI
+title: Get Collection with the Flow CLI
 sidebar_title: Get Collection
 description: How to get a collection from the command line
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ description: A command-line interface that provides useful utilities for buildin
 ---
 
 The Flow CLI includes several commands to interact with Flow networks, such as querying account information,
-or sending transactions. It also includes the [Flow Emulator](https://developers.flow.com/tools/flow-cli/start-emulator).
+or sending transactions. It also includes the [Flow Emulator](/tools/flow-cli/start-emulator).
 
 ## Installation
 
-Follow [these steps](https://developers.flow.com/tools/flow-cli/install.md) to install the Flow CLI on 
+Follow [these steps](/tools/flow-cli/install.md) to install the Flow CLI on 
 macOS, Linux, and Windows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,5 +9,5 @@ or sending transactions. It also includes the [Flow Emulator](https://developers
 
 ## Installation
 
-Follow [these steps](install.md) to install the Flow CLI on 
+Follow [these steps](https://developers.flow.com/tools/flow-cli/install.md) to install the Flow CLI on 
 macOS, Linux, and Windows.

--- a/docs/initialize-configuration.md
+++ b/docs/initialize-configuration.md
@@ -6,7 +6,7 @@ description: How to initialize Flow configuration using CLI
 
 Flow CLI uses a state to operate which is called configuration (usually `flow.json` file). 
 Before using commands that require this configuration we must initialize the project by 
-using the init command. Read more about [state configuration here](https://developers.flow.com/tools/flow-cli/configuration).
+using the init command. Read more about [state configuration here](/tools/flow-cli/configuration).
 
 ```shell
 flow init

--- a/docs/initialize-configuration.md
+++ b/docs/initialize-configuration.md
@@ -6,7 +6,7 @@ description: How to initialize Flow configuration using CLI
 
 Flow CLI uses a state to operate which is called configuration (usually `flow.json` file). 
 Before using commands that require this configuration we must initialize the project by 
-using the init command. Read more about [state configuration here](configuration.md).
+using the init command. Read more about [state configuration here](https://developers.flow.com/tools/flow-cli/configuration).
 
 ```shell
 flow init


### PR DESCRIPTION
Fix broken links in cli docs

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
