### PR TITLE
Add GH token to install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,6 +10,8 @@
     The version to install.
 .Parameter AddToPath
     Add the absolute destination path to the 'User' scope environment variable 'Path'.
+.Parameter GitHubToken
+    Optional GitHub token to use to prevent rate limiting.
 .EXAMPLE
     Install the current version
     .\install.ps1
@@ -22,50 +24,58 @@
 param (
     [string] $version="",
     [string] $directory = "$env:APPDATA\Flow",
-    [bool] $addToPath = $true
+    [bool] $addToPath = $true,
+    [string] $githubToken = ""
 )
-
+ 
 Set-StrictMode -Version 3.0
-
+ 
 # Enable support for ANSI escape sequences
 Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1
-
+ 
 $ErrorActionPreference = "Stop"
-
+ 
 $repo = "onflow/flow-cli"
 $versionURL = "https://api.github.com/repos/$repo/releases/latest"
 $assetsURL = "https://github.com/$repo/releases/download"
-
+ 
+# Add the GitHub token to the web request headers if it was provided
+$webRequestOptions = if ($githubToken) {
+	@{ 'Headers' = @{ 'Authorization' = "Bearer $githubToken" } }
+} else {
+    @{}
+}
+ 
 if (!$version) {
-    $q = (Invoke-WebRequest -Uri "$versionURL" -UseBasicParsing) | ConvertFrom-Json
+    $q = (Invoke-WebRequest -Uri "$versionURL" -UseBasicParsing @webRequestOptions) | ConvertFrom-Json
     $version = $q.tag_name
 }
-
+ 
 Write-Output("Installing version {0} ..." -f $version)
-
+ 
 New-Item -ItemType Directory -Force -Path $directory | Out-Null
-
+ 
 $progressPreference = 'silentlyContinue'
-
-Invoke-WebRequest -Uri "$assetsURL/$version/flow-cli-$version-windows-amd64.zip" -UseBasicParsing -OutFile "$directory\flow.zip"
-
+ 
+Invoke-WebRequest -Uri "$assetsURL/$version/flow-cli-$version-windows-amd64.zip" -UseBasicParsing -OutFile "$directory\flow.zip" @webRequestOptions
+ 
 Expand-Archive -Path "$directory\flow.zip" -DestinationPath "$directory" -Force
-
+ 
 try {
     Stop-Process -Name flow -Force
     Start-Sleep -Seconds 1
 }
 catch {}
-
+ 
 Move-Item -Path "$directory\flow-cli.exe" -Destination "$directory\flow.exe" -Force
-
+ 
 if ($addToPath) {
     Write-Output "Adding to PATH ..."
     $newPath = $Env:Path + ";$directory"
     [System.Environment]::SetEnvironmentVariable("PATH", $newPath)
     [System.Environment]::SetEnvironmentVariable("PATH", $newPath, [System.EnvironmentVariableTarget]::User)
 }
-
+ 
 Write-Output "Done."
-
+ 
 Start-Sleep -Seconds 1

--- a/install.ps1
+++ b/install.ps1
@@ -27,55 +27,55 @@ param (
     [bool] $addToPath = $true,
     [string] $githubToken = ""
 )
- 
+
 Set-StrictMode -Version 3.0
- 
+
 # Enable support for ANSI escape sequences
 Set-ItemProperty HKCU:\Console VirtualTerminalLevel -Type DWORD 1
- 
+
 $ErrorActionPreference = "Stop"
- 
+
 $repo = "onflow/flow-cli"
 $versionURL = "https://api.github.com/repos/$repo/releases/latest"
 $assetsURL = "https://github.com/$repo/releases/download"
- 
+
 # Add the GitHub token to the web request headers if it was provided
 $webRequestOptions = if ($githubToken) {
 	@{ 'Headers' = @{ 'Authorization' = "Bearer $githubToken" } }
 } else {
     @{}
 }
- 
+
 if (!$version) {
     $q = (Invoke-WebRequest -Uri "$versionURL" -UseBasicParsing @webRequestOptions) | ConvertFrom-Json
     $version = $q.tag_name
 }
- 
+
 Write-Output("Installing version {0} ..." -f $version)
- 
+
 New-Item -ItemType Directory -Force -Path $directory | Out-Null
- 
+
 $progressPreference = 'silentlyContinue'
- 
+
 Invoke-WebRequest -Uri "$assetsURL/$version/flow-cli-$version-windows-amd64.zip" -UseBasicParsing -OutFile "$directory\flow.zip" @webRequestOptions
- 
+
 Expand-Archive -Path "$directory\flow.zip" -DestinationPath "$directory" -Force
- 
+
 try {
     Stop-Process -Name flow -Force
     Start-Sleep -Seconds 1
 }
 catch {}
- 
+
 Move-Item -Path "$directory\flow-cli.exe" -Destination "$directory\flow.exe" -Force
- 
+
 if ($addToPath) {
     Write-Output "Adding to PATH ..."
     $newPath = $Env:Path + ";$directory"
     [System.Environment]::SetEnvironmentVariable("PATH", $newPath)
     [System.Environment]::SetEnvironmentVariable("PATH", $newPath, [System.EnvironmentVariableTarget]::User)
 }
- 
+
 Write-Output "Done."
- 
+
 Start-Sleep -Seconds 1


### PR DESCRIPTION
Closes #1031 

- Adds GH token as a parameter for install scripts
- For Windows, it is the parameter `-GitHubToken`
- For UNIX, it is an env var `$GITHUB_TOKEN`

I added some retry logic into the UNIX implementation (if cURL fails, retry without access token) just in case people have bad tokens floating around in their system or whatever reason.  This seems less important in Windows since the user is explicitly specifying the parameter + it gives a more verbose error message (actually says unauthorized in the terminal when I tested).

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
