### PR TITLE
Remove print statement from services.Transactions.Send

### DIFF
--- a/pkg/flowkit/services/transactions.go
+++ b/pkg/flowkit/services/transactions.go
@@ -313,8 +313,6 @@ func (t *Transactions) Send(
 	}
 
 	for _, signer := range accounts.getSigners() {
-		fmt.Println("signer ", signer.Address(), signer.Name())
-
 		err = tx.SetSigner(signer)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
## Description

Closes #728 and removes extra output that breaks JSON parsing.

See issue for details!

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
