### PR TITLE
Use service account key for flow dev account gen

### DIFF
--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -193,12 +193,7 @@ func (p *project) watch() error {
 
 // addAccount to the state and create it on the network.
 func (p *project) addAccount(name string) error {
-	serviceAccount, err := p.state.EmulatorServiceAccount()
-	if err != nil {
-		return err
-	}
-
-	privateKey, err := serviceAccount.Key().PrivateKey()
+	privateKey, err := p.service.Key().PrivateKey()
 	if err != nil {
 		return err
 	}

--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -215,7 +215,7 @@ func (p *project) addAccount(name string) error {
 	// create the account on the network and set the address
 	flowAcc, err := p.services.Accounts.Create(
 		p.service,
-		[]crypto.PublicKey{pubKey}, // need to get public key from private key
+		[]crypto.PublicKey{pubKey},
 		[]int{flow.AccountKeyWeightThreshold},
 		[]crypto.SignatureAlgorithm{crypto.ECDSA_P256},
 		[]crypto.HashAlgorithm{crypto.SHA3_256},

--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -203,14 +203,7 @@ func (p *project) addAccount(name string) error {
 		return err
 	}
 
-	newAccountKey := flowkit.NewHexAccountKeyFromPrivateKey(0, crypto.SHA3_256, *privateKey)
-
-	newDecodedKey, err := crypto.DecodePrivateKeyHex(newAccountKey.SigAlgo(), newAccountKey.PrivateKeyHex())
-	if err != nil {
-		return err
-	}
-
-	pubKey := newDecodedKey.PublicKey()
+	pubKey := (*privateKey).PublicKey()
 
 	// create the account on the network and set the address
 	flowAcc, err := p.services.Accounts.Create(
@@ -225,9 +218,9 @@ func (p *project) addAccount(name string) error {
 		return err
 	}
 
-	account := flowkit.NewAccount(name)
-	account.SetAddress(flowAcc.Address)
-	account.SetKey(newAccountKey)
+	account := flowkit.NewAccount(name).
+		SetAddress(flowAcc.Address).
+		SetKey(flowkit.NewHexAccountKeyFromPrivateKey(0, crypto.SHA3_256, *privateKey))
 
 	p.state.Accounts().AddOrUpdate(account)
 	p.state.Deployments().AddOrUpdate(config.Deployment{ // init empty deployment


### PR DESCRIPTION
Closes #949 

## Description

Use service account key in flow dev to create accounts for consistency
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
