### PR TITLE
Only trigger CD for release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 jobs:
   homebrew:
+      if: "!github.event.release.prerelease"
       name: Bump Homebrew formula
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
Closes #725 

## Description
Avoid triggering CD for pre-releases.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
