### PR TITLE
Update to 20mb for maxGRPCMessageSize

### DIFF
--- a/pkg/flowkit/gateway/grpc.go
+++ b/pkg/flowkit/gateway/grpc.go
@@ -35,9 +35,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// maxGRPCMessageSize 16mb, matching the value set in onflow/flow-go
+// maxGRPCMessageSize 20mb, matching the value set in onflow/flow-go
 // https://github.com/onflow/flow-go/blob/master/utils/grpc/grpc.go#L5
-const maxGRPCMessageSize = 1024 * 1024 * 16
+const maxGRPCMessageSize = 1024 * 1024 * 20
 
 // GrpcGateway is a gateway implementation that uses the Flow Access gRPC API.
 type GrpcGateway struct {


### PR DESCRIPTION
Closes #???

## Description

in tandem to https://github.com/onflow/flow-go/pull/3639

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
