### PR TITLE
Bugfix ENV parsing

### DIFF
--- a/pkg/flowkit/config/json/account.go
+++ b/pkg/flowkit/config/json/account.go
@@ -94,7 +94,7 @@ func transformSimpleToConfig(accountName string, a simpleAccount) (*config.Accou
 // tryReplaceEnv checks if value matches env regex, if it does it check whether the value was set in env,
 // if not set then it errors, otherwise it replaces the value with set env variable, and also returns the original key.
 func tryReplaceEnv(value string) (replaced string, original string, err error) {
-	envRegex, err := regexp.Compile(`^\$[{]?(\w+)[}]?`)
+	envRegex, err := regexp.Compile(`^\$(\w+)$|\{(\w+)\}$`)
 	if err != nil {
 		return "", "", err
 	}
@@ -109,6 +109,9 @@ func tryReplaceEnv(value string) (replaced string, original string, err error) {
 	}
 
 	envVar := found[0][1]
+	if found[0][2] != "" { // second regex
+		envVar = found[0][2]
+	}
 	if os.Getenv(envVar) == "" {
 		return "", "", fmt.Errorf("required environment variable %s not set", envVar)
 	}

--- a/pkg/flowkit/config/json/account.go
+++ b/pkg/flowkit/config/json/account.go
@@ -94,11 +94,23 @@ func transformSimpleToConfig(accountName string, a simpleAccount) (*config.Accou
 // tryReplaceEnv checks if value matches env regex, if it does it check whether the value was set in env,
 // if not set then it errors, otherwise it replaces the value with set env variable, and also returns the original key.
 func tryReplaceEnv(value string) (replaced string, original string, err error) {
-	if envPresent, _ := regexp.MatchString("^\\$\\w+", value); !envPresent {
+	envRegex, err := regexp.Compile(`^\$[{]?(\w+)[}]?`)
+	if err != nil {
+		return "", "", err
+	}
+
+	if !envRegex.MatchString(value) {
 		return
 	}
-	if os.Getenv(strings.ReplaceAll(value, "$", "")) == "" {
-		return "", "", fmt.Errorf("required environment variable %s not set", value)
+
+	found := envRegex.FindAllStringSubmatch(value, -1)
+	if len(found) == 0 {
+		return // should not happen
+	}
+
+	envVar := found[0][1]
+	if os.Getenv(envVar) == "" {
+		return "", "", fmt.Errorf("required environment variable %s not set", envVar)
 	}
 
 	original = value

--- a/pkg/flowkit/config/json/account_test.go
+++ b/pkg/flowkit/config/json/account_test.go
@@ -19,6 +19,7 @@ package json
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/onflow/flow-go-sdk"
@@ -503,4 +504,23 @@ func Test_ConfigInvalidAddress(t *testing.T) {
 
 	_, err = jsonAccounts.transformToConfig()
 	assert.Equal(t, err.Error(), "could not parse address: zz")
+}
+
+func Test_ReplaceENV(t *testing.T) {
+	t.Run("Valid ENV set vars", func(t *testing.T) {
+		os.Setenv("TEST", "foo")
+
+		tests := []string{"$TEST", "${TEST}"}
+		for _, test := range tests {
+			replaced, original, err := tryReplaceEnv(test)
+			assert.NoError(t, err)
+			assert.Equal(t, "foo", replaced)
+			assert.Equal(t, test, original)
+		}
+	})
+
+	t.Run("ENV not set", func(t *testing.T) {
+		_, _, err := tryReplaceEnv("$NOT_SET")
+		assert.EqualError(t, err, "required environment variable NOT_SET not set")
+	})
 }

--- a/pkg/flowkit/config/json/account_test.go
+++ b/pkg/flowkit/config/json/account_test.go
@@ -19,6 +19,7 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -522,5 +523,15 @@ func Test_ReplaceENV(t *testing.T) {
 	t.Run("ENV not set", func(t *testing.T) {
 		_, _, err := tryReplaceEnv("$NOT_SET")
 		assert.EqualError(t, err, "required environment variable NOT_SET not set")
+	})
+
+	t.Run("Should not match", func(t *testing.T) {
+		tests := []string{"TEST", "${TEST", "$TEST}", "$$$$", "123"}
+		for i, test := range tests {
+			replaced, original, err := tryReplaceEnv(test)
+			assert.NoError(t, err, fmt.Sprintf("test #%d", i))
+			assert.Equal(t, "", replaced)
+			assert.Equal(t, "", original)
+		}
 	})
 }

--- a/pkg/flowkit/config/loader_test.go
+++ b/pkg/flowkit/config/loader_test.go
@@ -514,7 +514,7 @@ func Test_JSONEnv(t *testing.T) {
 		composer.AddConfigParser(json.NewParser())
 
 		_, err = composer.Load([]string{"test.json"})
-		assert.EqualError(t, err, "required environment variable $NOT_EXISTS not set")
+		assert.EqualError(t, err, "required environment variable NOT_EXISTS not set")
 	})
 
 }


### PR DESCRIPTION
Closes #947 

## Description
Expand environment parsing to support previously supported `${}` format.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
