### PR TITLE
Add sandboxnet to default networks

### DIFF
--- a/pkg/flowkit/config/network.go
+++ b/pkg/flowkit/config/network.go
@@ -86,6 +86,13 @@ func DefaultTestnetNetwork() Network {
 	}
 }
 
+func DefaultSandboxNetwork() Network {
+	return Network{
+		Name: "sandboxnet",
+		Host: "secure.sandboxnet.nodes.onflow.org",
+	}
+}
+
 // DefaultMainnetNetwork get default mainnet network.
 func DefaultMainnetNetwork() Network {
 	return Network{
@@ -99,6 +106,7 @@ func DefaultNetworks() Networks {
 	return Networks{
 		DefaultEmulatorNetwork(),
 		DefaultTestnetNetwork(),
+		DefaultSandboxNetwork(),
 		DefaultMainnetNetwork(),
 	}
 }

--- a/pkg/flowkit/config/network.go
+++ b/pkg/flowkit/config/network.go
@@ -89,7 +89,7 @@ func DefaultTestnetNetwork() Network {
 func DefaultSandboxNetwork() Network {
 	return Network{
 		Name: "sandboxnet",
-		Host: "secure.sandboxnet.nodes.onflow.org:9000",
+		Host: "access.sandboxnet.nodes.onflow.org:9000",
 	}
 }
 

--- a/pkg/flowkit/config/network.go
+++ b/pkg/flowkit/config/network.go
@@ -89,7 +89,7 @@ func DefaultTestnetNetwork() Network {
 func DefaultSandboxNetwork() Network {
 	return Network{
 		Name: "sandboxnet",
-		Host: "secure.sandboxnet.nodes.onflow.org",
+		Host: "secure.sandboxnet.nodes.onflow.org:9000",
 	}
 }
 


### PR DESCRIPTION
Add support for sandboxnet to default networks. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
