### PR TITLE
Check if contract exists before removing

### DIFF
--- a/pkg/flowkit/services/accounts_test.go
+++ b/pkg/flowkit/services/accounts_test.go
@@ -195,13 +195,24 @@ func TestAccounts(t *testing.T) {
 			gw.SendSignedTransaction.Return(tests.NewTransaction(), nil)
 		})
 
+		gw.GetAccount.Run(func(args mock.Arguments) {
+			addr := args.Get(0).(flow.Address)
+			assert.Equal(t, addr.String(), serviceAcc.Address().String())
+			racc := tests.NewAccountWithAddress(addr.String())
+			racc.Contracts = map[string][]byte{
+				tests.ContractHelloString.Name: tests.ContractHelloString.Source,
+			}
+
+			gw.GetAccount.Return(racc, nil)
+		})
+
 		account, err := s.Accounts.RemoveContract(
 			serviceAcc,
-			tests.ContractHelloString.Filename,
+			tests.ContractHelloString.Name,
 		)
 
 		gw.Mock.AssertCalled(t, tests.GetAccountFunc, serviceAddress)
-		gw.Mock.AssertNumberOfCalls(t, tests.GetAccountFunc, 1)
+		gw.Mock.AssertNumberOfCalls(t, tests.GetAccountFunc, 2)
 		gw.Mock.AssertNumberOfCalls(t, tests.GetTransactionResultFunc, 1)
 		gw.Mock.AssertNumberOfCalls(t, tests.SendSignedTransactionFunc, 1)
 		assert.NotNil(t, account)


### PR DESCRIPTION
Closes #771 

## Description
This PR makes the process of removing a contract more clear, if contract doesn't exist it lets the user know instead of just succeeding.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
