### PR TITLE
Scaffolds within specified folders supporting Unity scaffold

### DIFF
--- a/internal/super/setup.go
+++ b/internal/super/setup.go
@@ -57,7 +57,7 @@ var SetupCommand = &command.Command{
 	Run:   create,
 }
 
-const scaffoldListURL = "https://raw.githubusercontent.com/onflow/flow-cli/7be54bad21bf52e38b91c5a4b5e21497f0f08af4/scaffolds.json"
+const scaffoldListURL = "https://raw.githubusercontent.com/onflow/flow-cli/master/scaffolds.json"
 
 type scaffold struct {
 	Repo        string `json:"repo"`
@@ -194,9 +194,11 @@ func cloneScaffold(targetDir string, conf scaffold) error {
 
 	// if we defined a folder remove everything else
 	if conf.Folder != "" {
-		folder := filepath.Join(targetDir, filepath.Dir(conf.Folder))
-
-		if err = os.Rename(folder, filepath.Join(targetDir, "../t")); err != nil {
+		err = os.Rename(
+			filepath.Join(targetDir, conf.Folder),
+			filepath.Join(targetDir, "../scaffold-temp"),
+		)
+		if err != nil {
 			return err
 		}
 
@@ -204,7 +206,7 @@ func cloneScaffold(targetDir string, conf scaffold) error {
 			return err
 		}
 
-		if err = os.Rename(filepath.Join(targetDir, "../t"), targetDir); err != nil {
+		if err = os.Rename(filepath.Join(targetDir, "../scaffold-temp"), targetDir); err != nil {
 			return err
 		}
 	}

--- a/scaffolds.json
+++ b/scaffolds.json
@@ -20,14 +20,14 @@
   {
     "name": "Simple Unity",
     "repo": "https://github.com/onflow/UnityFlowSDK.git",
-    "description": "Simple examples how to interact with Flow network using Unity SDK.",
+    "description": "Simple example demonstrating how to interact with the Flow network using Unity SDK.",
     "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946",
     "folder": "Samples~/FlowControlQuickstartCodeSample"
   },
   {
     "name": "Mobile Unity Game",
     "repo": "https://github.com/onflow/UnityFlowSDK.git",
-    "description": "Example Unity words game built on Flow using the Unity SDK.",
+    "description": "Example words game built on Flow using the Unity SDK.",
     "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946",
     "folder": "Samples~/FlowWords"
   }

--- a/scaffolds.json
+++ b/scaffolds.json
@@ -18,9 +18,16 @@
     "commit": "4158c5e11b6d2c9e1cbc99af597e3b42b2e6c193"
   },
   {
+    "name": "Simple Unity",
+    "repo": "https://github.com/onflow/UnityFlowSDK.git",
+    "description": "Simple examples how to interact with Flow network using Unity SDK.",
+    "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946",
+    "folder": "Samples~/FlowControlQuickstartCodeSample"
+  },
+  {
     "name": "Mobile Unity Game",
     "repo": "https://github.com/onflow/UnityFlowSDK.git",
-    "description": "Example Unity game Flow words.",
+    "description": "Example Unity words game built on Flow using the Unity SDK.",
     "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946",
     "folder": "Samples~/FlowWords"
   }

--- a/scaffolds.json
+++ b/scaffolds.json
@@ -16,5 +16,11 @@
     "repo": "https://github.com/onflow/scaffold-flow.git",
     "description": "Simple demo application using next.js and FCL with provided Cadence contracts.",
     "commit": "4158c5e11b6d2c9e1cbc99af597e3b42b2e6c193"
+  },
+  {
+    "name": "Mobile Unity Game",
+    "repo": "https://github.com/onflow/UnityFlowSDK/tree/main/Samples~/FlowWords",
+    "description": "Example Unity game Flow words.",
+    "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946"
   }
 ]

--- a/scaffolds.json
+++ b/scaffolds.json
@@ -19,8 +19,9 @@
   },
   {
     "name": "Mobile Unity Game",
-    "repo": "https://github.com/onflow/UnityFlowSDK/tree/main/Samples~/FlowWords",
+    "repo": "https://github.com/onflow/UnityFlowSDK.git",
     "description": "Example Unity game Flow words.",
-    "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946"
+    "commit": "d01a4b14a98383c18b4d57e87624cb8dba6d0946",
+    "folder": "Samples~/FlowWords"
   }
 ]


### PR DESCRIPTION
Closes #888 

## Description
Support specfying folder using scaffolds, so the same repo can contain multiple scaffolds inside each folder. This will unlock adding unity scaffolds. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
