### PR TITLE
Transaction Send multisign support 

### DIFF
--- a/docs/send-transactions.md
+++ b/docs/send-transactions.md
@@ -131,7 +131,7 @@ Specify the name of the account that will be used as payer in the transaction.
 ### Authorizer
 
 - Flag: `--authorizer`
-- Valid inputs: the name of an account defined in the configuration (`flow.json`)
+- Valid inputs: the name of a single or multiple comma-separated accounts defined in the configuration (`flow.json`)
 
 Specify the name of the account(s) that will be used as authorizer(s) in the transaction. If you want to provide multiple authorizers separate them using commas (e.g. `alice,bob`)
 

--- a/docs/send-transactions.md
+++ b/docs/send-transactions.md
@@ -133,7 +133,7 @@ Specify the name of the account that will be used as payer in the transaction.
 - Flag: `--authorizer`
 - Valid inputs: the name of an account defined in the configuration (`flow.json`)
 
-Specify the name of the account(s) that will be used as authorizer(s) in the transaction.
+Specify the name of the account(s) that will be used as authorizer(s) in the transaction. If you want to provide multiple authorizers separate them using commas (e.g. `alice,bob`)
 
 ### Arguments JSON
 

--- a/docs/send-transactions.md
+++ b/docs/send-transactions.md
@@ -114,6 +114,27 @@ Specify fields to exclude from the result output. Applies only to the text outpu
 
 Specify the name of the account that will be used to sign the transaction.
 
+### Proposer
+
+- Flag: `--proposer`
+- Valid inputs: the name of an account defined in the configuration (`flow.json`)
+
+Specify the name of the account that will be used as proposer in the transaction.
+
+### Payer
+
+- Flag: `--payer`
+- Valid inputs: the name of an account defined in the configuration (`flow.json`)
+
+Specify the name of the account that will be used as payer in the transaction.
+
+### Authorizer
+
+- Flag: `--authorizer`
+- Valid inputs: the name of an account defined in the configuration (`flow.json`)
+
+Specify the name of the account(s) that will be used as authorizer(s) in the transaction.
+
 ### Arguments JSON
 
 - Flag: `--args-json`

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -21,15 +21,14 @@ package transactions
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/onflow/flow-cli/pkg/flowkit/config"
-
-	"github.com/spf13/cobra"
-
-	"github.com/onflow/cadence"
 
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
+	"github.com/onflow/flow-cli/pkg/flowkit/config"
 	"github.com/onflow/flow-cli/pkg/flowkit/services"
+
+	"github.com/onflow/cadence"
+	"github.com/spf13/cobra"
 )
 
 type flagsSend struct {

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -34,9 +34,9 @@ type flagsSend struct {
 	ArgsJSON  string   `default:"" flag:"args-json" info:"arguments in JSON-Cadence format"`
 	Arg       []string `default:"" flag:"arg" info:"⚠️  Deprecated: use command arguments"`
 	Signer    string   `default:"" flag:"signer" info:"Account name from configuration used to sign the transaction as proposer, payer and suthorizer"`
-	Proposer  string   `default:"" flag:"signer" info:"Account name from configuration used as proposer"`
-	Payer     string   `default:"" flag:"signer" info:"Account name from configuration used as payer"`
-	Autorizer []string `default:"" flag:"signer" info:"Account name(s) from configuration used as authorizer(s)"`
+	Proposer  string   `default:"" flag:"proposer" info:"Account name from configuration used as proposer"`
+	Payer     string   `default:"" flag:"payer" info:"Account name from configuration used as payer"`
+	Autorizer []string `default:"" flag:"authorizer" info:"Account name(s) from configuration used as authorizer(s)"`
 	Include   []string `default:"" flag:"include" info:"Fields to include in the output"`
 	Exclude   []string `default:"" flag:"exclude" info:"Fields to exclude from the output (events)"`
 }
@@ -76,7 +76,7 @@ func send(
 		}
 	}
 
-	payerName := buildFlags.Payer
+	payerName := sendFlags.Payer
 	if payerName != "" {
 		payer, err = state.Accounts().ByName(payerName)
 		if err != nil {
@@ -93,6 +93,10 @@ func send(
 	}
 
 	signerName := sendFlags.Signer
+
+	if signerName == "" && proposer == nil && payer == nil && len(authorizers) == 0 {
+		signerName = state.Config().Emulators.Default().ServiceAccount
+	}
 
 	if signerName != "" {
 		if proposer != nil || payer != nil || len(authorizers) > 0 {

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -132,7 +132,7 @@ func send(
 		proposer.Key().Index(),
 		code,
 		codeFilename,
-		buildFlags.GasLimit,
+		sendFlags.GasLimit,
 		transactionArgs,
 		globalFlags.Network,
 		true,

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -36,7 +36,7 @@ type flagsSend struct {
 	Signer    string   `default:"" flag:"signer" info:"Account name from configuration used to sign the transaction as proposer, payer and suthorizer"`
 	Proposer  string   `default:"" flag:"proposer" info:"Account name from configuration used as proposer"`
 	Payer     string   `default:"" flag:"payer" info:"Account name from configuration used as payer"`
-	Autorizer []string `default:"" flag:"authorizer" info:"Account name(s) from configuration used as authorizer(s)"`
+	Autorizer []string `default:"" flag:"authorizer" info:"Name of a single or multiple comma-separated accounts used as authorizers from configuration"`
 	Include   []string `default:"" flag:"include" info:"Fields to include in the output"`
 	Exclude   []string `default:"" flag:"exclude" info:"Fields to exclude from the output (events)"`
 }

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -24,9 +24,9 @@ import (
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-cli/pkg/flowkit/services"
-	"github.com/onflow/flow-go-sdk"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -32,7 +32,7 @@ import (
 )
 
 type flagsSign struct {
-	Signer        []string `default:"emulator-account" flag:"signer" info:"name of the account used to sign"`
+	Signer        []string `default:"emulator-account" flag:"signer" info:"name of the account(s) used to sign"`
 	Include       []string `default:"" flag:"include" info:"Fields to include in the output. Valid values: signatures, code, payload."`
 	FromRemoteUrl string   `default:"" flag:"from-remote-url" info:"server URL where RLP can be fetched, signed RLP will be posted back to remote URL."`
 }

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -32,7 +32,7 @@ import (
 )
 
 type flagsSign struct {
-	Signer        []string `default:"emulator-account" flag:"signer" info:"name of the account(s) used to sign"`
+	Signer        []string `default:"emulator-account" flag:"signer" info:"name of a single or multiple comma-separated accounts used to sign"`
 	Include       []string `default:"" flag:"include" info:"Fields to include in the output. Valid values: signatures, code, payload."`
 	FromRemoteUrl string   `default:"" flag:"from-remote-url" info:"server URL where RLP can be fetched, signed RLP will be posted back to remote URL."`
 }

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -29,7 +29,6 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowkit/util"
 
 	"github.com/onflow/flow-go-sdk"
-
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/flowkit/arguments.go
+++ b/pkg/flowkit/arguments.go
@@ -66,37 +66,6 @@ func ParseArgumentsJSON(input string) ([]cadence.Value, error) {
 	return cadenceArgs, nil
 }
 
-func ParseArgumentsCommaSplit(input []string) ([]cadence.Value, error) {
-	args := make([]map[string]interface{}, 0)
-
-	if len(input) == 0 {
-		return make([]cadence.Value, 0), nil
-	}
-
-	for _, in := range input {
-		argInput := strings.Split(in, ":")
-
-		if len(argInput) != 2 {
-			return nil, fmt.Errorf(
-				"argument not passed in correct format, correct format is: Type:Value, got %s",
-				in,
-			)
-		}
-
-		argType := argInput[0]
-		argValue := argInput[1]
-		args = append(args, map[string]interface{}{
-			"value": processValue(argType, argValue),
-			"type":  argType,
-		})
-	}
-
-	jsonArgs, _ := json.Marshal(args)
-	cadenceArgs, err := ParseArgumentsJSON(string(jsonArgs))
-
-	return cadenceArgs, err
-}
-
 // sanitizeAddressArg sanitize address and make sure it has 0x prefix
 func processValue(argType string, argValue string) interface{} {
 	if argType == "Address" && !strings.Contains(argValue, "0x") {
@@ -109,18 +78,6 @@ func processValue(argType string, argValue string) interface{} {
 	return argValue
 }
 
-func ParseArguments(args []string, argsJSON string) (scriptArgs []cadence.Value, err error) {
-	if argsJSON != "" {
-		scriptArgs, err = ParseArgumentsJSON(argsJSON)
-	} else {
-		scriptArgs, err = ParseArgumentsCommaSplit(args)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return
-}
 func GetAuthorizerCount(fileName string, code []byte) int {
 
 	codes := make(map[common.Location][]byte)

--- a/pkg/flowkit/arguments.go
+++ b/pkg/flowkit/arguments.go
@@ -122,9 +122,9 @@ func ParseArguments(args []string, argsJSON string) (scriptArgs []cadence.Value,
 }
 func GetAuthorizerCount(fileName string, code []byte) int {
 
-	codes := map[common.Location]string{}
+	codes := make(map[common.Location][]byte)
 	location := common.StringLocation(fileName)
-	program, _ := cmd.PrepareProgram(string(code), location, codes)
+	program, _ := cmd.PrepareProgram(code, location, codes)
 
 	transactionDeclaration := program.TransactionDeclarations()
 	if len(transactionDeclaration) == 1 {

--- a/pkg/flowkit/arguments.go
+++ b/pkg/flowkit/arguments.go
@@ -21,6 +21,7 @@ package flowkit
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/onflow/cadence"

--- a/pkg/flowkit/services/transactions.go
+++ b/pkg/flowkit/services/transactions.go
@@ -29,11 +29,10 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowkit"
 
 	"github.com/onflow/flow-cli/pkg/flowkit/contracts"
-
-	"github.com/onflow/flow-go-sdk"
-
 	"github.com/onflow/flow-cli/pkg/flowkit/gateway"
 	"github.com/onflow/flow-cli/pkg/flowkit/output"
+
+	"github.com/onflow/flow-go-sdk"
 )
 
 // Transactions is a service that handles all transaction-related interactions.


### PR DESCRIPTION
Closes #667 

## Description

Added with some assumptions as follows:

- the first signer is the proposer 
- the last signer is the payer 
- authorizer count is taken from the transaction code 

this should also allow different weight keys to be used with multisign. So account can have more than one key.

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
