### PR TITLE
add a way to access rollback function

### DIFF
--- a/flowkit/gateway/emulator.go
+++ b/flowkit/gateway/emulator.go
@@ -343,3 +343,7 @@ func (g *EmulatorGateway) CoverageReport() *runtime.CoverageReport {
 func (g *EmulatorGateway) SetCoverageReport(coverageReport *runtime.CoverageReport) {
 	g.emulator.SetCoverageReport(coverageReport)
 }
+
+func (g *EmulatorGateway) RollbackToBlockHeight(height uint64) error {
+	return g.emulator.RollbackToBlockHeight(height)
+}


### PR DESCRIPTION
Add a way to rollback to another blockheight

## Description

Need a way to rollback to blockheight. 

Would it be better to add an accessor for Backend here since that interface has the method? 

Can we talk about abstraction levels here because ATM i think there are too many
______

For contributor use:

- [x ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
