### PR TITLE
Reference scaffolds by commit hashes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,7 @@ with the bellow content.
 {
   "name": "name of the scaffold",
   "repo": "HTTP URL to the repository containing the scaffold",
+  "commit": "Hash of the (latest) commit in your scaffold repository",
   "branch": "scaffold repository branch",
   "description": "user friendly description of the scaffold (what it contains, why it is used...)"
 }

--- a/scaffolds.json
+++ b/scaffolds.json
@@ -2,7 +2,7 @@
   {
     "name": "Simple Cadence Project",
     "repo": "https://github.com/sideninja/flow-basic-scaffold.git",
-    "branch": "main",
+    "tag": "v0.1.0",
     "description": "Scaffold contains required folder structure as well as some example Cadence code."
   }
 ]

--- a/scaffolds.json
+++ b/scaffolds.json
@@ -2,7 +2,7 @@
   {
     "name": "Simple Cadence Project",
     "repo": "https://github.com/sideninja/flow-basic-scaffold.git",
-    "tag": "v0.1.0",
-    "description": "Scaffold contains required folder structure as well as some example Cadence code."
+    "description": "Scaffold contains required folder structure as well as some example Cadence code.",
+    "commit": "0646fecc2f4da65aa5d7a7c8060c2bb741dcb879"
   }
 ]


### PR DESCRIPTION
Closes #797 

## Description
Reference scaffold by commit hash so the changes are not automatically reflected when running the setup command. We use a commit hash instead of a tag because you can change the tag to a new reference. We want to enforce our review process before pushing an update.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
