### PR TITLE
Remove progress logging from test command

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -78,9 +78,6 @@ func run(
 		testFiles[filename] = code
 	}
 
-	logger.StartProgress("Running tests...")
-	defer logger.StopProgress()
-
 	res, coverageReport, err := testCode(testFiles, state, testFlags.Cover)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The spinner from the progress logger, would cause some of the log messages to be overwritten.

**Before:**
![Screenshot from 2023-05-16 15-32-55](https://github.com/onflow/flow-cli/assets/1778965/1ff46509-149c-4605-9fb6-1bcac4d6657f)

**After:**
![Screenshot from 2023-05-16 15-42-51](https://github.com/onflow/flow-cli/assets/1778965/5cbac9c9-45b8-44fb-914b-8e90b389f038)


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
