### PR TITLE
P256 key generation with SLIP10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.20.1 // indirect
 	github.com/libp2p/go-libp2p-tls v0.4.1 // indirect
 	github.com/libp2p/go-openssl v0.1.0 // indirect
+	github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -160,7 +161,6 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/thoas/go-funk v0.9.2 // indirect
 	github.com/turbolent/prettier v0.0.0-20220320183459-661cc755135d // indirect
-	github.com/tyler-smith/go-bip32 v1.0.0 // indirect
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,7 +172,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e h1:0XBUw73chJ1VYSsfvcPvVT7auykAJce9FpRr10L6Qhw=
-github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:P13beTBKr5Q18lJe1rIoLUqjM+CB1zYrRg44ZqGuQSA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -560,6 +559,8 @@ github.com/libp2p/go-libp2p-tls v0.4.1 h1:1ByJUbyoMXvYXDoW6lLsMxqMViQNXmt+CfQqln
 github.com/libp2p/go-libp2p-tls v0.4.1/go.mod h1:EKCixHEysLNDlLUoKxv+3f/Lp90O2EXNjTr0UQDnrIw=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
+github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12 h1:qFV7dBLhw5z4hka5gjtIzg1Kq9ie8t8P7Cy0uIxRyAQ=
+github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12/go.mod h1:QIsK6U93yCP6TnGsShCv5wl4gcz/mpCHl+aToBsl5Sc=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
@@ -847,7 +848,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.1.5-0.20170601210322-f6abca593680/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v0.0.0-20170601210322-f6abca593680/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -872,8 +873,6 @@ github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2bi
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/turbolent/prettier v0.0.0-20220320183459-661cc755135d h1:5JInRQbk5UBX8JfUvKh2oYTLMVwj3p6n+wapDDm7hko=
 github.com/turbolent/prettier v0.0.0-20220320183459-661cc755135d/go.mod h1:Nlx5Y115XQvNcIdIy7dZXaNSUpzwBSge4/Ivk93/Yog=
-github.com/tyler-smith/go-bip32 v1.0.0 h1:sDR9juArbUgX+bO/iblgZnMPeWY1KZMUC2AFUJdv5KE=
-github.com/tyler-smith/go-bip32 v1.0.0/go.mod h1:onot+eHknzV4BVPwrzqY5OoVpyCvnwD7lMawL5aQupE=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -1502,7 +1501,6 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 lukechampine.com/blake3 v1.1.7 h1:GgRMhmdsuK8+ii6UZFDL8Nb+VyMwadAgcJyfYHxG6n0=
 lukechampine.com/blake3 v1.1.7/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=
 pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=

--- a/pkg/flowkit/go.mod
+++ b/pkg/flowkit/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.13
 	github.com/gosuri/uilive v0.0.4
 	github.com/joho/godotenv v1.4.0
+	github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12
 	github.com/manifoldco/promptui v0.9.0
 	github.com/onflow/cadence v0.28.0
 	github.com/onflow/cadence-tools/test v0.2.1-0.20221012182900-f46efb551c55
@@ -20,7 +21,6 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/thoas/go-funk v0.9.2
-	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75
 	gonum.org/v1/gonum v0.11.0
@@ -45,6 +45,7 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
@@ -173,5 +174,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )

--- a/pkg/flowkit/go.sum
+++ b/pkg/flowkit/go.sum
@@ -526,6 +526,8 @@ github.com/libp2p/go-libp2p-tls v0.4.1 h1:1ByJUbyoMXvYXDoW6lLsMxqMViQNXmt+CfQqln
 github.com/libp2p/go-libp2p-tls v0.4.1/go.mod h1:EKCixHEysLNDlLUoKxv+3f/Lp90O2EXNjTr0UQDnrIw=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
+github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12 h1:qFV7dBLhw5z4hka5gjtIzg1Kq9ie8t8P7Cy0uIxRyAQ=
+github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12/go.mod h1:QIsK6U93yCP6TnGsShCv5wl4gcz/mpCHl+aToBsl5Sc=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
@@ -760,7 +762,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/testify v1.1.5-0.20170601210322-f6abca593680/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v0.0.0-20170601210322-f6abca593680/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -783,8 +785,6 @@ github.com/thoas/go-funk v0.9.2/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xz
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/turbolent/prettier v0.0.0-20220320183459-661cc755135d h1:5JInRQbk5UBX8JfUvKh2oYTLMVwj3p6n+wapDDm7hko=
 github.com/turbolent/prettier v0.0.0-20220320183459-661cc755135d/go.mod h1:Nlx5Y115XQvNcIdIy7dZXaNSUpzwBSge4/Ivk93/Yog=
-github.com/tyler-smith/go-bip32 v1.0.0 h1:sDR9juArbUgX+bO/iblgZnMPeWY1KZMUC2AFUJdv5KE=
-github.com/tyler-smith/go-bip32 v1.0.0/go.mod h1:onot+eHknzV4BVPwrzqY5OoVpyCvnwD7lMawL5aQupE=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/pkg/flowkit/keys.go
+++ b/pkg/flowkit/keys.go
@@ -30,8 +30,8 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto/cloudkms"
 
 	goeth "github.com/ethereum/go-ethereum/accounts"
+	slip10 "github.com/lmars/go-slip10"
 	"github.com/onflow/flow-cli/pkg/flowkit/config"
-	bip32 "github.com/tyler-smith/go-bip32"
 	bip39 "github.com/tyler-smith/go-bip39"
 )
 
@@ -311,7 +311,11 @@ func (a *Bip44AccountKey) Validate() error {
 	}
 
 	seed := bip39.NewSeed(a.mnemonic, "")
-	accountKey, err := bip32.NewMasterKey(seed)
+	curve := slip10.CurveBitcoin
+	if a.sigAlgo == crypto.ECDSA_P256 {
+		curve = slip10.CurveP256
+	}
+	accountKey, err := slip10.NewMasterKeyWithCurve(seed, curve)
 	if err != nil {
 		return err
 	}

--- a/pkg/flowkit/services/keys.go
+++ b/pkg/flowkit/services/keys.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowkit/util"
 
 	goeth "github.com/ethereum/go-ethereum/accounts"
-	bip32 "github.com/tyler-smith/go-bip32"
+	slip10 "github.com/lmars/go-slip10"
 	bip39 "github.com/tyler-smith/go-bip39"
 )
 
@@ -84,7 +84,12 @@ func (k *Keys) DerivePrivateKeyFromMnemonic(mnemonic string, sigAlgo crypto.Sign
 	}
 
 	seed := bip39.NewSeed(mnemonic, "")
-	accountKey, err := bip32.NewMasterKey(seed)
+	curve := slip10.CurveBitcoin
+	if sigAlgo == crypto.ECDSA_P256 {
+		curve = slip10.CurveP256
+	}
+
+	accountKey, err := slip10.NewMasterKeyWithCurve(seed, curve)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flowkit/services/keys.go
+++ b/pkg/flowkit/services/keys.go
@@ -70,12 +70,23 @@ func (k *Keys) GetMnemonic() (string, error) {
 
 func (k *Keys) DerivePrivateKeyFromMnemonic(mnemonic string, sigAlgo crypto.SignatureAlgorithm, derivationPath string) (crypto.PrivateKey, error) {
 
-	if derivationPath == "" {
-		derivationPath = "m/44'/539'/0'/0/0"
-	}
-
 	if !bip39.IsMnemonicValid(mnemonic) {
 		return nil, fmt.Errorf("invalid mnemonic")
+	}
+
+	seed := bip39.NewSeed(mnemonic, "")
+
+	return k.derivePrivateKeyFromSeed(seed, sigAlgo, derivationPath)
+}
+
+func (k *Keys) derivePrivateKeyFromSeed(seed []byte, sigAlgo crypto.SignatureAlgorithm, derivationPath string) (crypto.PrivateKey, error) {
+	// sanity check of seed length
+	if len(seed) < 16 {
+		return nil, fmt.Errorf("seed length should be at least 16 bytes, got %d", len(seed))
+	}
+
+	if derivationPath == "" {
+		derivationPath = "m/44'/539'/0'/0/0"
 	}
 
 	path, err := goeth.ParseDerivationPath(derivationPath)
@@ -83,10 +94,11 @@ func (k *Keys) DerivePrivateKeyFromMnemonic(mnemonic string, sigAlgo crypto.Sign
 		return nil, fmt.Errorf("invalid derivation path")
 	}
 
-	seed := bip39.NewSeed(mnemonic, "")
-	curve := slip10.CurveBitcoin
+	curve := slip10.CurveBitcoin // case ECDSA_secp256k1
 	if sigAlgo == crypto.ECDSA_P256 {
 		curve = slip10.CurveP256
+	} else if sigAlgo != crypto.ECDSA_secp256k1 {
+		return nil, fmt.Errorf("invalid signature algorithm")
 	}
 
 	accountKey, err := slip10.NewMasterKeyWithCurve(seed, curve)

--- a/pkg/flowkit/services/keys_test.go
+++ b/pkg/flowkit/services/keys_test.go
@@ -53,10 +53,10 @@ func TestKeys(t *testing.T) {
 		t.Parallel()
 
 		_, s, _ := setup()
-		key, err := s.Keys.DerivePrivateKeyFromMnemonic("isolate visa defy link gate ordinary notice desert punch zero please pistol", crypto.ECDSA_P256, "")
+		key, err := s.Keys.DerivePrivateKeyFromMnemonic("normal dune pole key case cradle unfold require tornado mercy hospital buyer", crypto.ECDSA_P256, "")
 
 		assert.NoError(t, err)
-		assert.Equal(t, key.String(), "0x04430b77d604b52815494a8e453e1ffa2483644c063a0b7a46eb5effb3dc7b0b")
+		assert.Equal(t, key.String(), "0x638dc9ad0eee91d09249f0fd7c5323a11600e20d5b9105b66b782a96236e74cf")
 	})
 
 	//https://github.com/onflow/ledger-app-flow/blob/dc61213a9c3d73152b78b7391d04165d07f1ad89/tests_speculos/test-basic-show-address-expert.js#L28

--- a/pkg/flowkit/services/keys_test.go
+++ b/pkg/flowkit/services/keys_test.go
@@ -22,9 +22,6 @@ import (
 	"encoding/hex"
 	"testing"
 
-	goeth "github.com/ethereum/go-ethereum/accounts"
-	slip10 "github.com/lmars/go-slip10"
-
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,63 +49,55 @@ func TestKeys(t *testing.T) {
 		assert.Equal(t, key.String(), "0x134f702d0872dba9c7aea15498aab9b2ffedd5aeebfd8ac3cf47c591f0d7ce52")
 	})
 
-	t.Run("Test Slip10 - P256", func(t *testing.T) {
+	t.Run("Test Vector SLIP-0010", func(t *testing.T) {
+		// test against SLIP-0010 test vector. All data are taken from:
+		//  https://github.com/satoshilabs/slips/blob/master/slip-0010.md#test-vectors
 		t.Parallel()
+		_, s, _ := setup()
 
-		curve := slip10.CurveP256
-		sigAlgo := crypto.ECDSA_P256
-		seed := []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0x0e, 0x0f}
-		path, _ := goeth.ParseDerivationPath("m/0'/1/2'/2/1000000000")
-
-		accountKey, _ := slip10.NewMasterKeyWithCurve(seed, curve)
-		// https://github.com/satoshilabs/slips/blob/master/slip-0010.md#test-vector-1-for-nist256p1
-		privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
-
-		assert.Equal(t, privateKey.String(), "0x612091aaa12e22dd2abef664f8a01a82cae99ad7441b7ef8110424915c268bc2")
-
-		expectedPrivateKeys := []string{
-			"0x6939694369114c67917a182c59ddb8cafc3004e63ca5d3b84403ba8613debc0c",
-			"0x284e9d38d07d21e4e281b645089a94f4cf5a5a81369acf151a1c3a57f18b2129",
-			"0x694596e8a54f252c960eb771a3c41e7e32496d03b954aeb90f61635b8e092aa7",
-			"0x5996c37fd3dd2679039b23ed6f70b506c6b56b3cb5e424681fb0fa64caf82aaa",
-			"0x21c4f269ef0a5fd1badf47eeacebeeaa3de22eb8e5b0adcd0f27dd99d34d0119",
+		type testEntry struct {
+			sigAlgo    crypto.SignatureAlgorithm
+			seed       string
+			path       string
+			privateKey string
 		}
-		for i, n := range path {
-			accountKey, _ = accountKey.NewChildKey(n)
-			privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
 
-			assert.Equal(t, privateKey.String(), expectedPrivateKeys[i])
-
+		testVector := []testEntry{
+			testEntry{
+				sigAlgo:    crypto.ECDSA_secp256k1,
+				seed:       "000102030405060708090a0b0c0d0e0f",
+				path:       "m/0'/1/2'/2/1000000000",
+				privateKey: "0x471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8",
+			},
+			testEntry{
+				sigAlgo:    crypto.ECDSA_P256,
+				seed:       "000102030405060708090a0b0c0d0e0f",
+				path:       "m/0'/1/2'/2/1000000000",
+				privateKey: "0x21c4f269ef0a5fd1badf47eeacebeeaa3de22eb8e5b0adcd0f27dd99d34d0119",
+			},
+			testEntry{
+				sigAlgo:    crypto.ECDSA_secp256k1,
+				seed:       "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542",
+				path:       "m/0/2147483647'/1/2147483646'/2",
+				privateKey: "0xbb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23",
+			},
+			testEntry{
+				sigAlgo:    crypto.ECDSA_P256,
+				seed:       "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542",
+				path:       "m/0/2147483647'/1/2147483646'/2",
+				privateKey: "0xbb0a77ba01cc31d77205d51d08bd313b979a71ef4de9b062f8958297e746bd67",
+			},
 		}
-	})
 
-	t.Run("Test Slip10 - secp256k1", func(t *testing.T) {
-		t.Parallel()
-
-		curve := slip10.CurveBitcoin
-		sigAlgo := crypto.ECDSA_secp256k1
-		seed := []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0x0e, 0x0f}
-		path, _ := goeth.ParseDerivationPath("m/0'/1/2'/2/1000000000")
-
-		accountKey, _ := slip10.NewMasterKeyWithCurve(seed, curve)
-		// https://github.com/satoshilabs/slips/blob/master/slip-0010.md#test-vector-1-for-nist256p1
-		privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
-
-		assert.Equal(t, privateKey.String(), "0xe8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35")
-
-		expectedPrivateKeys := []string{
-			"0xedb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea",
-			"0x3c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368",
-			"0xcbce0d719ecf7431d88e6a89fa1483e02e35092af60c042b1df2ff59fa424dca",
-			"0x0f479245fb19a38a1954c5c7c0ebab2f9bdfd96a17563ef28a6a4b1a2a764ef4",
-			"0x471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8",
-		}
-		for i, n := range path {
-			accountKey, _ = accountKey.NewChildKey(n)
-			privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
-
-			assert.Equal(t, privateKey.String(), expectedPrivateKeys[i])
-
+		for _, test := range testVector {
+			seed, err := hex.DecodeString(test.seed)
+			assert.NoError(t, err)
+			// use derivePrivateKeyFromSeed to test instead of DerivePrivateKeyFromMnemonic
+			// because the test vector provides seeds, while it's not possible to derive mnemonics
+			// corresponding to seeds.
+			privateKey, err := s.Keys.derivePrivateKeyFromSeed(seed, test.sigAlgo, test.path)
+			assert.NoError(t, err)
+			assert.Equal(t, test.privateKey, privateKey.String())
 		}
 	})
 

--- a/pkg/flowkit/services/keys_test.go
+++ b/pkg/flowkit/services/keys_test.go
@@ -82,6 +82,36 @@ func TestKeys(t *testing.T) {
 		}
 	})
 
+	t.Run("Test Slip10 - secp256k1", func(t *testing.T) {
+		t.Parallel()
+
+		curve := slip10.CurveBitcoin
+		sigAlgo := crypto.ECDSA_secp256k1
+		seed := []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0x0e, 0x0f}
+		path, _ := goeth.ParseDerivationPath("m/0'/1/2'/2/1000000000")
+
+		accountKey, _ := slip10.NewMasterKeyWithCurve(seed, curve)
+		// https://github.com/satoshilabs/slips/blob/master/slip-0010.md#test-vector-1-for-nist256p1
+		privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
+
+		assert.Equal(t, privateKey.String(), "0xe8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35")
+
+		expectedPrivateKeys := []string{
+			"0xedb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea",
+			"0x3c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368",
+			"0xcbce0d719ecf7431d88e6a89fa1483e02e35092af60c042b1df2ff59fa424dca",
+			"0x0f479245fb19a38a1954c5c7c0ebab2f9bdfd96a17563ef28a6a4b1a2a764ef4",
+			"0x471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8",
+		}
+		for i, n := range path {
+			accountKey, _ = accountKey.NewChildKey(n)
+			privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
+
+			assert.Equal(t, privateKey.String(), expectedPrivateKeys[i])
+
+		}
+	})
+
 	t.Run("Generate Keys with mnemonic (default path)", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/flowkit/services/keys_test.go
+++ b/pkg/flowkit/services/keys_test.go
@@ -22,6 +22,9 @@ import (
 	"encoding/hex"
 	"testing"
 
+	goeth "github.com/ethereum/go-ethereum/accounts"
+	slip10 "github.com/lmars/go-slip10"
+
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,6 +50,36 @@ func TestKeys(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, key.String(), "0x134f702d0872dba9c7aea15498aab9b2ffedd5aeebfd8ac3cf47c591f0d7ce52")
+	})
+
+	t.Run("Test Slip10 - P256", func(t *testing.T) {
+		t.Parallel()
+
+		curve := slip10.CurveP256
+		sigAlgo := crypto.ECDSA_P256
+		seed := []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0x0e, 0x0f}
+		path, _ := goeth.ParseDerivationPath("m/0'/1/2'/2/1000000000")
+
+		accountKey, _ := slip10.NewMasterKeyWithCurve(seed, curve)
+		// https://github.com/satoshilabs/slips/blob/master/slip-0010.md#test-vector-1-for-nist256p1
+		privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
+
+		assert.Equal(t, privateKey.String(), "0x612091aaa12e22dd2abef664f8a01a82cae99ad7441b7ef8110424915c268bc2")
+
+		expectedPrivateKeys := []string{
+			"0x6939694369114c67917a182c59ddb8cafc3004e63ca5d3b84403ba8613debc0c",
+			"0x284e9d38d07d21e4e281b645089a94f4cf5a5a81369acf151a1c3a57f18b2129",
+			"0x694596e8a54f252c960eb771a3c41e7e32496d03b954aeb90f61635b8e092aa7",
+			"0x5996c37fd3dd2679039b23ed6f70b506c6b56b3cb5e424681fb0fa64caf82aaa",
+			"0x21c4f269ef0a5fd1badf47eeacebeeaa3de22eb8e5b0adcd0f27dd99d34d0119",
+		}
+		for i, n := range path {
+			accountKey, _ = accountKey.NewChildKey(n)
+			privateKey, _ := crypto.DecodePrivateKey(sigAlgo, accountKey.Key)
+
+			assert.Equal(t, privateKey.String(), expectedPrivateKeys[i])
+
+		}
 	})
 
 	t.Run("Generate Keys with mnemonic (default path)", func(t *testing.T) {


### PR DESCRIPTION
Closes #???

## Description

Hao from lilico alerter on discord about SLIP10 [0] [1]; when I was developing BIP44 I developed with BIP32 ( which is using same private key generation for P256 as sec256k1 )

But seems https://github.com/satoshilabs has some SLIP for this, and it is even mentioned in our FLIP about hd wallet generation.  

So I fixed our implementation to use SLIP10 instead of BIP32. 


[0] https://discord.com/channels/613813861610684416/709804784089301002/1038105907806081064
[1] https://github.com/satoshilabs/slips/blob/master/slip-0010.md
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
