### PR TITLE
Allow env vars for flow.json address

### DIFF
--- a/flowkit/config/json/account.go
+++ b/flowkit/config/json/account.go
@@ -79,6 +79,14 @@ func transformSimpleToConfig(accountName string, a simpleAccount) (*config.Accou
 	}
 	key.PrivateKey = pkey
 
+	replacedAddress, _, err := tryReplaceEnv(a.Address)
+	if err != nil {
+		return nil, err
+	}
+	if replacedAddress != "" {
+		a.Address = replacedAddress
+	}
+
 	address, err := transformAddress(a.Address)
 	if err != nil {
 		return nil, err

--- a/flowkit/config/json/account_test.go
+++ b/flowkit/config/json/account_test.go
@@ -369,6 +369,35 @@ func Test_ConfigAccountsMap(t *testing.T) {
 	assert.Equal(t, emulatorAccount.Name, "emulator-account")
 }
 
+func Test_ConfigAccountsMapWithEnvVars(t *testing.T) {
+
+	os.Setenv("FLOW_EMULATOR_ADDRESS", "f8d6e0586b0a20c7")
+	os.Setenv("FLOW_EMULATOR_KEY", "dd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+
+	b := []byte(`{
+		"emulator-account": {
+			"address": "$FLOW_EMULATOR_ADDRESS",
+			"key": "$FLOW_EMULATOR_KEY"
+		},
+		"testnet-account": {
+			"address": "3c1162386b0a245f",
+			"key": "1232967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47"
+		}
+	}`)
+
+	var jsonAccounts jsonAccounts
+	err := json.Unmarshal(b, &jsonAccounts)
+	assert.NoError(t, err)
+
+	accounts, err := jsonAccounts.transformToConfig()
+	assert.NoError(t, err)
+	emulatorAccount, err := accounts.ByName("emulator-account")
+	assert.NoError(t, err)
+	assert.Equal(t, emulatorAccount.Address.String(), "f8d6e0586b0a20c7")
+	assert.Equal(t, emulatorAccount.Key.PrivateKey.String(), "0xdd72967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
+	assert.Equal(t, emulatorAccount.Name, "emulator-account")
+}
+
 func Test_TransformDefaultAccountToJSON(t *testing.T) {
 	privateKey, err := crypto.DecodePrivateKeyHex(crypto.ECDSA_P256, "1272967fd2bd75234ae9037dd4694c1f00baad63a10c35172bf65fbb8ad74b47")
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes #1039 

## Description

Allow env vars for flow.json address

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
