### PR TITLE
Support LCOV format for code coverage

### DIFF
--- a/flowkit/go.mod
+++ b/flowkit/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.22
 	github.com/gosuri/uilive v0.0.4
 	github.com/lmars/go-slip10 v0.0.0-20190606092855-400ba44fee12
-	github.com/onflow/cadence v0.39.4
+	github.com/onflow/cadence v0.39.10
 	github.com/onflow/flow-emulator v0.50.4
 	github.com/onflow/flow-go v0.31.1-0.20230607185125-e75265a6c631
 	github.com/onflow/flow-go-sdk v0.41.2

--- a/flowkit/go.sum
+++ b/flowkit/go.sum
@@ -541,6 +541,8 @@ github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
 github.com/onflow/cadence v0.39.4 h1:Rg2WUtrgXWADHlN2n0NKo+0sAdijx67oiTNdrG0vJOM=
 github.com/onflow/cadence v0.39.4/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
+github.com/onflow/cadence v0.39.10 h1:JDHIbjm41yRqRSKB/xeKlceVig1HysZoAgTI+KGWUFU=
+github.com/onflow/cadence v0.39.10/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3 h1:wV+gcgOY0oJK4HLZQYQoK+mm09rW1XSxf83yqJwj0n4=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3/go.mod h1:Osvy81E/+tscQM+d3kRFjktcIcZj2bmQ9ESqRQWDEx8=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+KoV76wQ6BR6qI7G65vuuRXxDDqX7E=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/gosuri/uilive v0.0.4
 	github.com/manifoldco/promptui v0.9.0
-	github.com/onflow/cadence v0.39.4
+	github.com/onflow/cadence v0.39.10
 	github.com/onflow/cadence-tools/languageserver v0.29.1
 	github.com/onflow/cadence-tools/test v0.9.0
 	github.com/onflow/fcl-dev-wallet v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -787,6 +787,8 @@ github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
 github.com/onflow/cadence v0.39.4 h1:Rg2WUtrgXWADHlN2n0NKo+0sAdijx67oiTNdrG0vJOM=
 github.com/onflow/cadence v0.39.4/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
+github.com/onflow/cadence v0.39.10 h1:JDHIbjm41yRqRSKB/xeKlceVig1HysZoAgTI+KGWUFU=
+github.com/onflow/cadence v0.39.10/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
 github.com/onflow/cadence-tools/languageserver v0.29.1 h1:d9aBD7w7MfwztpbJqCjOGWt8foEqWKrTSGPNEmhe9yU=
 github.com/onflow/cadence-tools/languageserver v0.29.1/go.mod h1:NMxYUwoMqkNkKfsVaZMh1OmlHNC0DGVxKhbt8zYiMtc=
 github.com/onflow/cadence-tools/lint v0.8.2 h1:iKYmhwhf47XDVlmNOsuRTkE7y5/4aCFoh0NcRmSAFwQ=

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -92,7 +92,18 @@ func run(
 	}
 
 	if coverageReport != nil {
-		file, err := json.MarshalIndent(coverageReport, "", "  ")
+		var file []byte
+		var err error
+
+		ext := path.Ext(testFlags.CoverProfile)
+		if ext == ".json" {
+			file, err = json.MarshalIndent(coverageReport, "", "  ")
+		} else if ext == ".lcov" {
+			file, err = coverageReport.MarshalLCOV()
+		} else {
+			return nil, fmt.Errorf("given format: %v, only .json and .lcov are supported", ext)
+		}
+
 		if err != nil {
 			return nil, fmt.Errorf("error serializing coverage report: %w", err)
 		}


### PR DESCRIPTION
## Description

Updates the `onflow/cadence` dependency to version `v0.39.10`, which contains supports for marshaling a `CoverageReport` object to LCOV format.

The new format can be generated with:

```bash
flow test --cover --coverprofile=coverage.lcov tests/test_approval_voting.cdc
```

The filename for the `--coverprofile` flag, should have the `.lcov` extension
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
