### PR TITLE
Deploy ignore non-existing contract

### DIFF
--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -250,11 +250,7 @@ func (p *Project) Deploy(network string, update bool) ([]*project.Contract, erro
 		// special case for emulator updates, where we remove and add a contract because it allows us to have more freedom in changes.
 		// Updating contracts is limited as described in https://developers.flow.com/cadence/language/contract-updatability
 		if update && network == config.DefaultEmulatorNetwork().Name {
-			_, err = accounts.RemoveContract(targetAccount, contract.Name)
-			if err != nil {
-				deployErr.add(contract, err, fmt.Sprintf("failed to remove the contract %s before the update", contract.Name))
-				continue
-			}
+			_, _ = accounts.RemoveContract(targetAccount, contract.Name) // ignore failure as it's meant to be best-effort
 		}
 
 		txID, updated, err := accounts.AddContract(


### PR DESCRIPTION
## Description
Ignore failure to remove during deploy on the emulator. This ignores non-existing contract error which is ok to skip to deploy a new contract.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
