### PR TITLE
Allow importing helper/utility files in test files

### DIFF
--- a/flowkit/tests/resources.go
+++ b/flowkit/tests/resources.go
@@ -324,6 +324,15 @@ var ScriptImport = Resource{
 	`),
 }
 
+var HelperImport = Resource{
+	Filename: "test_helpers.cdc",
+	Source: []byte(`
+		pub fun double(_ x: Int): Int {
+			return x * 2
+		}
+	`),
+}
+
 var TestScriptSimple = Resource{
 	Filename: "./testScriptSimple.cdc",
 	Source: []byte(`
@@ -352,6 +361,18 @@ var TestScriptWithImport = Resource{
             assert(hello.greeting == "Hello, World!")
         }
     `),
+}
+
+var TestScriptWithHelperImport = Resource{
+	Filename: "testScriptWithHelperImport.cdc",
+	Source: []byte(`
+		import Test
+		import "test_helpers.cdc"
+
+		pub fun testDouble() {
+			Test.expect(double(2), Test.equal(4))
+		}
+	`),
 }
 
 var TestScriptWithRelativeImports = Resource{
@@ -437,6 +458,7 @@ var resources = []Resource{
 	ContractSimpleUpdated,
 	TransactionSimple,
 	ScriptImport,
+	HelperImport,
 	ContractA,
 	ContractB,
 	ContractC,

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -133,8 +133,17 @@ func importResolver(scriptPath string, state *flowkit.State) cdcTests.ImportReso
 		if !isFileImport {
 			return "", fmt.Errorf("cannot import from %s", location)
 		}
-
 		relativePath := stringLocation.String()
+
+		if strings.Contains(relativePath, "_helper") {
+			importedScriptFilePath := absolutePath(scriptPath, relativePath)
+			scriptCode, err := state.ReadFile(importedScriptFilePath)
+			if err != nil {
+				return "", nil
+			}
+			return string(scriptCode), nil
+		}
+
 		contractFound := false
 		for _, contract := range *state.Contracts() {
 			if strings.Contains(relativePath, contract.Location) {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -37,6 +37,10 @@ import (
 	"github.com/onflow/flow-cli/internal/util"
 )
 
+// Import statements with a path that contain this substring,
+// are considered to be helper/utility scripts for test files.
+const helperScriptSubstr = "_helper"
+
 type flagsTests struct {
 	Cover        bool   `default:"false" flag:"cover" info:"Use the cover flag to calculate coverage report"`
 	CoverProfile string `default:"coverage.json" flag:"coverprofile" info:"Filename to write the calculated coverage report"`
@@ -135,7 +139,7 @@ func importResolver(scriptPath string, state *flowkit.State) cdcTests.ImportReso
 		}
 		relativePath := stringLocation.String()
 
-		if strings.Contains(relativePath, "_helper") {
+		if strings.Contains(relativePath, helperScriptSubstr) {
 			importedScriptFilePath := absolutePath(scriptPath, relativePath)
 			scriptCode, err := state.ReadFile(importedScriptFilePath)
 			if err != nil {

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -38,8 +38,9 @@ func TestExecutingTests(t *testing.T) {
 		_, state, _ := util.TestMocks(t)
 
 		script := tests.TestScriptSimple
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, _, err := testCode(testFiles, state, false)
 
 		require.NoError(t, err)
@@ -52,8 +53,9 @@ func TestExecutingTests(t *testing.T) {
 		_, state, _ := util.TestMocks(t)
 
 		script := tests.TestScriptSimpleFailing
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, _, err := testCode(testFiles, state, false)
 
 		require.NoError(t, err)
@@ -76,8 +78,9 @@ func TestExecutingTests(t *testing.T) {
 
 		// Execute script
 		script := tests.TestScriptWithImport
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, _, err := testCode(testFiles, state, false)
 
 		require.NoError(t, err)
@@ -115,8 +118,9 @@ func TestExecutingTests(t *testing.T) {
 
 		// Execute script
 		script := tests.TestScriptWithRelativeImports
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, _, err := testCode(testFiles, state, false)
 
 		require.NoError(t, err)
@@ -130,8 +134,9 @@ func TestExecutingTests(t *testing.T) {
 
 		// Execute script
 		script := tests.TestScriptWithHelperImport
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, _, err := testCode(testFiles, state, false)
 
 		require.NoError(t, err)
@@ -153,8 +158,9 @@ func TestExecutingTests(t *testing.T) {
 
 		// Execute script
 		script := tests.TestScriptWithImport
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		_, _, err := testCode(testFiles, state, false)
 
 		require.Error(t, err)
@@ -177,8 +183,9 @@ func TestExecutingTests(t *testing.T) {
 
 		// Execute script
 		script := tests.TestScriptWithFileRead
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, _, err := testCode(testFiles, state, false)
 
 		require.NoError(t, err)
@@ -199,8 +206,9 @@ func TestExecutingTests(t *testing.T) {
 
 		// Execute script
 		script := tests.TestScriptWithCoverage
-		testFiles := make(map[string][]byte, 0)
-		testFiles[script.Filename] = script.Source
+		testFiles := map[string][]byte{
+			script.Filename: script.Source,
+		}
 		results, coverageReport, err := testCode(testFiles, state, true)
 
 		require.NoError(t, err)

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -124,6 +124,21 @@ func TestExecutingTests(t *testing.T) {
 		assert.NoError(t, results[script.Filename][0].Error)
 	})
 
+	t.Run("with helper script import", func(t *testing.T) {
+		t.Parallel()
+		_, state, _ := util.TestMocks(t)
+
+		// Execute script
+		script := tests.TestScriptWithHelperImport
+		testFiles := make(map[string][]byte, 0)
+		testFiles[script.Filename] = script.Source
+		results, _, err := testCode(testFiles, state, false)
+
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.NoError(t, results[script.Filename][0].Error)
+	})
+
 	t.Run("with missing contract location from config", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/148

## Description

> Able to write modular test cases means a developer can import the utility functions from a cadence file to the test file. to avoid repetitive code.

(taken from https://github.com/onflow/developer-grants/issues/148#issuecomment-1549064834)

**Note:** By convention, we consider files that contain the `_helper` substring, to be helper/utility files. Of course, this is just an initial implementation detail, feel free to suggest an alternative. The main difficulty here is that we can't distinguish from a `common.StringLocation`, if we are dealing with a contract, or with a simple script containing Cadence code. The `importResolver` function, has business logic which rejects any imports that are not declared in the `flow.json` config file.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
