### PR TITLE
Fix transaction default signer

### DIFF
--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -64,9 +64,19 @@ func send(
 	codeFilename := args[0]
 
 	transactionSigner := sendFlags.Signer
-	if sendFlags.Signer == config.DefaultEmulatorServiceAccountName { // use service account by default
-		transactionSigner = state.Config().Emulators.Default().ServiceAccount
+
+	if sendFlags.Signer == config.DefaultEmulatorServiceAccountName {
+		if state.Config().Emulators.Default() == nil {
+			if globalFlags.Network == config.DefaultEmulatorNetwork().Name {
+				return nil, fmt.Errorf("an emulator account is required in flow config")
+			} else {
+				return nil, fmt.Errorf("please specify a signer")
+			}
+		} else {
+			transactionSigner = state.Config().Emulators.Default().ServiceAccount
+		}
 	}
+
 	signer, err := state.Accounts().ByName(transactionSigner)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR will prevent cli from crashing if there is no default signer found and instead will return error message.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
