### PR TITLE
Report system chunk transactions within a block

### DIFF
--- a/internal/blocks/blocks_test.go
+++ b/internal/blocks/blocks_test.go
@@ -46,14 +46,30 @@ func Test_GetBlock(t *testing.T) {
 			assert.Equal(t, uint64(100), args.Get(3).(uint64))
 		}).Return(nil, nil)
 
-		srv.GetCollection.Return(nil, nil)
-
 		returnBlock := tests.NewBlock()
 		returnBlock.Height = uint64(100)
 
 		srv.GetBlock.Run(func(args mock.Arguments) {
 			assert.Equal(t, uint64(100), args.Get(1).(flowkit.BlockQuery).Height)
 		}).Return(returnBlock, nil)
+
+		returnCollection := tests.NewCollection()
+		transaction1 := tests.NewTransaction()
+		transaction2 := tests.NewTransaction()
+		returnCollection.TransactionIDs = []flow.Identifier{
+			transaction1.ID(),
+			transaction2.ID(),
+		}
+		transactions := []*flow.Transaction{
+			transaction1,
+			transaction2,
+		}
+
+		srv.GetTransactionsByBlockID.Run(func(args mock.Arguments) {
+			assert.Equal(t, returnBlock.ID, args.Get(1).(flow.Identifier))
+		}).Return(transactions, nil, nil)
+
+		srv.GetCollection.Return(returnCollection, nil)
 
 		result, err := get(inArgs, command.GlobalFlags{}, util.NoLogger, rw, srv.Mock)
 		assert.NotNil(t, result)

--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -82,13 +82,31 @@ func get(
 	}
 
 	collections := make([]*flowsdk.Collection, 0)
+	collectionTxs := 0
 	if command.ContainsFlag(blockFlags.Include, "transactions") {
+		var lastCollection *flowsdk.Collection
 		for _, guarantee := range block.CollectionGuarantees {
 			collection, err := flow.GetCollection(context.Background(), guarantee.CollectionID)
 			if err != nil {
 				return nil, err
 			}
 			collections = append(collections, collection)
+			collectionTxs += len(collection.TransactionIDs)
+			lastCollection = collection
+		}
+
+		transactions, _, err := flow.GetTransactionsByBlockID(context.Background(), block.ID)
+		if err != nil {
+			return nil, err
+		}
+		// The last transaction returned from `flow.GetTransactionsByBlockID`,
+		// is the system chunk transaction. We add it as the last transaction
+		// in the last collection.
+		if lastCollection != nil && len(transactions) == (collectionTxs+1) {
+			lastCollection.TransactionIDs = append(
+				lastCollection.TransactionIDs,
+				transactions[collectionTxs].ID(),
+			)
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/onflow/flow-cli/issues/911

## Description

The last transaction returned from `flow.GetTransactionsByBlockID`, is the system chunk transaction. We add it as the last transaction in the last collection, so it can be returned from the command:

```bash
flow blocks get 53665542 --network=mainnet --include transactions
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
