### PR TITLE
Bugfix remove new line in the filter output

### DIFF
--- a/internal/command/result.go
+++ b/internal/command/result.go
@@ -66,7 +66,7 @@ func formatResult(result Result, filterFlag string, formatFlag string) (string, 
 			return "", err
 		}
 
-		return fmt.Sprintf("%v\n", value), nil
+		return fmt.Sprintf("%v", value), nil
 	}
 
 	switch strings.ToLower(formatFlag) {


### PR DESCRIPTION
Closes #829 #828 

## Description
Remove a new line at the end of a filtered output.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
