### PR TITLE
Get block height each deploy itteration

### DIFF
--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -270,13 +270,13 @@ func (p *Project) Deploy(network string, update bool) ([]*contracts.Contract, er
 	))
 	defer p.logger.StopProgress()
 
-	block, err := p.gateway.GetLatestBlock()
-	if err != nil {
-		return nil, err
-	}
-
 	deployErr := &ErrProjectDeploy{}
 	for _, contract := range orderedContracts {
+		block, err := p.gateway.GetLatestBlock()
+		if err != nil {
+			return nil, err
+		}
+
 		targetAccount, err := p.state.Accounts().ByName(contract.AccountName())
 		if err != nil {
 			return nil, fmt.Errorf("target account for deploying contract not found in configuration")


### PR DESCRIPTION
Closes #720 

## Description
In the case of a lot of deployment contracts, the block height might get outdated. Make sure to get the latest block for each iteration.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
