### PR TITLE
Fix Windows install script PATH environment variable behaviour

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -69,11 +69,15 @@ catch {}
 
 Move-Item -Path "$directory\flow-cli.exe" -Destination "$directory\flow.exe" -Force
 
-if ($addToPath) {
+# Check if the directory is already in the PATH
+$existingPaths = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User).Split(';')
+
+if ($addToPath -and $existingPaths -notcontains $directory) {
     Write-Output "Adding to PATH ..."
-    $newPath = $Env:Path + ";$directory"
-    [System.Environment]::SetEnvironmentVariable("PATH", $newPath)
-    [System.Environment]::SetEnvironmentVariable("PATH", $newPath, [System.EnvironmentVariableTarget]::User)
+    $processPath = [System.Environment]::GetEnvironmentVariable('PATH', [System.EnvironmentVariableTarget]::Process) + ";$directory"
+    $userPath = [System.Environment]::GetEnvironmentVariable('PATH', [System.EnvironmentVariableTarget]::User) + ";$directory"
+    [System.Environment]::SetEnvironmentVariable("PATH", $processPath, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable("PATH", $userPath, [System.EnvironmentVariableTarget]::User)
 }
 
 Write-Output "Done."


### PR DESCRIPTION
Closes #1058 

## Description

Fixes issue of system PATH being inherited by user PATH each install & issue of `%AppData%/Flow` path duplication

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
