### PR TITLE
Return an exit code of 1 for test scripts with failures

### DIFF
--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/internal/accounts"
@@ -114,5 +116,9 @@ func main() {
 
 	if err := cmd.Execute(); err != nil {
 		util.Exit(1, err.Error())
+	}
+
+	if status := *test.TestCommand.Status; status > 0 {
+		os.Exit(int(status))
 	}
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -66,10 +66,11 @@ type RunWithState func(
 ) (Result, error)
 
 type Command struct {
-	Cmd   *cobra.Command
-	Flags any
-	Run   run
-	RunS  RunWithState
+	Cmd    *cobra.Command
+	Flags  any
+	Run    run
+	RunS   RunWithState
+	Status *int
 }
 
 const (

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -48,6 +48,8 @@ type flagsTests struct {
 
 var testFlags = flagsTests{}
 
+var status = 0
+
 var TestCommand = &command.Command{
 	Cmd: &cobra.Command{
 		Use:     "test <filename>",
@@ -56,8 +58,9 @@ var TestCommand = &command.Command{
 		Args:    cobra.MinimumNArgs(1),
 		GroupID: "tools",
 	},
-	Flags: &testFlags,
-	RunS:  run,
+	Flags:  &testFlags,
+	RunS:   run,
+	Status: &status,
 }
 
 func run(
@@ -127,6 +130,12 @@ func testCode(
 			return nil, nil, err
 		}
 		testResults[scriptPath] = results
+		for _, result := range results {
+			if result.Error != nil {
+				status = 1
+				break
+			}
+		}
 	}
 	return testResults, coverageReport, nil
 }


### PR DESCRIPTION
## Description

The `flow test` command returns an exit code of 0, even when there are test failures. It will be easier for CI workflows, if an exit code of 1 is returned in that case, to signal that the test workflow failed. This is also the same behavior that the `go test` tool exhibits.

See image:

![Screenshot from 2023-06-11 17-54-15](https://github.com/onflow/flow-cli/assets/1778965/9bc14608-1f8c-4a06-b053-13d05e3b6bc0)

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
