### PR TITLE
Support relative path for loading contracts

### DIFF
--- a/pkg/flowkit/config/loader.go
+++ b/pkg/flowkit/config/loader.go
@@ -68,6 +68,7 @@ type Loader struct {
 	readerWriter     ReaderWriter
 	configParsers    Parsers
 	accountsFromFile map[string]string
+	LoadedLocations  []string
 }
 
 // NewLoader returns a new loader.
@@ -115,6 +116,7 @@ func (l *Loader) Save(conf *Config, path string) error {
 }
 
 func (l *Loader) loadConfig(confPath string) (*Config, error) {
+	l.LoadedLocations = append(l.LoadedLocations, confPath)
 	raw, err := l.loadFile(confPath)
 
 	if err != nil {

--- a/pkg/flowkit/state.go
+++ b/pkg/flowkit/state.go
@@ -184,10 +184,10 @@ func (p *State) DeploymentContractsByNetwork(network string) ([]*project.Contrac
 			// if we loaded config from a single location, we should make the path of contracts defined in config relative to
 			// config path we have provided, this will make cases where we execute loading in different path than config work
 			if len(p.confLoader.LoadedLocations) == 1 {
-				location, err = filepath.Rel(p.confLoader.LoadedLocations[0], location)
-				if err != nil {
-					return nil, err
-				}
+				location = filepath.Join(
+					filepath.Dir(p.confLoader.LoadedLocations[0]),
+					location,
+				)
 			}
 
 			code, err := p.readerWriter.ReadFile(location)


### PR DESCRIPTION
Closes #778 

## Description
Support using relative location to flow.json when CLI/flowkit is not run in the same folder as flow.json.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
