### PR TITLE
Handle relative import path for contracts in `test` command

### DIFF
--- a/pkg/flowkit/services/tests.go
+++ b/pkg/flowkit/services/tests.go
@@ -20,13 +20,13 @@ package services
 
 import (
 	"fmt"
+	"strings"
 
 	cdcTests "github.com/onflow/cadence-tools/test"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-cli/pkg/flowkit"
-	"github.com/onflow/flow-cli/pkg/flowkit/config"
 	"github.com/onflow/flow-cli/pkg/flowkit/output"
 	"github.com/onflow/flow-cli/pkg/flowkit/util"
 )
@@ -84,13 +84,17 @@ func (t *Tests) importResolver(scriptPath string, readerWriter flowkit.ReaderWri
 			return "", fmt.Errorf("cannot import from %s", location)
 		}
 
-		importedContract, err := t.resolveContract(stringLocation)
-		if err != nil {
-			return "", err
+		relativePath := stringLocation.String()
+		for _, contract := range *t.state.Contracts() {
+			if !strings.Contains(relativePath, contract.Location) {
+				return "", fmt.Errorf(
+					"cannot find contract with location '%s' in configuration",
+					relativePath,
+				)
+			}
 		}
 
-		importedContractFilePath := util.AbsolutePath(scriptPath, importedContract.Location)
-
+		importedContractFilePath := util.AbsolutePath(scriptPath, relativePath)
 		contractCode, err := readerWriter.ReadFile(importedContractFilePath)
 		if err != nil {
 			return "", err
@@ -98,18 +102,6 @@ func (t *Tests) importResolver(scriptPath string, readerWriter flowkit.ReaderWri
 
 		return string(contractCode), nil
 	}
-}
-
-func (t *Tests) resolveContract(stringLocation common.StringLocation) (config.Contract, error) {
-	relativePath := stringLocation.String()
-	for _, contract := range *t.state.Contracts() {
-		if contract.Location == relativePath {
-			return contract, nil
-		}
-	}
-
-	return config.Contract{},
-		fmt.Errorf("cannot find contract with location '%s' in configuration", relativePath)
 }
 
 func (t *Tests) fileResolver(scriptPath string, readerWriter flowkit.ReaderWriter) cdcTests.FileResolver {

--- a/pkg/flowkit/services/tests.go
+++ b/pkg/flowkit/services/tests.go
@@ -85,13 +85,18 @@ func (t *Tests) importResolver(scriptPath string, readerWriter flowkit.ReaderWri
 		}
 
 		relativePath := stringLocation.String()
+		contractFound := false
 		for _, contract := range *t.state.Contracts() {
-			if !strings.Contains(relativePath, contract.Location) {
-				return "", fmt.Errorf(
-					"cannot find contract with location '%s' in configuration",
-					relativePath,
-				)
+			if strings.Contains(relativePath, contract.Location) {
+				contractFound = true
+				break
 			}
+		}
+		if !contractFound {
+			return "", fmt.Errorf(
+				"cannot find contract with location '%s' in configuration",
+				relativePath,
+			)
 		}
 
 		importedContractFilePath := util.AbsolutePath(scriptPath, relativePath)

--- a/pkg/flowkit/services/tests_test.go
+++ b/pkg/flowkit/services/tests_test.go
@@ -90,7 +90,7 @@ func TestExecutingTests(t *testing.T) {
 		assert.NoError(t, results[script.Filename][0].Error)
 	})
 
-	t.Run("with relative import", func(t *testing.T) {
+	t.Run("with relative imports", func(t *testing.T) {
 		t.Parallel()
 
 		// Setup
@@ -101,15 +101,25 @@ func TestExecutingTests(t *testing.T) {
 			tests.ContractHelloString.Source,
 			os.ModeTemporary,
 		)
+		readerWriter.WriteFile(
+			"../contracts/FooContract.cdc",
+			tests.ContractFooCoverage.Source,
+			os.ModeTemporary,
+		)
 
-		c := config.Contract{
+		contractHello := config.Contract{
 			Name:     tests.ContractHelloString.Name,
 			Location: tests.ContractHelloString.Filename,
 		}
-		st.Contracts().AddOrUpdate(c)
+		st.Contracts().AddOrUpdate(contractHello)
+		contractFoo := config.Contract{
+			Name:     tests.ContractFooCoverage.Name,
+			Location: tests.ContractFooCoverage.Filename,
+		}
+		st.Contracts().AddOrUpdate(contractFoo)
 
 		// Execute script
-		script := tests.TestScriptWithRelativeImport
+		script := tests.TestScriptWithRelativeImports
 		testFiles := make(map[string][]byte, 0)
 		testFiles[script.Filename] = script.Source
 		results, _, err := s.Tests.Execute(testFiles, readerWriter, false)

--- a/pkg/flowkit/tests/resources.go
+++ b/pkg/flowkit/tests/resources.go
@@ -353,14 +353,18 @@ var TestScriptWithImport = Resource{
     `),
 }
 
-var TestScriptWithRelativeImport = Resource{
+var TestScriptWithRelativeImports = Resource{
 	Filename: "testScriptWithRelativeImport.cdc",
 	Source: []byte(`
+        import FooContract from "../contracts/FooContract.cdc"
         import Hello from "../contracts/contractHello.cdc"
 
         pub fun testSimple() {
             let hello = Hello()
             assert(hello.greeting == "Hello, World!")
+
+            let fooContract = FooContract()
+            assert("Carmichael" == fooContract.getIntegerTrait(41041))
         }
     `),
 }

--- a/pkg/flowkit/tests/resources.go
+++ b/pkg/flowkit/tests/resources.go
@@ -353,6 +353,18 @@ var TestScriptWithImport = Resource{
     `),
 }
 
+var TestScriptWithRelativeImport = Resource{
+	Filename: "testScriptWithRelativeImport.cdc",
+	Source: []byte(`
+        import Hello from "../contracts/contractHello.cdc"
+
+        pub fun testSimple() {
+            let hello = Hello()
+            assert(hello.greeting == "Hello, World!")
+        }
+    `),
+}
+
 var TestScriptWithFileRead = Resource{
 	Filename: "testScriptWithFileRead.cdc",
 	Source: []byte(`


### PR DESCRIPTION
PR for context: https://github.com/SupunS/cadence-testing/pull/1