### PR TITLE
Fix project aliases resolving with new import schema

### DIFF
--- a/pkg/flowkit/project/contract.go
+++ b/pkg/flowkit/project/contract.go
@@ -63,4 +63,5 @@ func (c *Contract) Location() string {
 	return c.location
 }
 
+// Aliases map contract locations to fixed addresses on Flow network
 type Aliases map[string]string

--- a/pkg/flowkit/project/deployment.go
+++ b/pkg/flowkit/project/deployment.go
@@ -151,7 +151,8 @@ func (d *Deployment) buildDependencies() error {
 				continue
 			}
 
-			if _, exists := d.aliases[location]; exists {
+			// todo identifier aliases
+			if _, exists := d.aliases[importPath]; exists {
 				continue // if aliased then skip, not a dependency
 			}
 

--- a/pkg/flowkit/project/deployment.go
+++ b/pkg/flowkit/project/deployment.go
@@ -51,13 +51,15 @@ type Deployment struct {
 	// map of contracts by their location specified in state
 	contractsByLocation map[string]*deployContract
 	contractsByName     map[string]*deployContract
+	aliases             Aliases
 }
 
 // NewDeployment from the flowkit Contracts and loaded from the contract location using a loader.
-func NewDeployment(contracts []*Contract) (*Deployment, error) {
+func NewDeployment(contracts []*Contract, aliases Aliases) (*Deployment, error) {
 	deployment := &Deployment{
 		contractsByLocation: make(map[string]*deployContract),
 		contractsByName:     make(map[string]*deployContract),
+		aliases:             aliases,
 	}
 
 	for _, contract := range contracts {
@@ -149,10 +151,12 @@ func (d *Deployment) buildDependencies() error {
 				continue
 			}
 
-			// todo make sure aliases are resolved
+			if _, exists := d.aliases[location]; exists {
+				continue // if aliased then skip, not a dependency
+			}
 
 			return fmt.Errorf(
-				"import from %s could not be found: %s, make sure import path is correct",
+				"import from %s could not be found: %s, make sure import path is correct, and the contract is added to deployments or has an alias",
 				contract.Name,
 				location,
 			)

--- a/pkg/flowkit/project/deployment_test.go
+++ b/pkg/flowkit/project/deployment_test.go
@@ -219,7 +219,7 @@ func TestContractDeploymentOrder(t *testing.T) {
 			}
 
 			if strings.Contains(testCase.name, "unresolved") {
-				assert.EqualError(t, err, "import from ContractH could not be found: Foo.cdc, make sure import path is correct")
+				assert.EqualError(t, err, "import from ContractH could not be found: Foo.cdc, make sure import path is correct, and the contract is added to deployments or has an alias")
 				return
 			}
 

--- a/pkg/flowkit/project/deployment_test.go
+++ b/pkg/flowkit/project/deployment_test.go
@@ -211,7 +211,7 @@ func TestContractDeploymentOrder(t *testing.T) {
 				)
 			}
 
-			deployment, err := NewDeployment(contracts)
+			deployment, err := NewDeployment(contracts, nil)
 
 			contracts, err = deployment.Sort()
 			if !strings.Contains(testCase.name, "unresolved") && !strings.Contains(testCase.name, "cycle") {

--- a/pkg/flowkit/project/program_test.go
+++ b/pkg/flowkit/project/program_test.go
@@ -88,10 +88,6 @@ func TestProgram(t *testing.T) {
 		}}
 
 		for i, test := range tests {
-			if i+1 < len(tests) {
-				continue
-			} // todo remove
-
 			program, err := NewProgram(&testScript{code: test.code})
 			require.NoError(t, err, fmt.Sprintf("import test %d failed", i))
 			assert.Equal(t, len(test.imports) > 0, program.HasImports(), fmt.Sprintf("import test %d failed", i))

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -220,7 +220,7 @@ func (p *Project) Deploy(network string, update bool) ([]*project.Contract, erro
 		return nil, err
 	}
 
-	deployment, err := project.NewDeployment(contracts)
+	deployment, err := project.NewDeployment(contracts, p.state.AliasesForNetwork(network))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flowkit/services/project_test.go
+++ b/pkg/flowkit/services/project_test.go
@@ -19,14 +19,17 @@
 package services
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-cli/pkg/flowkit/config"
@@ -152,10 +155,29 @@ func TestProject(t *testing.T) {
 		}
 		state.Deployments().AddOrUpdate(d)
 
+		// for checking imports are correctly resolved
+		resolved := map[string]string{
+			tests.ContractB.Name: fmt.Sprintf(`import ContractA from 0x%s`, tests.Donald().Address().Hex()),
+			tests.ContractC.Name: fmt.Sprintf(`
+		import ContractB from 0x%s
+		import ContractA from 0x%s`, a.Address().Hex(), tests.Donald().Address().Hex()),
+		} // don't change formatting of the above code since it compares the strings with included formatting
+
 		gw.SendSignedTransaction.Run(func(args mock.Arguments) {
 			tx := args.Get(0).(*flowkit.Transaction)
 			assert.Equal(t, tx.FlowTransaction().Payer, a.Address())
 			assert.True(t, strings.Contains(string(tx.FlowTransaction().Script), "signer.contracts.add"))
+
+			argCode := tx.FlowTransaction().Arguments[1]
+			decodeCode, _ := jsoncdc.Decode(nil, argCode)
+			code, _ := hex.DecodeString(decodeCode.ToGoValue().(string))
+
+			argName := tx.FlowTransaction().Arguments[0]
+			decodeName, _ := jsoncdc.Decode(nil, argName)
+
+			testCode, found := resolved[decodeName.ToGoValue().(string)]
+			require.True(t, found)
+			assert.True(t, strings.Contains(string(code), testCode))
 
 			gw.SendSignedTransaction.Return(tests.NewTransaction(), nil)
 		})
@@ -163,10 +185,14 @@ func TestProject(t *testing.T) {
 		contracts, err := s.Project.Deploy(emulator, false)
 
 		assert.NoError(t, err)
-		assert.Equal(t, len(contracts), 1)
+		assert.Equal(t, len(contracts), 2)
 		gw.Mock.AssertCalled(t, tests.GetLatestBlockFunc)
 		gw.Mock.AssertCalled(t, tests.GetAccountFunc, a.Address())
-		gw.Mock.AssertNumberOfCalls(t, tests.GetTransactionResultFunc, 1)
+		gw.Mock.AssertNumberOfCalls(t, tests.GetTransactionResultFunc, 2)
+	})
+
+	t.Run("Deploy Project New Import Schema and Aliases", func(t *testing.T) {
+		// todo
 	})
 
 	t.Run("Deploy Project Duplicate Address", func(t *testing.T) {

--- a/pkg/flowkit/state.go
+++ b/pkg/flowkit/state.go
@@ -222,7 +222,8 @@ func (p *State) AliasesForNetwork(network string) project.Aliases {
 	// get all contracts for selected network and if any has an address as target make it an alias
 	for _, contract := range p.conf.Contracts.ByNetwork(network) {
 		if contract.IsAlias() {
-			aliases[path.Clean(contract.Location)] = contract.Alias
+			aliases[path.Clean(contract.Location)] = contract.Alias // alias for import by file location
+			aliases[contract.Name] = contract.Alias                 // alias for import by name
 		}
 	}
 

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -481,7 +481,7 @@ func Test_GetAliases(t *testing.T) {
 	aliases := p.AliasesForNetwork("emulator")
 	contracts, _ := p.DeploymentContractsByNetwork("emulator")
 
-	assert.Len(t, aliases, 1)
+	assert.Len(t, aliases, 2)
 	assert.Equal(t, aliases["../hungry-kitties/cadence/contracts/FungibleToken.cdc"], "ee82856bf20e2aa6")
 	assert.Len(t, contracts, 1)
 	assert.Equal(t, contracts[0].Name, "NonFungibleToken")
@@ -499,11 +499,11 @@ func Test_GetAliasesComplex(t *testing.T) {
 	assert.Len(t, cEmulator, 1)
 	assert.Equal(t, cEmulator[0].Name, "NonFungibleToken")
 
-	assert.Len(t, aEmulator, 2)
+	assert.Len(t, aEmulator, 4)
 	assert.Equal(t, aEmulator["../hungry-kitties/cadence/contracts/FungibleToken.cdc"], "ee82856bf20e2aa6")
 	assert.Equal(t, aEmulator["../hungry-kitties/cadence/contracts/Kibble.cdc"], "ee82856bf20e2aa6")
 
-	assert.Len(t, aTestnet, 1)
+	assert.Len(t, aTestnet, 2)
 	assert.Equal(t, aTestnet["../hungry-kitties/cadence/contracts/Kibble.cdc"], "ee82856bf20e2aa6")
 
 	assert.Len(t, cTestnet, 2)

--- a/pkg/flowkit/tests/resources.go
+++ b/pkg/flowkit/tests/resources.go
@@ -339,6 +339,9 @@ var resources = []Resource{
 	ContractA,
 	ContractB,
 	ContractC,
+	ContractAA,
+	ContractBB,
+	ContractCC,
 }
 
 func ReaderWriter() (afero.Afero, afero.Fs) {

--- a/pkg/flowkit/tests/resources.go
+++ b/pkg/flowkit/tests/resources.go
@@ -154,6 +154,37 @@ var ContractC = Resource{
 	`),
 }
 
+var ContractAA = Resource{
+	Name:     "ContractAA",
+	Filename: "contractAA.cdc",
+	Source:   []byte(`pub contract ContractAA {}`),
+}
+
+var ContractBB = Resource{
+	Name:     "ContractBB",
+	Filename: "contractBB.cdc",
+	Source: []byte(`
+		import "ContractAA"
+		pub contract ContractB {}
+	`),
+}
+
+var ContractCC = Resource{
+	Name:     "ContractCC",
+	Filename: "contractCC.cdc",
+	Source: []byte(`
+		import "ContractBB"
+		import "ContractAA"
+
+		pub contract ContractC {
+			pub let x: String
+			init(x: String) {
+				self.x = x
+			}
+		}
+	`),
+}
+
 var TransactionArgString = Resource{
 	Filename: "transactionArg.cdc",
 	Source: []byte(`


### PR DESCRIPTION
Closes: #812 #821 

There was a regression in how the new import schema works with the aliases. Tests were added to assert functioning and fix was made.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
