### PR TITLE
Trigger actions on release publish

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -2,7 +2,7 @@ name: Build Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   releases-matrix:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,8 @@
 name: Publish Release
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
 jobs:
   homebrew:
       name: Bump Homebrew formula

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,12 +1,8 @@
 name: Publish Release
 
-on:
-  release:
-    types: [published]
-
+on: workflow_dispatch
 jobs:
   homebrew:
-      if: github.event_name == 'release' && github.event.action == 'published' # skip for pre-release
       name: Bump Homebrew formula
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
## Description
Better to trigger on publish as created event can be skipped if done programmatically. 
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
