### PR TITLE
Add install and run to contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Use your best judgment, and feel free to propose changes to this document in a p
 
 ## Table Of Contents
 
-[Getting Started](#project-overview)
+[Getting Started](#getting-started)
 
 [How Can I Contribute?](#how-can-i-contribute)
 
@@ -21,6 +21,20 @@ Use your best judgment, and feel free to propose changes to this document in a p
 - [Go Styleguide](#go-styleguide)
 
 [Additional Notes](#additional-notes)
+
+## Getting Started
+
+Install the necessary dependencies:
+
+```
+go get ./...
+```
+
+To run the repo:
+
+```
+go run cmd/main.go
+```
 
 ## How Can I Contribute?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ go get ./...
 To run the repo:
 
 ```
-go run cmd/main.go
+go run cmd/flow/main.go
 ```
 
 ## How Can I Contribute?


### PR DESCRIPTION
Closes https://github.com/onflow/flow-cli/issues/839

## Description

Docs were missing install and run commands for repo. Added.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
