### PR TITLE
Fix URL in supper commands help banner

### DIFF
--- a/internal/super/output.go
+++ b/internal/super/output.go
@@ -138,7 +138,7 @@ func failureDeployment(err error, contractPathNames map[string]string) string {
 func helpBanner() string {
 	var out bytes.Buffer
 	out.WriteString(output.Italic("The development environment will watch your Cadence files and automatically keep your project updated on the emulator.\n"))
-	out.WriteString(output.Italic("Please add your contracts in the contracts folder. Read more about it here: https://developers.flow.com/tools/flow-cli/supercommands\n"))
+	out.WriteString(output.Italic("Please add your contracts in the contracts folder. Read more about it here: https://developers.flow.com/tools/flow-cli/super-commands\n"))
 	out.WriteString(output.Italic("Be aware that resources stored in accounts might no longer be valid after contract code changes.\n\n"))
 	return out.String()
 }


### PR DESCRIPTION
## Description

The URL shown under the super commands help banner is invalid:

![Screenshot 2023-02-19 at 16 16 46](https://user-images.githubusercontent.com/36109955/219957145-3425272d-5071-43ec-986e-9577705202ce.png)

![Screenshot 2023-02-19 at 16 17 13](https://user-images.githubusercontent.com/36109955/219957186-40ac08c3-407e-4b5f-a401-fb7d14f46cd2.png)
