### PR TITLE
Don't overwrite contract if it exists

### DIFF
--- a/flowkit/flowkit.go
+++ b/flowkit/flowkit.go
@@ -371,10 +371,14 @@ func (f *Flowkit) AddContract(
 			Name: name,
 		})
 	}
-	state.Contracts().AddOrUpdate(config.Contract{
-		Name:     name,
-		Location: contract.Location,
-	})
+
+	// don't add contract if it already exists because it might overwrite existing data
+	if c, _ := state.Contracts().ByName(name); c == nil {
+		state.Contracts().AddOrUpdate(config.Contract{
+			Name:     name,
+			Location: contract.Location,
+		})
+	}
 
 	return sentTx.ID(), updateExisting, err
 }


### PR DESCRIPTION
Closes #1047 

## Description
If a contract already exists don't overwrite it because it looses data like aliases.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
