### PR TITLE
Implement the new import format in test command

### DIFF
--- a/flowkit/tests/resources.go
+++ b/flowkit/tests/resources.go
@@ -354,7 +354,7 @@ var TestScriptSimpleFailing = Resource{
 var TestScriptWithImport = Resource{
 	Filename: "testScriptWithImport.cdc",
 	Source: []byte(`
-        import Hello from "contractHello.cdc"
+        import "Hello"
 
         pub fun testSimple() {
             let hello = Hello()
@@ -378,8 +378,8 @@ var TestScriptWithHelperImport = Resource{
 var TestScriptWithRelativeImports = Resource{
 	Filename: "testScriptWithRelativeImport.cdc",
 	Source: []byte(`
-        import FooContract from "../contracts/FooContract.cdc"
-        import Hello from "../contracts/contractHello.cdc"
+        import "FooContract"
+        import "Hello"
 
         pub fun testSimple() {
             let hello = Hello()
@@ -406,7 +406,7 @@ var TestScriptWithFileRead = Resource{
 var TestScriptWithCoverage = Resource{
 	Filename: "testScriptWithCoverage.cdc",
 	Source: []byte(`
-		import FooContract from "FooContract.cdc"
+		import "FooContract"
 
 		pub let foo = FooContract()
 

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/flowkit"
+	"github.com/onflow/flow-cli/flowkit/config"
 	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
@@ -157,22 +158,21 @@ func importResolver(scriptPath string, state *flowkit.State) cdcTests.ImportReso
 			return string(scriptCode), nil
 		}
 
-		contractFound := false
-		for _, contract := range *state.Contracts() {
-			if strings.Contains(relativePath, contract.Location) {
-				contractFound = true
+		var contract *config.Contract
+		for _, c := range *state.Contracts() {
+			if c.Name == relativePath {
+				contract = &c
 				break
 			}
 		}
-		if !contractFound {
+		if contract == nil {
 			return "", fmt.Errorf(
 				"cannot find contract with location '%s' in configuration",
 				relativePath,
 			)
 		}
 
-		importedContractFilePath := absolutePath(scriptPath, relativePath)
-		contractCode, err := state.ReadFile(importedContractFilePath)
+		contractCode, err := state.ReadFile(contract.Location)
 		if err != nil {
 			return "", err
 		}

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -215,7 +215,7 @@ func TestExecutingTests(t *testing.T) {
 		require.Len(t, results, 1)
 		assert.NoError(t, results[script.Filename][0].Error)
 
-		location := common.StringLocation("FooContract.cdc")
+		location := common.StringLocation("FooContract")
 		coverage := coverageReport.Coverage[location]
 
 		assert.Equal(t, []int{}, coverage.MissedLines())


### PR DESCRIPTION
Closes https://github.com/onflow/flow-cli/issues/810

## Description

The new import format is mostly used in unit tests, where contracts can be constructed, and don't have to be deployed on the blockchain. For example:

```cadence
import Test
import "FooContract"

pub let foo = FooContract()

pub fun testAddSpecialNumber() {
    // Act
    foo.addSpecialNumber(78557, "Sierpinski")

    // Assert
    Test.assert("Sierpinski" == foo.getIntegerTrait(78557))
}
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
