### PR TITLE
Change const to var for build variables

### DIFF
--- a/internal/accounts/create-interactive.go
+++ b/internal/accounts/create-interactive.go
@@ -96,7 +96,7 @@ func createInteractive(state *flowkit.State) error {
 	return nil
 }
 
-const (
+var (
 	testAddress = ""
 	mainAddress = ""
 	testKey     = ""


### PR DESCRIPTION
Defining variable as const doesn't work with variables passed in as build flags.