### PR TITLE
Refactor contract aliases

### DIFF
--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -67,7 +67,7 @@ func addContract(
 		contractData = output.NewContractPrompt()
 	}
 
-	contracts := config.StringToContracts(
+	contract := config.StringToContract(
 		contractData["name"],
 		contractData["source"],
 		contractData["emulator"],
@@ -75,9 +75,7 @@ func addContract(
 		contractData["mainnet"],
 	)
 
-	for _, contract := range contracts {
-		state.Contracts().AddOrUpdate(contract.Name, contract)
-	}
+	state.Contracts().AddOrUpdate(contract.Name, contract)
 
 	err = state.SaveEdited(globalFlags.ConfigPaths)
 	if err != nil {

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -75,7 +75,7 @@ func addContract(
 		contractData["mainnet"],
 	)
 
-	state.Contracts().AddOrUpdate(contract.Name, contract)
+	state.Contracts().AddOrUpdate(contract)
 
 	err = state.SaveEdited(globalFlags.ConfigPaths)
 	if err != nil {

--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -298,7 +298,7 @@ func (p *project) renameContract(oldLocation string, newLocation string) {
 	for _, c := range *p.state.Contracts() {
 		if c.Location == oldLocation {
 			c.Location = newLocation
-			p.state.Contracts().AddOrUpdate(c.Name, c)
+			p.state.Contracts().AddOrUpdate(c)
 		}
 	}
 }

--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -267,7 +267,7 @@ func (p *project) addContract(
 		Name: contract.Name,
 	}
 
-	p.state.Contracts().AddOrUpdate(name, contract)
+	p.state.Contracts().AddOrUpdate(contract)
 	p.state.Deployments().AddContract(account, emulator, deployment)
 	return nil
 }

--- a/pkg/flowkit/CHANGELOG.md
+++ b/pkg/flowkit/CHANGELOG.md
@@ -24,6 +24,11 @@ already part of the contract you are adding.
 - Package: `config`
 - Type: `Contracts`
 
+---
+Don't return error if contract by name not found but rather just a `nil`.
+- Method: `ByName`
+- Package: `config`
+- Type: `Contracts`
 
 ### Added
 

--- a/pkg/flowkit/CHANGELOG.md
+++ b/pkg/flowkit/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Flowkit Changelog
+
+All notable changes to flowkit APIs will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+---
+The `Network` property was removed from `Contract` type. The network is now included in 
+the `Aliases` on the contract. We also removed having multiple contracts by same name just to 
+accommodate multiple aliases. Now there's only one contract identified by name, 
+and if there are multiple network aliases they are contained in the `Aliases` list. 
+- Package: `config`
+- Type: `Contracts`
+
+---
+A method `Contracts.AddOrUpdate(name, contract)` was changed to not include the name, as it's 
+already part of the contract you are adding.
+- Method: `AddOrUpdate`
+- Package: `config`
+- Type: `Contracts`
+
+
+### Added
+
+---
+
+New type `Aliases` was added to `Contracts`. 
+Aliases contain new functions to get the aliases by network and add new aliases.
+- Package: `config`
+- Type: `Contracts`
+

--- a/pkg/flowkit/config/config.go
+++ b/pkg/flowkit/config/config.go
@@ -78,8 +78,7 @@ func (c *Config) Validate() error {
 		}
 
 		for _, con := range d.Contracts {
-			_, err := c.Contracts.ByName(con.Name)
-			if err != nil {
+			if c.Contracts.ByName(con.Name) == nil {
 				return fmt.Errorf("deployment contains nonexisting contract %s", con.Name)
 			}
 		}

--- a/pkg/flowkit/config/config.go
+++ b/pkg/flowkit/config/config.go
@@ -56,9 +56,11 @@ const (
 // Validate the configuration values.
 func (c *Config) Validate() error {
 	for _, con := range c.Contracts {
-		_, err := c.Networks.ByName(con.Network)
-		if con.Network != "" && err != nil {
-			return fmt.Errorf("contract %s contains nonexisting network %s", con.Name, con.Network)
+		for _, alias := range con.Aliases {
+			_, err := c.Networks.ByName(alias.Network)
+			if alias.Network != "" && err != nil {
+				return fmt.Errorf("contract %s alias contains nonexisting network %s", con.Name, alias.Network)
+			}
 		}
 	}
 

--- a/pkg/flowkit/config/config_test.go
+++ b/pkg/flowkit/config/config_test.go
@@ -151,7 +151,7 @@ func Test_GetContractsByNameAndNetworkComplex(t *testing.T) {
 	market, err := conf.Contracts.ByName("KittyItemsMarket")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "0x123123123", market.Aliases.ByNetwork("testnet").Address.String())
+	assert.Equal(t, "0000000123123123", market.Aliases.ByNetwork("testnet").Address.String())
 }
 
 func Test_GetAccountByNameComplex(t *testing.T) {

--- a/pkg/flowkit/config/config_test.go
+++ b/pkg/flowkit/config/config_test.go
@@ -137,10 +137,11 @@ func generateComplexConfig() config.Config {
 
 func Test_GetContractsForNetworkComplex(t *testing.T) {
 	conf := generateComplexConfig()
-	kitty, err := conf.Contracts.ByName("KittyItems")
-	assert.NoError(t, err)
-	market, err := conf.Contracts.ByName("KittyItemsMarket")
-	assert.NoError(t, err)
+	kitty := conf.Contracts.ByName("KittyItems")
+	assert.NotNil(t, kitty)
+
+	market := conf.Contracts.ByName("KittyItemsMarket")
+	assert.NotNil(t, market)
 
 	assert.Equal(t, "KittyItems", kitty.Name)
 	assert.Equal(t, "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc", market.Location)
@@ -148,8 +149,8 @@ func Test_GetContractsForNetworkComplex(t *testing.T) {
 
 func Test_GetContractsByNameAndNetworkComplex(t *testing.T) {
 	conf := generateComplexConfig()
-	market, err := conf.Contracts.ByName("KittyItemsMarket")
-	assert.NoError(t, err)
+	market := conf.Contracts.ByName("KittyItemsMarket")
+	assert.NotNil(t, market)
 
 	assert.Equal(t, "0000000123123123", market.Aliases.ByNetwork("testnet").Address.String())
 }

--- a/pkg/flowkit/config/config_test.go
+++ b/pkg/flowkit/config/config_test.go
@@ -46,27 +46,25 @@ func generateComplexConfig() config.Config {
 		Contracts: config.Contracts{{
 			Name:     "NonFungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "FungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/FungibleToken.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "Kibble",
 			Location: "./cadence/kibble/contracts/Kibble.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "KittyItems",
 			Location: "./cadence/kittyItems/contracts/KittyItems.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "KittyItemsMarket",
 			Location: "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc",
-			Network:  "emulator",
+			Aliases: []config.Alias{{
+				Network: "testnet",
+				Address: flow.HexToAddress("0x123123123"),
+			}},
 		}, {
 			Name:     "KittyItemsMarket",
 			Location: "0x123123123",
-			Network:  "testnet",
 		}},
 		Deployments: config.Deployments{{
 			Network: "emulator",
@@ -150,22 +148,10 @@ func Test_GetContractsForNetworkComplex(t *testing.T) {
 
 func Test_GetContractsByNameAndNetworkComplex(t *testing.T) {
 	conf := generateComplexConfig()
-	market, err := conf.Contracts.ByNameAndNetwork("KittyItemsMarket", "testnet")
+	market, err := conf.Contracts.ByName("KittyItemsMarket")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "0x123123123", market.Location)
-}
-
-func Test_GetContractsByNetworkComplex(t *testing.T) {
-	conf := generateComplexConfig()
-	contracts := conf.Contracts.ByNetwork("emulator")
-
-	assert.Len(t, contracts, 5)
-	assert.Equal(t, "NonFungibleToken", contracts[0].Name)
-	assert.Equal(t, "FungibleToken", contracts[1].Name)
-	assert.Equal(t, "Kibble", contracts[2].Name)
-	assert.Equal(t, "KittyItems", contracts[3].Name)
-	assert.Equal(t, "KittyItemsMarket", contracts[4].Name)
+	assert.Equal(t, "0x123123123", market.Aliases.ByNetwork("testnet").Address.String())
 }
 
 func Test_GetAccountByNameComplex(t *testing.T) {

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -50,8 +50,8 @@ func (a *Aliases) ByNetwork(network string) *Alias {
 
 type Contracts []Contract
 
-// IsAlias checks if contract has an alias.
-func (c *Contract) IsAlias() bool {
+// IsAliased checks if contract has an alias.
+func (c *Contract) IsAliased() bool {
 	return len(c.Aliases) > 0
 }
 

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -80,9 +80,9 @@ func (c *Contracts) ByName(name string) (*Contract, error) {
 }
 
 // AddOrUpdate add new or update if already present.
-func (c *Contracts) AddOrUpdate(name string, contract Contract) {
+func (c *Contracts) AddOrUpdate(contract Contract) {
 	for i, existingContract := range *c {
-		if existingContract.Name == name {
+		if existingContract.Name == contract.Name {
 			(*c)[i] = contract
 			return
 		}

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -31,6 +31,7 @@ type Contract struct {
 	Aliases  Aliases
 }
 
+// Alias defines an existing pre-deployed contract address for specific network.
 type Alias struct {
 	Network string
 	Address flow.Address

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -18,43 +18,41 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go-sdk"
+)
 
 // Contract defines the configuration for a Cadence contract.
 type Contract struct {
 	Name     string
 	Location string
-	Network  string
-	Alias    string
+	Aliases  Aliases
+}
+
+type Alias struct {
+	Network string
+	Address flow.Address
+}
+
+type Aliases []Alias
+
+func (a *Aliases) ByNetwork(network string) *Alias {
+	for _, alias := range *a {
+		if alias.Network == network {
+			return &alias
+		}
+	}
+
+	return nil
 }
 
 type Contracts []Contract
 
 // IsAlias checks if contract has an alias.
 func (c *Contract) IsAlias() bool {
-	return c.Alias != ""
-}
-
-// ByNameAndNetwork get contract array for account and network.
-func (c *Contracts) ByNameAndNetwork(name string, network string) (*Contract, error) {
-	for _, contract := range *c {
-		if contract.Network == network && contract.Name == name {
-			return &contract, nil
-		}
-	}
-
-	// if we don't find contract by name and network create a new contract
-	// and replace only name and source with existing
-	cName, err := c.ByName(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Contract{
-		Name:     cName.Name,
-		Network:  network,
-		Location: cName.Location,
-	}, nil
+	return len(c.Aliases) > 0
 }
 
 // ByName get contract by name.
@@ -68,24 +66,10 @@ func (c *Contracts) ByName(name string) (*Contract, error) {
 	return nil, fmt.Errorf("contract named %s does not exist in configuration", name)
 }
 
-// ByNetwork returns all contracts for specific network.
-func (c *Contracts) ByNetwork(network string) Contracts {
-	var contracts []Contract
-
-	for _, contract := range *c {
-		if contract.Network == network || contract.Network == "" {
-			contracts = append(contracts, contract)
-		}
-	}
-
-	return contracts
-}
-
 // AddOrUpdate add new or update if already present.
 func (c *Contracts) AddOrUpdate(name string, contract Contract) {
 	for i, existingContract := range *c {
-		if existingContract.Name == name &&
-			existingContract.Network == contract.Network {
+		if existingContract.Name == name {
 			(*c)[i] = contract
 			return
 		}

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -19,6 +19,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go-sdk"
 )
 
@@ -91,9 +93,8 @@ func (c *Contracts) AddOrUpdate(contract Contract) {
 
 // Remove contract by its name.
 func (c *Contracts) Remove(name string) error {
-	_, err := c.ByName(name)
-	if err != nil {
-		return err
+	if c.ByName(name) != nil {
+		return fmt.Errorf("contract by name %s doesn't exist", name)
 	}
 
 	for i, contract := range *c {

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -19,8 +19,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/onflow/flow-go-sdk"
 )
 
@@ -69,14 +67,14 @@ func (c *Contract) IsAliased() bool {
 }
 
 // ByName get contract by name.
-func (c *Contracts) ByName(name string) (*Contract, error) {
+func (c *Contracts) ByName(name string) *Contract {
 	for _, contract := range *c {
 		if contract.Name == name {
-			return &contract, nil
+			return &contract
 		}
 	}
 
-	return nil, fmt.Errorf("contract named %s does not exist in configuration", name)
+	return nil
 }
 
 // AddOrUpdate add new or update if already present.

--- a/pkg/flowkit/config/contract.go
+++ b/pkg/flowkit/config/contract.go
@@ -49,6 +49,18 @@ func (a *Aliases) ByNetwork(network string) *Alias {
 	return nil
 }
 
+func (a *Aliases) Add(network string, address flow.Address) {
+	for _, alias := range *a {
+		if alias.Network == network {
+			return // already exists
+		}
+	}
+	*a = append(*a, Alias{
+		Network: network,
+		Address: address,
+	})
+}
+
 type Contracts []Contract
 
 // IsAliased checks if contract has an alias.

--- a/pkg/flowkit/config/json/contract_test.go
+++ b/pkg/flowkit/config/json/contract_test.go
@@ -76,14 +76,14 @@ func Test_ConfigContractsComplex(t *testing.T) {
 	assert.Equal(t, "./cadence/kittyItems/contracts/KittyItems.cdc", kittyItems.Location)
 	assert.Equal(t, "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc", kittyItemsMarket.Location)
 
-	assert.Equal(t, "", kittyItemsMarket.Aliases.ByNetwork("emulator"))
+	assert.True(t, kittyItemsMarket.Aliases.ByNetwork("emulator") == nil)
 
 	assert.True(t, kittyItemsMarket.IsAliased())
-	assert.Equal(t, nil, kittyItemsMarket.Aliases.ByNetwork("emulator"))
+	assert.True(t, kittyItemsMarket.Aliases.ByNetwork("emulator") == nil)
 	assert.Equal(t, "f8d6e0586b0a20c7", kittyItemsMarket.Aliases.ByNetwork("testnet").Address.String())
 
 	assert.False(t, kittyItems.IsAliased())
-	assert.Equal(t, nil, kittyItems.Aliases.ByNetwork("emulator"))
+	assert.True(t, kittyItems.Aliases.ByNetwork("emulator") == nil)
 }
 
 func Test_ConfigContractsAliases(t *testing.T) {

--- a/pkg/flowkit/config/json/contract_test.go
+++ b/pkg/flowkit/config/json/contract_test.go
@@ -67,29 +67,23 @@ func Test_ConfigContractsComplex(t *testing.T) {
 
 	assert.Len(t, contracts, 2)
 
-	contract, err := contracts.ByName("KittyItems")
-	assert.NoError(t, err)
-	kittyItemsMarketEmulator, err := contracts.ByNameAndNetwork("KittyItemsMarket", "emulator")
+	kittyItems, err := contracts.ByName("KittyItems")
 	assert.NoError(t, err)
 
-	kittyItemsMarketTestnet, err := contracts.ByNameAndNetwork("KittyItemsMarket", "testnet")
+	kittyItemsMarket, err := contracts.ByName("KittyItemsMarket")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "./cadence/kittyItems/contracts/KittyItems.cdc", contract.Location)
-	assert.Equal(t, "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc", kittyItemsMarketEmulator.Location)
-	assert.Equal(t, "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc", kittyItemsMarketTestnet.Location)
+	assert.Equal(t, "./cadence/kittyItems/contracts/KittyItems.cdc", kittyItems.Location)
+	assert.Equal(t, "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc", kittyItemsMarket.Location)
 
-	kittyItemsEmulator, err := contracts.ByNameAndNetwork("KittyItems", "emulator")
-	assert.NoError(t, err)
+	assert.Equal(t, "", kittyItemsMarket.Aliases.ByNetwork("emulator"))
 
-	kittyItemsTestnet, err := contracts.ByNameAndNetwork("KittyItems", "testnet")
-	assert.NoError(t, err)
+	assert.True(t, kittyItemsMarket.IsAliased())
+	assert.Equal(t, nil, kittyItemsMarket.Aliases.ByNetwork("emulator"))
+	assert.Equal(t, "f8d6e0586b0a20c7", kittyItemsMarket.Aliases.ByNetwork("testnet").Address.String())
 
-	assert.Equal(t, "", kittyItemsEmulator.Alias)
-	assert.Equal(t, "", kittyItemsTestnet.Alias)
-
-	assert.Equal(t, "f8d6e0586b0a20c7", kittyItemsMarketTestnet.Alias)
-	assert.Equal(t, "", kittyItemsMarketEmulator.Alias)
+	assert.False(t, kittyItems.IsAliased())
+	assert.Equal(t, nil, kittyItems.Aliases.ByNetwork("emulator"))
 }
 
 func Test_ConfigContractsAliases(t *testing.T) {
@@ -119,37 +113,21 @@ func Test_ConfigContractsAliases(t *testing.T) {
 
 	fungibleToken, err := contracts.ByName("FungibleToken")
 	assert.NoError(t, err)
-	fungibleTokenEmulator, err := contracts.ByNameAndNetwork("FungibleToken", "emulator")
-	assert.NoError(t, err)
-
-	fungibleTokenTestnet, err := contracts.ByNameAndNetwork("FungibleToken", "testnet")
-	assert.NoError(t, err)
-
-	assert.Equal(t, "emulator", fungibleToken.Network)
-	assert.Equal(t, "e5a8b7f23e8b548f", fungibleToken.Alias)
+	assert.True(t, fungibleToken.IsAliased())
+	assert.Equal(t, "e5a8b7f23e8b548f", fungibleToken.Aliases.ByNetwork("emulator").Address.String())
 	assert.Equal(t, "../hungry-kitties/cadence/contracts/FungibleToken.cdc", fungibleToken.Location)
-	assert.Equal(t, "e5a8b7f23e8b548f", fungibleTokenEmulator.Alias)
-	assert.Equal(t, "", fungibleTokenTestnet.Alias)
-	assert.Equal(t, "testnet", fungibleTokenTestnet.Network)
-	assert.Equal(t, "../hungry-kitties/cadence/contracts/FungibleToken.cdc", fungibleTokenTestnet.Location)
-	assert.Equal(t, "../hungry-kitties/cadence/contracts/FungibleToken.cdc", fungibleTokenEmulator.Location)
 
-	kibbleTestnet, err := contracts.ByNameAndNetwork("Kibble", "testnet")
+	kibble, err := contracts.ByName("Kibble")
 	assert.NoError(t, err)
+	assert.True(t, kibble.IsAliased())
+	assert.Equal(t, "../hungry-kitties/cadence/contracts/Kibble.cdc", kibble.Location)
+	assert.Equal(t, "ead892083b3e2c6c", kibble.Aliases.ByNetwork("testnet").Address.String())
+	assert.Equal(t, "f8d6e0586b0a20c7", kibble.Aliases.ByNetwork("emulator").Address.String())
 
-	kibbleEmulator, err := contracts.ByNameAndNetwork("Kibble", "emulator")
+	nft, err := contracts.ByName("NonFungibleToken")
 	assert.NoError(t, err)
-
-	assert.Equal(t, kibbleTestnet.Network, "testnet")
-	assert.Equal(t, kibbleTestnet.Alias, "ead892083b3e2c6c")
-	assert.Equal(t, kibbleEmulator.Alias, "f8d6e0586b0a20c7")
-	assert.Equal(t, kibbleTestnet.Location, "../hungry-kitties/cadence/contracts/Kibble.cdc")
-	nftTestnet, err := contracts.ByNameAndNetwork("NonFungibleToken", "testnet")
-	assert.NoError(t, err)
-
-	assert.Equal(t, nftTestnet.Network, "testnet")
-	assert.Equal(t, nftTestnet.Alias, "")
-	assert.Equal(t, nftTestnet.Location, "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc")
+	assert.False(t, nft.IsAliased())
+	assert.Equal(t, nft.Location, "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc")
 }
 
 func Test_TransformContractToJSON(t *testing.T) {

--- a/pkg/flowkit/config/json/contract_test.go
+++ b/pkg/flowkit/config/json/contract_test.go
@@ -37,11 +37,11 @@ func Test_ConfigContractsSimple(t *testing.T) {
 	contracts, err := jsonContracts.transformToConfig()
 	assert.NoError(t, err)
 
-	contract, err := contracts.ByName("KittyItems")
-	assert.NoError(t, err)
+	contract := contracts.ByName("KittyItems")
+	assert.NotNil(t, contract)
 
-	marketContract, err := contracts.ByName("KittyItemsMarket")
-	assert.NoError(t, err)
+	marketContract := contracts.ByName("KittyItemsMarket")
+	assert.NotNil(t, marketContract)
 
 	assert.Equal(t, "./cadence/kittyItems/contracts/KittyItems.cdc", contract.Location)
 	assert.Equal(t, "./cadence/kittyItems/contracts/KittyItemsMarket.cdc", marketContract.Location)
@@ -67,11 +67,11 @@ func Test_ConfigContractsComplex(t *testing.T) {
 
 	assert.Len(t, contracts, 2)
 
-	kittyItems, err := contracts.ByName("KittyItems")
-	assert.NoError(t, err)
+	kittyItems := contracts.ByName("KittyItems")
+	assert.NotNil(t, kittyItems)
 
-	kittyItemsMarket, err := contracts.ByName("KittyItemsMarket")
-	assert.NoError(t, err)
+	kittyItemsMarket := contracts.ByName("KittyItemsMarket")
+	assert.NotNil(t, kittyItemsMarket)
 
 	assert.Equal(t, "./cadence/kittyItems/contracts/KittyItems.cdc", kittyItems.Location)
 	assert.Equal(t, "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc", kittyItemsMarket.Location)
@@ -111,21 +111,21 @@ func Test_ConfigContractsAliases(t *testing.T) {
 	contracts, err := jsonContracts.transformToConfig()
 	assert.NoError(t, err)
 
-	fungibleToken, err := contracts.ByName("FungibleToken")
-	assert.NoError(t, err)
+	fungibleToken := contracts.ByName("FungibleToken")
+	assert.NotNil(t, fungibleToken)
 	assert.True(t, fungibleToken.IsAliased())
 	assert.Equal(t, "e5a8b7f23e8b548f", fungibleToken.Aliases.ByNetwork("emulator").Address.String())
 	assert.Equal(t, "../hungry-kitties/cadence/contracts/FungibleToken.cdc", fungibleToken.Location)
 
-	kibble, err := contracts.ByName("Kibble")
-	assert.NoError(t, err)
+	kibble := contracts.ByName("Kibble")
+	assert.NotNil(t, kibble)
 	assert.True(t, kibble.IsAliased())
 	assert.Equal(t, "../hungry-kitties/cadence/contracts/Kibble.cdc", kibble.Location)
 	assert.Equal(t, "ead892083b3e2c6c", kibble.Aliases.ByNetwork("testnet").Address.String())
 	assert.Equal(t, "f8d6e0586b0a20c7", kibble.Aliases.ByNetwork("emulator").Address.String())
 
-	nft, err := contracts.ByName("NonFungibleToken")
-	assert.NoError(t, err)
+	nft := contracts.ByName("NonFungibleToken")
+	assert.NotNil(t, nft)
 	assert.False(t, nft.IsAliased())
 	assert.Equal(t, nft.Location, "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc")
 }

--- a/pkg/flowkit/config/loader.go
+++ b/pkg/flowkit/config/loader.go
@@ -242,7 +242,7 @@ func (l *Loader) composeConfig(baseConf *Config, conf *Config) {
 		baseConf.Networks.AddOrUpdate(network.Name, network)
 	}
 	for _, contract := range conf.Contracts {
-		baseConf.Contracts.AddOrUpdate(contract.Name, contract)
+		baseConf.Contracts.AddOrUpdate(contract)
 	}
 	for _, deployment := range conf.Deployments {
 		baseConf.Deployments.AddOrUpdate(deployment)

--- a/pkg/flowkit/config/parsers.go
+++ b/pkg/flowkit/config/parsers.go
@@ -96,53 +96,41 @@ func StringToHexKey(key string, sigAlgo string) (crypto.PrivateKey, error) {
 	return privateKey, nil
 }
 
-// StringToContracts converts strings to contracts.
-func StringToContracts(
+// StringToContract converts strings to contracts.
+func StringToContract(
 	name string,
 	source string,
 	emulatorAlias string,
 	testnetAlias string,
 	mainnetAlias string,
-) []Contract {
-	contracts := make([]Contract, 0)
+) Contract {
+	contract := Contract{
+		Name:     name,
+		Location: source,
+	}
 
 	if emulatorAlias != "" {
-		contracts = append(contracts, Contract{
-			Name:     name,
-			Location: source,
-			Network:  DefaultEmulatorNetwork().Name,
-			Alias:    emulatorAlias,
-		})
+		contract.Aliases.Add(
+			DefaultEmulatorNetwork().Name,
+			flow.HexToAddress(emulatorAlias),
+		)
 	}
 
 	if mainnetAlias != "" {
-		contracts = append(contracts, Contract{
-			Name:     name,
-			Location: source,
-			Network:  DefaultMainnetNetwork().Name,
-			Alias:    mainnetAlias,
-		})
+		contract.Aliases.Add(
+			DefaultMainnetNetwork().Name,
+			flow.HexToAddress(mainnetAlias),
+		)
 	}
 
 	if testnetAlias != "" {
-		contracts = append(contracts, Contract{
-			Name:     name,
-			Location: source,
-			Network:  DefaultTestnetNetwork().Name,
-			Alias:    testnetAlias,
-		})
+		contract.Aliases.Add(
+			DefaultTestnetNetwork().Name,
+			flow.HexToAddress(testnetAlias),
+		)
 	}
 
-	if emulatorAlias == "" && testnetAlias == "" {
-		contracts = append(contracts, Contract{
-			Name:     name,
-			Location: source,
-			Network:  "",
-			Alias:    "",
-		})
-	}
-
-	return contracts
+	return contract
 }
 
 // StringToNetwork converts string to network.

--- a/pkg/flowkit/project/contract.go
+++ b/pkg/flowkit/project/contract.go
@@ -63,5 +63,5 @@ func (c *Contract) Location() string {
 	return c.location
 }
 
-// Aliases map contract locations to fixed addresses on Flow network
-type Aliases map[string]string
+// LocationAliases map contract locations to fixed addresses on Flow network
+type LocationAliases map[string]string

--- a/pkg/flowkit/project/deployment.go
+++ b/pkg/flowkit/project/deployment.go
@@ -51,11 +51,11 @@ type Deployment struct {
 	// map of contracts by their location specified in state
 	contractsByLocation map[string]*deployContract
 	contractsByName     map[string]*deployContract
-	aliases             Aliases
+	aliases             LocationAliases
 }
 
 // NewDeployment from the flowkit Contracts and loaded from the contract location using a loader.
-func NewDeployment(contracts []*Contract, aliases Aliases) (*Deployment, error) {
+func NewDeployment(contracts []*Contract, aliases LocationAliases) (*Deployment, error) {
 	deployment := &Deployment{
 		contractsByLocation: make(map[string]*deployContract),
 		contractsByName:     make(map[string]*deployContract),

--- a/pkg/flowkit/project/imports.go
+++ b/pkg/flowkit/project/imports.go
@@ -33,10 +33,10 @@ type Account interface {
 // ImportReplacer implements file import replacements functionality for the project contracts with optionally included aliases.
 type ImportReplacer struct {
 	contracts []*Contract
-	aliases   Aliases
+	aliases   LocationAliases
 }
 
-func NewImportReplacer(contracts []*Contract, aliases Aliases) *ImportReplacer {
+func NewImportReplacer(contracts []*Contract, aliases LocationAliases) *ImportReplacer {
 	return &ImportReplacer{
 		contracts: contracts,
 		aliases:   aliases,

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -100,11 +100,11 @@ type StandardContract struct {
 func (p *Project) ReplaceStandardContractReferenceToAlias(standardContract StandardContract) error {
 	//replace contract with alias
 	mainnet := config.DefaultMainnetNetwork().Name
-	c, err := p.state.Config().Contracts.ByName(standardContract.Name)
-	if err != nil {
-		return err
+	contract := p.state.Config().Contracts.ByName(standardContract.Name)
+	if contract == nil {
+		return fmt.Errorf("contract not found") // shouldn't occur
 	}
-	c.Aliases.Add(mainnet, standardContract.Address)
+	contract.Aliases.Add(mainnet, standardContract.Address)
 
 	//remove from deploy
 	for di, d := range p.state.Config().Deployments {

--- a/pkg/flowkit/services/project.go
+++ b/pkg/flowkit/services/project.go
@@ -99,11 +99,12 @@ type StandardContract struct {
 
 func (p *Project) ReplaceStandardContractReferenceToAlias(standardContract StandardContract) error {
 	//replace contract with alias
-	c, err := p.state.Config().Contracts.ByNameAndNetwork(standardContract.Name, config.DefaultMainnetNetwork().Name)
+	mainnet := config.DefaultMainnetNetwork().Name
+	c, err := p.state.Config().Contracts.ByName(standardContract.Name)
 	if err != nil {
 		return err
 	}
-	c.Alias = standardContract.Address.String()
+	c.Aliases.Add(mainnet, standardContract.Address)
 
 	//remove from deploy
 	for di, d := range p.state.Config().Deployments {

--- a/pkg/flowkit/services/project_test.go
+++ b/pkg/flowkit/services/project_test.go
@@ -75,7 +75,6 @@ func TestProject(t *testing.T) {
 		c := config.Contract{
 			Name:     "Hello",
 			Location: tests.ContractHelloString.Filename,
-			Network:  "emulator",
 		}
 		state.Contracts().AddOrUpdate(c.Name, c)
 
@@ -122,22 +121,22 @@ func TestProject(t *testing.T) {
 		c1 := config.Contract{
 			Name:     "ContractB",
 			Location: tests.ContractB.Filename,
-			Network:  emulator,
 		}
 		state.Contracts().AddOrUpdate(c1.Name, c1)
 
 		c2 := config.Contract{
 			Name:     "Aliased",
 			Location: tests.ContractA.Filename,
-			Network:  emulator,
-			Alias:    tests.Donald().Address().String(),
+			Aliases: []config.Alias{{
+				Network: emulator,
+				Address: tests.Donald().Address(),
+			}},
 		}
 		state.Contracts().AddOrUpdate(c2.Name, c2)
 
 		c3 := config.Contract{
 			Name:     "ContractC",
 			Location: tests.ContractC.Filename,
-			Network:  emulator,
 		}
 		state.Contracts().AddOrUpdate(c3.Name, c3)
 
@@ -200,22 +199,22 @@ func TestProject(t *testing.T) {
 		c1 := config.Contract{
 			Name:     "ContractBB",
 			Location: tests.ContractBB.Filename,
-			Network:  emulator,
 		}
 		state.Contracts().AddOrUpdate(c1.Name, c1)
 
 		c2 := config.Contract{
 			Name:     "ContractAA",
 			Location: tests.ContractAA.Filename,
-			Network:  emulator,
-			Alias:    tests.Donald().Address().String(),
+			Aliases: []config.Alias{{
+				Network: emulator,
+				Address: tests.Donald().Address(),
+			}},
 		}
 		state.Contracts().AddOrUpdate(c2.Name, c2)
 
 		c3 := config.Contract{
 			Name:     "ContractCC",
 			Location: tests.ContractCC.Filename,
-			Network:  emulator,
 		}
 		state.Contracts().AddOrUpdate(c3.Name, c3)
 
@@ -277,7 +276,6 @@ func TestProject(t *testing.T) {
 		c := config.Contract{
 			Name:     "Hello",
 			Location: tests.ContractHelloString.Filename,
-			Network:  "emulator",
 		}
 		state.Contracts().AddOrUpdate(c.Name, c)
 
@@ -327,7 +325,6 @@ func simpleDeploy(state *flowkit.State, s *Services, update bool) ([]*project.Co
 	c := config.Contract{
 		Name:     tests.ContractHelloString.Name,
 		Location: tests.ContractHelloString.Filename,
-		Network:  "emulator",
 	}
 	state.Contracts().AddOrUpdate(c.Name, c)
 
@@ -382,7 +379,6 @@ func TestProject_Integration(t *testing.T) {
 			testContracts[i] = config.Contract{
 				Name:     c.Name,
 				Location: c.Filename,
-				Network:  n.Name,
 			}
 			state.Contracts().AddOrUpdate(c.Name, testContracts[i])
 		}
@@ -391,8 +387,10 @@ func TestProject_Integration(t *testing.T) {
 		state.Contracts().AddOrUpdate(cA.Name, config.Contract{
 			Name:     cA.Name,
 			Location: cA.Filename,
-			Network:  n.Name,
-			Alias:    srvAcc.Address().String(),
+			Aliases: []config.Alias{{
+				Network: n.Name,
+				Address: srvAcc.Address(),
+			}},
 		})
 
 		state.Deployments().AddOrUpdate(config.Deployment{

--- a/pkg/flowkit/services/project_test.go
+++ b/pkg/flowkit/services/project_test.go
@@ -122,7 +122,7 @@ func TestProject(t *testing.T) {
 			Name:     "ContractB",
 			Location: tests.ContractB.Filename,
 		}
-		state.Contracts().AddOrUpdate(c1.Name, c1)
+		state.Contracts().AddOrUpdate(c1)
 
 		c2 := config.Contract{
 			Name:     "Aliased",
@@ -132,13 +132,13 @@ func TestProject(t *testing.T) {
 				Address: tests.Donald().Address(),
 			}},
 		}
-		state.Contracts().AddOrUpdate(c2.Name, c2)
+		state.Contracts().AddOrUpdate(c2)
 
 		c3 := config.Contract{
 			Name:     "ContractC",
 			Location: tests.ContractC.Filename,
 		}
-		state.Contracts().AddOrUpdate(c3.Name, c3)
+		state.Contracts().AddOrUpdate(c3)
 
 		state.Networks().AddOrUpdate(emulator, config.DefaultEmulatorNetwork())
 
@@ -200,7 +200,7 @@ func TestProject(t *testing.T) {
 			Name:     "ContractBB",
 			Location: tests.ContractBB.Filename,
 		}
-		state.Contracts().AddOrUpdate(c1.Name, c1)
+		state.Contracts().AddOrUpdate(c1)
 
 		c2 := config.Contract{
 			Name:     "ContractAA",
@@ -210,13 +210,13 @@ func TestProject(t *testing.T) {
 				Address: tests.Donald().Address(),
 			}},
 		}
-		state.Contracts().AddOrUpdate(c2.Name, c2)
+		state.Contracts().AddOrUpdate(c2)
 
 		c3 := config.Contract{
 			Name:     "ContractCC",
 			Location: tests.ContractCC.Filename,
 		}
-		state.Contracts().AddOrUpdate(c3.Name, c3)
+		state.Contracts().AddOrUpdate(c3)
 
 		state.Networks().AddOrUpdate(emulator, config.DefaultEmulatorNetwork())
 
@@ -277,7 +277,7 @@ func TestProject(t *testing.T) {
 			Name:     "Hello",
 			Location: tests.ContractHelloString.Filename,
 		}
-		state.Contracts().AddOrUpdate(c.Name, c)
+		state.Contracts().AddOrUpdate(c)
 
 		n := config.Network{
 			Name: "emulator",
@@ -326,7 +326,7 @@ func simpleDeploy(state *flowkit.State, s *Services, update bool) ([]*project.Co
 		Name:     tests.ContractHelloString.Name,
 		Location: tests.ContractHelloString.Filename,
 	}
-	state.Contracts().AddOrUpdate(c.Name, c)
+	state.Contracts().AddOrUpdate(c)
 
 	n := config.Network{
 		Name: "emulator",
@@ -380,11 +380,11 @@ func TestProject_Integration(t *testing.T) {
 				Name:     c.Name,
 				Location: c.Filename,
 			}
-			state.Contracts().AddOrUpdate(c.Name, testContracts[i])
+			state.Contracts().AddOrUpdate(testContracts[i])
 		}
 
 		cA := tests.ContractA
-		state.Contracts().AddOrUpdate(cA.Name, config.Contract{
+		state.Contracts().AddOrUpdate(config.Contract{
 			Name:     cA.Name,
 			Location: cA.Filename,
 			Aliases: []config.Alias{{

--- a/pkg/flowkit/services/project_test.go
+++ b/pkg/flowkit/services/project_test.go
@@ -76,7 +76,7 @@ func TestProject(t *testing.T) {
 			Name:     "Hello",
 			Location: tests.ContractHelloString.Filename,
 		}
-		state.Contracts().AddOrUpdate(c.Name, c)
+		state.Contracts().AddOrUpdate(c)
 
 		n := config.Network{
 			Name: "emulator",

--- a/pkg/flowkit/services/project_test.go
+++ b/pkg/flowkit/services/project_test.go
@@ -113,7 +113,7 @@ func TestProject(t *testing.T) {
 		assert.Equal(t, contracts[0].AccountAddress, acct2.Address())
 	})
 
-	t.Run("Deploy Project Using Aliases", func(t *testing.T) {
+	t.Run("Deploy Project Using LocationAliases", func(t *testing.T) {
 		t.Parallel()
 
 		emulator := config.DefaultEmulatorNetwork().Name
@@ -191,7 +191,7 @@ func TestProject(t *testing.T) {
 		gw.Mock.AssertNumberOfCalls(t, tests.GetTransactionResultFunc, 2)
 	})
 
-	t.Run("Deploy Project New Import Schema and Aliases", func(t *testing.T) {
+	t.Run("Deploy Project New Import Schema and LocationAliases", func(t *testing.T) {
 		t.Parallel()
 
 		emulator := config.DefaultEmulatorNetwork().Name

--- a/pkg/flowkit/services/scripts_test.go
+++ b/pkg/flowkit/services/scripts_test.go
@@ -94,7 +94,6 @@ func TestScripts_Integration(t *testing.T) {
 		c := config.Contract{
 			Name:     tests.ContractHelloString.Name,
 			Location: tests.ContractHelloString.Filename,
-			Network:  "emulator",
 		}
 		state.Contracts().AddOrUpdate(c)
 

--- a/pkg/flowkit/services/scripts_test.go
+++ b/pkg/flowkit/services/scripts_test.go
@@ -96,7 +96,7 @@ func TestScripts_Integration(t *testing.T) {
 			Location: tests.ContractHelloString.Filename,
 			Network:  "emulator",
 		}
-		state.Contracts().AddOrUpdate(c.Name, c)
+		state.Contracts().AddOrUpdate(c)
 
 		n := config.Network{
 			Name: "emulator",

--- a/pkg/flowkit/services/tests_test.go
+++ b/pkg/flowkit/services/tests_test.go
@@ -71,9 +71,8 @@ func TestExecutingTests(t *testing.T) {
 		c := config.Contract{
 			Name:     tests.ContractHelloString.Name,
 			Location: tests.ContractHelloString.Filename,
-			Network:  "emulator",
 		}
-		st.Contracts().AddOrUpdate(c.Name, c)
+		st.Contracts().AddOrUpdate(c)
 
 		// Execute script
 		script := tests.TestScriptWithImport

--- a/pkg/flowkit/services/transactions_test.go
+++ b/pkg/flowkit/services/transactions_test.go
@@ -303,9 +303,8 @@ func TestTransactions_Integration(t *testing.T) {
 		c := config.Contract{
 			Name:     tests.ContractHelloString.Name,
 			Location: tests.ContractHelloString.Filename,
-			Network:  "emulator",
 		}
-		state.Contracts().AddOrUpdate(c.Name, c)
+		state.Contracts().AddOrUpdate(c)
 
 		n := config.Network{
 			Name: "emulator",

--- a/pkg/flowkit/state.go
+++ b/pkg/flowkit/state.go
@@ -174,7 +174,7 @@ func (p *State) DeploymentContractsByNetwork(network string) ([]*project.Contrac
 
 		// go through each contract in this deployment
 		for _, deploymentContract := range deploy.Contracts {
-			c, err := p.conf.Contracts.ByNameAndNetwork(deploymentContract.Name, network)
+			c, err := p.conf.Contracts.ByName(deploymentContract.Name)
 			if err != nil {
 				return nil, err
 			}
@@ -216,14 +216,15 @@ func (p *State) AccountsForNetwork(network string) Accounts {
 }
 
 // AliasesForNetwork returns all deployment aliases for a network.
-func (p *State) AliasesForNetwork(network string) project.Aliases {
-	aliases := make(project.Aliases)
+func (p *State) AliasesForNetwork(network string) project.LocationAliases {
+	aliases := make(project.LocationAliases)
 
 	// get all contracts for selected network and if any has an address as target make it an alias
-	for _, contract := range p.conf.Contracts.ByNetwork(network) {
-		if contract.IsAlias() {
-			aliases[path.Clean(contract.Location)] = contract.Alias // alias for import by file location
-			aliases[contract.Name] = contract.Alias                 // alias for import by name
+	for _, contract := range p.conf.Contracts {
+		if contract.IsAliased() && contract.Aliases.ByNetwork(network) != nil {
+			alias := contract.Aliases.ByNetwork(network).Address.String()
+			aliases[path.Clean(contract.Location)] = alias // alias for import by file location
+			aliases[contract.Name] = alias                 // alias for import by name
 		}
 	}
 

--- a/pkg/flowkit/state.go
+++ b/pkg/flowkit/state.go
@@ -174,9 +174,9 @@ func (p *State) DeploymentContractsByNetwork(network string) ([]*project.Contrac
 
 		// go through each contract in this deployment
 		for _, deploymentContract := range deploy.Contracts {
-			c, err := p.conf.Contracts.ByName(deploymentContract.Name)
-			if err != nil {
-				return nil, err
+			c := p.conf.Contracts.ByName(deploymentContract.Name)
+			if c == nil {
+				return nil, fmt.Errorf("contract with name %s not found", deploymentContract.Name)
 			}
 
 			code, err := p.readerWriter.ReadFile(c.Location)

--- a/pkg/flowkit/state_test.go
+++ b/pkg/flowkit/state_test.go
@@ -62,27 +62,22 @@ func generateComplexProject() State {
 		Contracts: config.Contracts{{
 			Name:     "NonFungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "FungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/FungibleToken.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "Kibble",
 			Location: "./cadence/kibble/contracts/Kibble.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "KittyItems",
 			Location: "./cadence/kittyItems/contracts/KittyItems.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "KittyItemsMarket",
 			Location: "./cadence/kittyItemsMarket/contracts/KittyItemsMarket.cdc",
-			Network:  "emulator",
-		}, {
-			Name:     "KittyItemsMarket",
-			Location: "0x123123123",
-			Network:  "testnet",
+			Aliases: config.Aliases{{
+				Network: "testnet",
+				Address: flow.HexToAddress("0x123123123"),
+			}},
 		}},
 		Deployments: config.Deployments{{
 			Network: "emulator",
@@ -176,7 +171,6 @@ func generateSimpleProject() State {
 		Contracts: config.Contracts{{
 			Name:     "NonFungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
-			Network:  "emulator",
 		}},
 		Deployments: config.Deployments{{
 			Network: "emulator",
@@ -221,12 +215,13 @@ func generateAliasesProject() State {
 		Contracts: config.Contracts{{
 			Name:     "NonFungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/NonFungibleToken.cdc",
-			Network:  "emulator",
 		}, {
 			Name:     "FungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/FungibleToken.cdc",
-			Network:  "emulator",
-			Alias:    "ee82856bf20e2aa6",
+			Aliases: config.Aliases{{
+				Network: "emulator",
+				Address: flow.HexToAddress("ee82856bf20e2aa6"),
+			}},
 		}},
 		Deployments: config.Deployments{{
 			Network: "emulator",
@@ -273,18 +268,24 @@ func generateAliasesComplexProject() State {
 		}, {
 			Name:     "FungibleToken",
 			Location: "../hungry-kitties/cadence/contracts/FungibleToken.cdc",
-			Network:  "emulator",
-			Alias:    "ee82856bf20e2aa6",
+			Aliases: config.Aliases{{
+				Network: "emulator",
+				Address: flow.HexToAddress("ee82856bf20e2aa6"),
+			}},
 		}, {
 			Name:     "Kibble",
 			Location: "../hungry-kitties/cadence/contracts/Kibble.cdc",
-			Network:  "testnet",
-			Alias:    "ee82856bf20e2aa6",
+			Aliases: config.Aliases{{
+				Network: "testnet",
+				Address: flow.HexToAddress("ee82856bf20e2aa6"),
+			}},
 		}, {
 			Name:     "Kibble",
 			Location: "../hungry-kitties/cadence/contracts/Kibble.cdc",
-			Network:  "emulator",
-			Alias:    "ee82856bf20e2aa6",
+			Aliases: config.Aliases{{
+				Network: "emulator",
+				Address: flow.HexToAddress("ee82856bf20e2aa6"),
+			}},
 		}},
 		Deployments: config.Deployments{{
 			Network: "emulator",

--- a/pkg/flowkit/tests/testnet_test.go
+++ b/pkg/flowkit/tests/testnet_test.go
@@ -129,19 +129,16 @@ func Test_Testnet_ProjectDeploy(t *testing.T) {
 	state.Contracts().AddOrUpdate(config.Contract{
 		Name:     ContractA.Name,
 		Location: ContractA.Filename,
-		Network:  testnet,
 	})
 
-	state.Contracts().AddOrUpdate(ContractB.Name, config.Contract{
+	state.Contracts().AddOrUpdate(config.Contract{
 		Name:     ContractB.Name,
 		Location: ContractB.Filename,
-		Network:  testnet,
 	})
 
-	state.Contracts().AddOrUpdate(ContractC.Name, config.Contract{
+	state.Contracts().AddOrUpdate(config.Contract{
 		Name:     ContractC.Name,
 		Location: ContractC.Filename,
-		Network:  testnet,
 	})
 
 	initArg, _ := cadence.NewString("foo")

--- a/pkg/flowkit/tests/testnet_test.go
+++ b/pkg/flowkit/tests/testnet_test.go
@@ -126,7 +126,7 @@ var testnet = config.DefaultTestnetNetwork().Name
 func Test_Testnet_ProjectDeploy(t *testing.T) {
 	_, state, srv, mockFs := initTestnet(t)
 
-	state.Contracts().AddOrUpdate(ContractA.Name, config.Contract{
+	state.Contracts().AddOrUpdate(config.Contract{
 		Name:     ContractA.Name,
 		Location: ContractA.Filename,
 		Network:  testnet,


### PR DESCRIPTION
Closes #870 

## Description
Refactor contracts to not have multiple copies of contract for each alias, but rather have one contract include the list of all alises.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
