### PR TITLE
Bugfix transaction result use ID direclty

### DIFF
--- a/pkg/flowkit/gateway/emulator.go
+++ b/pkg/flowkit/gateway/emulator.go
@@ -138,8 +138,8 @@ func (g *EmulatorGateway) SendSignedTransaction(tx *flowkit.Transaction) (*flow.
 	return tx.FlowTransaction(), nil
 }
 
-func (g *EmulatorGateway) GetTransactionResult(tx *flow.Transaction, waitSeal bool) (*flow.TransactionResult, error) {
-	result, err := g.backend.GetTransactionResult(g.ctx, tx.ID())
+func (g *EmulatorGateway) GetTransactionResult(ID flow.Identifier, waitSeal bool) (*flow.TransactionResult, error) {
+	result, err := g.backend.GetTransactionResult(g.ctx, ID)
 	if err != nil {
 		return nil, UnwrapStatusError(err)
 	}

--- a/pkg/flowkit/gateway/gateway.go
+++ b/pkg/flowkit/gateway/gateway.go
@@ -30,7 +30,7 @@ type Gateway interface {
 	GetAccount(flow.Address) (*flow.Account, error)
 	SendSignedTransaction(*flowkit.Transaction) (*flow.Transaction, error)
 	GetTransaction(flow.Identifier) (*flow.Transaction, error)
-	GetTransactionResult(*flow.Identifier, bool) (*flow.TransactionResult, error)
+	GetTransactionResult(flow.Identifier, bool) (*flow.TransactionResult, error)
 	ExecuteScript([]byte, []cadence.Value) (cadence.Value, error)
 	GetLatestBlock() (*flow.Block, error)
 	GetBlockByHeight(uint64) (*flow.Block, error)

--- a/pkg/flowkit/gateway/gateway.go
+++ b/pkg/flowkit/gateway/gateway.go
@@ -29,8 +29,8 @@ import (
 type Gateway interface {
 	GetAccount(flow.Address) (*flow.Account, error)
 	SendSignedTransaction(*flowkit.Transaction) (*flow.Transaction, error)
-	GetTransactionResult(*flow.Transaction, bool) (*flow.TransactionResult, error)
 	GetTransaction(flow.Identifier) (*flow.Transaction, error)
+	GetTransactionResult(*flow.Identifier, bool) (*flow.TransactionResult, error)
 	ExecuteScript([]byte, []cadence.Value) (cadence.Value, error)
 	GetLatestBlock() (*flow.Block, error)
 	GetBlockByHeight(uint64) (*flow.Block, error)

--- a/pkg/flowkit/gateway/grpc.go
+++ b/pkg/flowkit/gateway/grpc.go
@@ -115,20 +115,20 @@ func (g *GrpcGateway) SendSignedTransaction(transaction *flowkit.Transaction) (*
 }
 
 // GetTransaction gets a transaction by ID from the Flow Access API.
-func (g *GrpcGateway) GetTransaction(id flow.Identifier) (*flow.Transaction, error) {
-	return g.client.GetTransaction(g.ctx, id)
+func (g *GrpcGateway) GetTransaction(ID flow.Identifier) (*flow.Transaction, error) {
+	return g.client.GetTransaction(g.ctx, ID)
 }
 
 // GetTransactionResult gets a transaction result by ID from the Flow Access API.
-func (g *GrpcGateway) GetTransactionResult(tx *flow.Transaction, waitSeal bool) (*flow.TransactionResult, error) {
-	result, err := g.client.GetTransactionResult(g.ctx, tx.ID())
+func (g *GrpcGateway) GetTransactionResult(ID flow.Identifier, waitSeal bool) (*flow.TransactionResult, error) {
+	result, err := g.client.GetTransactionResult(g.ctx, ID)
 	if err != nil {
 		return nil, err
 	}
 
 	if result.Status != flow.TransactionStatusSealed && waitSeal {
 		time.Sleep(time.Second)
-		return g.GetTransactionResult(tx, waitSeal)
+		return g.GetTransactionResult(ID, waitSeal)
 	}
 
 	return result, nil

--- a/pkg/flowkit/services/accounts.go
+++ b/pkg/flowkit/services/accounts.go
@@ -258,7 +258,7 @@ func (a *Accounts) Create(
 
 	a.logger.StartProgress("Waiting for transaction to be sealed...")
 
-	result, err := a.gateway.GetTransactionResult(sentTx, true)
+	result, err := a.gateway.GetTransactionResult(sentTx.ID(), true)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (a *Accounts) AddContract(
 	}
 
 	// we wait for transaction to be sealed
-	trx, err := a.gateway.GetTransactionResult(sentTx, true)
+	trx, err := a.gateway.GetTransactionResult(sentTx.ID(), true)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func (a *Accounts) RemoveContract(
 		return nil, err
 	}
 
-	txr, err := a.gateway.GetTransactionResult(sentTx, true)
+	txr, err := a.gateway.GetTransactionResult(sentTx.ID(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -93,7 +93,7 @@ func (p *Project) Init(
 	return state, nil
 }
 
-//Defines a Mainnet Standard Contract ( e.g Core Contracts, FungibleToken, NonFungibleToken )
+// Defines a Mainnet Standard Contract ( e.g Core Contracts, FungibleToken, NonFungibleToken )
 type StandardContract struct {
 	Name     string
 	Address  flow.Address
@@ -359,7 +359,7 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 			continue
 		}
 
-		result, err := p.gateway.GetTransactionResult(sentTx, true)
+		result, err := p.gateway.GetTransactionResult(sentTx.ID(), true)
 		if err != nil {
 			p.logger.StopProgress()
 			p.logger.Error(fmt.Sprintf("%s error: %s", contract.Name(), err))

--- a/pkg/flowkit/services/transactions.go
+++ b/pkg/flowkit/services/transactions.go
@@ -73,8 +73,7 @@ func (t *Transactions) GetStatus(
 		t.logger.StartProgress("Waiting for transaction to be sealed...")
 	}
 
-	result, err := t.gateway.GetTransactionResult(tx, waitSeal)
-
+	result, err := t.gateway.GetTransactionResult(id, waitSeal)
 	t.logger.StopProgress()
 
 	return tx, result, err
@@ -214,7 +213,7 @@ func (t *Transactions) SendSigned(
 		return nil, nil, err
 	}
 
-	res, err := t.gateway.GetTransactionResult(sentTx, true)
+	res, err := t.gateway.GetTransactionResult(sentTx.ID(), true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -274,7 +273,7 @@ func (t *Transactions) Send(
 
 	t.logger.StartProgress("Waiting for transaction to be sealed...")
 
-	res, err := t.gateway.GetTransactionResult(sentTx, true)
+	res, err := t.gateway.GetTransactionResult(sentTx.ID(), true)
 
 	t.logger.StopProgress()
 

--- a/pkg/flowkit/services/transactions_test.go
+++ b/pkg/flowkit/services/transactions_test.go
@@ -76,7 +76,7 @@ func TestTransactions(t *testing.T) {
 		})
 
 		gw.GetTransactionResult.Run(func(args mock.Arguments) {
-			assert.Equal(t, txID, args.Get(0).(*flow.Transaction).ID())
+			assert.Equal(t, txID, args.Get(0).(flow.Identifier))
 			gw.GetTransactionResult.Return(tests.NewTransactionResult(nil), nil)
 		})
 

--- a/pkg/flowkit/tests/gateway.go
+++ b/pkg/flowkit/tests/gateway.go
@@ -73,7 +73,7 @@ func DefaultMockGateway() *TestGateway {
 		),
 		GetTransactionResult: m.On(
 			GetTransactionResultFunc,
-			mock.AnythingOfType("*flow.Transaction"),
+			mock.AnythingOfType("flow.Identifier"),
 			mock.AnythingOfType("bool"),
 		),
 		GetTransaction: m.On(

--- a/pkg/flowkit/tests/gateway.go
+++ b/pkg/flowkit/tests/gateway.go
@@ -39,6 +39,8 @@ const (
 	GetTransactionFunc        = "GetTransaction"
 )
 
+// go:generate
+
 type TestGateway struct {
 	Mock                  *mocks.Gateway
 	SendSignedTransaction *mock.Call

--- a/pkg/flowkit/tests/mocks/Gateway.go
+++ b/pkg/flowkit/tests/mocks/Gateway.go
@@ -224,11 +224,11 @@ func (_m *Gateway) GetTransaction(_a0 flow.Identifier) (*flow.Transaction, error
 }
 
 // GetTransactionResult provides a mock function with given fields: _a0, _a1
-func (_m *Gateway) GetTransactionResult(_a0 *flow.Transaction, _a1 bool) (*flow.TransactionResult, error) {
+func (_m *Gateway) GetTransactionResult(_a0 flow.Identifier, _a1 bool) (*flow.TransactionResult, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *flow.TransactionResult
-	if rf, ok := ret.Get(0).(func(*flow.Transaction, bool) *flow.TransactionResult); ok {
+	if rf, ok := ret.Get(0).(func(flow.Identifier, bool) *flow.TransactionResult); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
@@ -237,7 +237,7 @@ func (_m *Gateway) GetTransactionResult(_a0 *flow.Transaction, _a1 bool) (*flow.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*flow.Transaction, bool) error); ok {
+	if rf, ok := ret.Get(1).(func(flow.Identifier, bool) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
Closes: #659 

This is a PR addressing issues coming from the lack of canonical schema for transaction payloads. The problems is that some transactions are made from JS or other libs that produce a bit different format to how the format is in Go SDK thus causing the recalculation of those transaction ID to be different than to the one returned. So the solution is to pass ID to the get transaction result directly. After canonical schema is defined this will get better.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
