### PR TITLE
Add documentation for 'test' command

### DIFF
--- a/docs/run-tests.md
+++ b/docs/run-tests.md
@@ -1,0 +1,43 @@
+---
+title: Run Cadence tests with the Flow CLI
+sidebar_title: Run Cadence tests
+description: How to run Cadence tests from the command line
+---
+
+The Flow CLI provides a command to run Cadence tests. 
+
+```shell
+flow test /path/to/test_script.cdc
+```
+
+⚠️ The `test` command expects configuration to be initialized. See [flow init](initialize-configuration.md) command.
+
+
+## Example Usage
+A simple Cadence script `test_script.cdc`, which has a test case for running a cadence script on-chain:
+```cadence
+import Test
+
+pub fun testSimpleScript() {
+    var blockchain = Test.newEmulatorBlockchain()
+    var result = blockchain.executeScript(
+        "pub fun main(a: Int, b: Int): Int { return a + b }",
+        [2, 3]
+    )
+    
+    assert(result.status == Test.ResultStatus.succeeded)
+    assert((result.returnValue! as! Int) == 5)
+}
+```
+Above test-script can be run with the CLI as follows, and the test results will be printed on the console.
+```shell
+> flow test test_script.cdc
+
+Running tests...
+
+Test results:
+- PASS: testSimpleScript
+```
+
+To learn more about writing tests in Cadence, have a look at the [Cadence testing framework](https://developers.flow.com/cadence/testing-framework).
+


### PR DESCRIPTION
Depends on https://github.com/onflow/flow-cli/pull/640

## Description

Adds documentation for the `test` command added in #640.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
