### PR TITLE
Alternative to a required cadence folder when using dev command

### DIFF
--- a/internal/super/files.go
+++ b/internal/super/files.go
@@ -71,7 +71,11 @@ type projectFiles struct {
 // exist checks if current directory contains all project files required.
 func (f *projectFiles) exist() error {
 	if _, err := os.Stat(f.cadencePath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("required cadence folder does not exist")
+		if _, err := os.Stat(contractDir); errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("required cadence folder or contract folder does not exist")
+		} else if err == nil {
+			f.cadencePath = "" // in case there's no cadence folder we just use contracts folder directly
+		}
 	}
 	if _, err := os.Stat(config.DefaultPath); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("required project configuration ('flow.json') does not exist")


### PR DESCRIPTION
Closes #836 

## Description
If `cadence` folder is not present fallback to using `contracts` and other standard folders.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
