### PR TITLE
Pair Mixpanel tracking event with user distinct id

### DIFF
--- a/pkg/flowkit/util/mixpanel.go
+++ b/pkg/flowkit/util/mixpanel.go
@@ -44,6 +44,11 @@ type MixpanelClient struct {
 func TrackCommandUsage(command *cobra.Command) error {
 	mixpanelEvent := newEvent(command)
 	mixpanelEvent.setUpEvent(MIXPANEL_PROJECT_TOKEN, FLOW_CLI)
+	distinctId, err := GenerateNewDistinctId()
+	if err != nil {
+		return err
+	}
+	mixpanelEvent.setEventDistinctId(distinctId)
 	eventPayload, err := encodePayload(mixpanelEvent)
 	if err != nil {
 		return err

--- a/pkg/flowkit/util/mixpanel.go
+++ b/pkg/flowkit/util/mixpanel.go
@@ -22,9 +22,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/spf13/cobra"
 )
 
 const (

--- a/pkg/flowkit/util/mixpanel.go
+++ b/pkg/flowkit/util/mixpanel.go
@@ -45,7 +45,7 @@ type MixpanelClient struct {
 func TrackCommandUsage(command *cobra.Command) error {
 	mixpanelEvent := newEvent(command)
 	mixpanelEvent.setUpEvent(MIXPANEL_PROJECT_TOKEN, FLOW_CLI)
-	distinctId, err := GenerateNewDistinctId()
+	distinctId, err := uniqueUserID()
 	if err != nil {
 		return err
 	}

--- a/pkg/flowkit/util/mixpanelEvent.go
+++ b/pkg/flowkit/util/mixpanelEvent.go
@@ -26,6 +26,7 @@ const (
 	MIXPANEL_EVENT_PROJECT_TOKEN = "token"
 	MIXPANEL_EVENT_CALLER        = "caller"
 	FLOW_CLI                     = "flow-cli"
+	MIXPANEL_EVENT_DISTINCT_ID   = "distinct_id"
 )
 
 type event struct {
@@ -43,4 +44,8 @@ func newEvent(command *cobra.Command) *event {
 func (e *event) setUpEvent(token string, caller string) {
 	e.Properties[MIXPANEL_EVENT_PROJECT_TOKEN] = token
 	e.Properties[MIXPANEL_EVENT_CALLER] = caller
+}
+
+func (e *event) setEventDistinctId(distinctId string) {
+	e.Properties[MIXPANEL_EVENT_DISTINCT_ID] = distinctId
 }

--- a/pkg/flowkit/util/mixpanelUser.go
+++ b/pkg/flowkit/util/mixpanelUser.go
@@ -32,7 +32,7 @@ type mixpanelUser struct {
 }
 
 func getMixPanelUser() (*mixpanelUser, error) {
-	distinctId, err := GenerateNewDistinctId()
+	distinctId, err := uniqueUserID()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flowkit/util/mixpanelUser.go
+++ b/pkg/flowkit/util/mixpanelUser.go
@@ -32,7 +32,7 @@ type mixpanelUser struct {
 }
 
 func getMixPanelUser() (*mixpanelUser, error) {
-	distinctId, err := generateNewDistinctId()
+	distinctId, err := GenerateNewDistinctId()
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (e *mixpanelUser) configureUserTracking(enable bool) {
 	e.Set["$timezone"] = nil
 }
 
-func generateNewDistinctId() (string, error) {
+func GenerateNewDistinctId() (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
 		return "", err

--- a/pkg/flowkit/util/mixpanelUser.go
+++ b/pkg/flowkit/util/mixpanelUser.go
@@ -52,7 +52,7 @@ func (e *mixpanelUser) configureUserTracking(enable bool) {
 	e.Set["$timezone"] = nil
 }
 
-func GenerateNewDistinctId() (string, error) {
+func uniqueUserID() (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
To find out how many unique users we have, we are pairing each events with distinct user id

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
