### PR TITLE
Expose `CoverageReport` through `EmulatorGateway`

### DIFF
--- a/flowkit/gateway/emulator.go
+++ b/flowkit/gateway/emulator.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime"
 	emulator "github.com/onflow/flow-emulator"
 	"github.com/onflow/flow-emulator/convert/sdk"
 	"github.com/onflow/flow-emulator/server/backend"
@@ -333,4 +334,12 @@ func (g *EmulatorGateway) GetLatestProtocolStateSnapshot() ([]byte, error) {
 // SecureConnection placeholder func to complete gateway interface implementation
 func (g *EmulatorGateway) SecureConnection() bool {
 	return false
+}
+
+func (g *EmulatorGateway) CoverageReport() *runtime.CoverageReport {
+	return g.emulator.CoverageReport()
+}
+
+func (g *EmulatorGateway) SetCoverageReport(coverageReport *runtime.CoverageReport) {
+	g.emulator.SetCoverageReport(coverageReport)
 }

--- a/flowkit/go.mod
+++ b/flowkit/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12
 	github.com/onflow/cadence v0.38.1
-	github.com/onflow/flow-emulator v0.47.0
+	github.com/onflow/flow-emulator v0.48.0
 	github.com/onflow/flow-go v0.30.1-0.20230419183628-e1fa8dba5ec5
 	github.com/onflow/flow-go-sdk v0.40.0
 	github.com/onflow/flow-go/crypto v0.24.7

--- a/flowkit/go.sum
+++ b/flowkit/go.sum
@@ -429,6 +429,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+K
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3/go.mod h1:dqAUVWwg+NlOhsuBHex7bEWmsUjsiExzhe/+t4xNH6A=
 github.com/onflow/flow-emulator v0.47.0 h1:iCkTjWGLdrJXnSxSJZK1xBYVKCrH5iCy6ufNGAyLnWk=
 github.com/onflow/flow-emulator v0.47.0/go.mod h1:NgLTIHMmvCKuDlwlQjwDzt2PSmgD/ntnFvDT4GZoGKI=
+github.com/onflow/flow-emulator v0.48.0 h1:Nblo4HzZIrRQQDCRATDRGIDMJmn/4EuHpSLJmr+yn2Y=
+github.com/onflow/flow-emulator v0.48.0/go.mod h1:NgLTIHMmvCKuDlwlQjwDzt2PSmgD/ntnFvDT4GZoGKI=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0 h1:XEKE6qJUw3luhsYmIOteXP53gtxNxrwTohgxJXCYqBE=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
 github.com/onflow/flow-go v0.30.1-0.20230419183628-e1fa8dba5ec5 h1:yIybhxP2b7OiXHWMaHXLSG8X32KIF7G8nI6akjSrGeY=

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onflow/fcl-dev-wallet v0.6.0
 	github.com/onflow/flow-cli/flowkit v1.0.0-beta05
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3
-	github.com/onflow/flow-emulator v0.47.0
+	github.com/onflow/flow-emulator v0.48.0
 	github.com/onflow/flow-go-sdk v0.40.0
 	github.com/onflowser/flowser/v2 v2.0.14-beta
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -787,6 +787,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+K
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3/go.mod h1:dqAUVWwg+NlOhsuBHex7bEWmsUjsiExzhe/+t4xNH6A=
 github.com/onflow/flow-emulator v0.47.0 h1:iCkTjWGLdrJXnSxSJZK1xBYVKCrH5iCy6ufNGAyLnWk=
 github.com/onflow/flow-emulator v0.47.0/go.mod h1:NgLTIHMmvCKuDlwlQjwDzt2PSmgD/ntnFvDT4GZoGKI=
+github.com/onflow/flow-emulator v0.48.0 h1:Nblo4HzZIrRQQDCRATDRGIDMJmn/4EuHpSLJmr+yn2Y=
+github.com/onflow/flow-emulator v0.48.0/go.mod h1:NgLTIHMmvCKuDlwlQjwDzt2PSmgD/ntnFvDT4GZoGKI=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0 h1:XEKE6qJUw3luhsYmIOteXP53gtxNxrwTohgxJXCYqBE=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
 github.com/onflow/flow-go v0.30.1-0.20230419183628-e1fa8dba5ec5 h1:yIybhxP2b7OiXHWMaHXLSG8X32KIF7G8nI6akjSrGeY=


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/132
Depends on: https://github.com/onflow/flow-emulator/pull/362

## Description

This will allow tools that build on-top of the Flow Emulator through the Flow CLI, to be able to inject/retrieve the `CoverageReport` object.
Context: https://github.com/bjartek/overflow/pull/107
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
