### PR TITLE
fix mismatching tar naming in shell install script for x86 cpu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ get_architecture() {
     esac
     case "$_cputype" in
         x86_64 | x86-64 | x64 | amd64)
-            _cputype=x86_64
+            _cputype=amd64
             ;;
          arm64 | aarch64)
             _cputype=arm64


### PR DESCRIPTION
for x84 the install script download targets with `x86_64` while the binaries' names include amd64`. E.g.
* generated name `https://github.com/onflow/flow-cli/releases/download/v0.42.0/flow-cli-v0.42.0-darwin-x86_64.tar.gz`
* actual name `https://github.com/onflow/flow-cli/releases/download/v0.42.0/flow-cli-v0.42.0-darwin-amd64.tar.gz`
