### PR TITLE
Improve coverage report statistics for integration tests

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -113,6 +113,38 @@ func testCode(
 	runner := cdcTests.NewTestRunner()
 	if coverageEnabled {
 		coverageReport = runtime.NewCoverageReport()
+		contracts := map[string]string{
+			"FlowToken":             "0x0ae53cb6e3f42a79",
+			"FlowFees":              "0xe5a8b7f23e8b548f",
+			"FungibleToken":         "0xee82856bf20e2aa6",
+			"FlowClusterQC":         "0xf8d6e0586b0a20c7",
+			"FlowDKG":               "0xf8d6e0586b0a20c7",
+			"FlowEpoch":             "0xf8d6e0586b0a20c7",
+			"FlowIDTableStaking":    "0xf8d6e0586b0a20c7",
+			"FlowServiceAccount":    "0xf8d6e0586b0a20c7",
+			"FlowStakingCollection": "0xf8d6e0586b0a20c7",
+			"FlowStorageFees":       "0xf8d6e0586b0a20c7",
+			"LockedTokens":          "0xf8d6e0586b0a20c7",
+			"NodeVersionBeacon":     "0xf8d6e0586b0a20c7",
+			"StakingProxy":          "0xf8d6e0586b0a20c7",
+			"ExampleNFT":            "0xf8d6e0586b0a20c7",
+			"FUSD":                  "0xf8d6e0586b0a20c7",
+			"NFTStorefront":         "0xf8d6e0586b0a20c7",
+			"NFTStorefrontV2":       "0xf8d6e0586b0a20c7",
+		}
+		for name, address := range contracts {
+			addr, _ := common.HexToAddress(address)
+			location := common.AddressLocation{
+				Address: addr,
+				Name:    name,
+			}
+			coverageReport.ExcludeLocation(location)
+		}
+		coverageReport.WithLocationInspectionHandler(func(location common.Location) bool {
+			_, addressLoc := location.(common.AddressLocation)
+			_, stringLoc := location.(common.StringLocation)
+			return addressLoc || stringLoc
+		})
 		runner = runner.WithCoverageReport(coverageReport)
 	}
 


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/132

## Description

The coverage report generated from integration tests, includes all the system contracts (+ some already provided, with the `--contracts` flag), due to the underlying backend implementation using the Flow Emulator. This not only creates "noise", but it also skews the metrics, since these contracts are not really of interest in the context of integration tests.

With the proposed changes, our goal is to:
- Exclude all the system contracts from coverage report (this is currently supported from the `CoverageReport` API, by using the `ExcludeLocation` method)
- Exclude all scripts and transactions from coverage report (this is currently being introduced [upstream](https://github.com/onflow/cadence/pull/2474), in the Cadence repository)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
