### PR TITLE
Fix: improve import parsing regex

### DIFF
--- a/pkg/flowkit/project/program.go
+++ b/pkg/flowkit/project/program.go
@@ -75,8 +75,8 @@ func (p *Program) HasImports() bool {
 func (p *Program) replaceImport(from string, to string) *Program {
 	code := string(p.Code())
 
-	pathRegex := regexp.MustCompile(fmt.Sprintf(`import (\w+) from "%s"`, from))
-	identifierRegex := regexp.MustCompile(fmt.Sprintf(`import "(%s)"`, from))
+	pathRegex := regexp.MustCompile(fmt.Sprintf(`import\s+(\w+)\s+from\s+"%s"`, from))
+	identifierRegex := regexp.MustCompile(fmt.Sprintf(`import\s+"(%s)"`, from))
 
 	replacement := fmt.Sprintf(`import $1 from 0x%s`, to)
 	code = pathRegex.ReplaceAllString(code, replacement)

--- a/pkg/flowkit/project/program_test.go
+++ b/pkg/flowkit/project/program_test.go
@@ -151,6 +151,8 @@ func TestProgram(t *testing.T) {
 		code := []byte(`
 			import Foo from "./Foo.cdc"
 			import "Bar"
+			import  FooSpace  from  "./FooSpace.cdc"
+			import   "BarSpace"
 
 			pub contract Foo {}
 		`)
@@ -158,6 +160,8 @@ func TestProgram(t *testing.T) {
 		replaced := []byte(`
 			import Foo from 0x1
 			import Bar from 0x2
+			import FooSpace from 0x3
+			import BarSpace from 0x4
 
 			pub contract Foo {}
 		`)
@@ -167,7 +171,9 @@ func TestProgram(t *testing.T) {
 
 		program.
 			replaceImport("./Foo.cdc", "1").
-			replaceImport("Bar", "2")
+			replaceImport("Bar", "2").
+			replaceImport("./FooSpace.cdc", "3").
+			replaceImport("BarSpace", "4")
 
 		assert.Equal(t, string(replaced), string(program.Code()))
 	})


### PR DESCRIPTION
Closes [#886 ](https://github.com/onflow/flow-cli/issues/886)

## Description

Improve import regex to handle extra spacing that may appear 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
