### PR TITLE
Add Flow CLI to PATH in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,9 @@ if [ -n "$GITHUB_TOKEN" ]; then
   github_token_header="Authorization: Bearer $GITHUB_TOKEN"
 fi
 
-modify_dotfiles = true
+modify_dotfiles=true
 if [ -n "$NO_MODIFY_DOTFILES" ]; then
-  modify_dotfiles = false
+  modify_dotfiles=false
 fi
 
 # Get the architecture (CPU, OS) of the current system as a string.
@@ -41,7 +41,7 @@ get_architecture() {
         Darwin)
             _ostype=darwin
             _targetpath=/usr/local/bin
-            modify_dotfiles = false
+            modify_dotfiles=false
             ;;
         *)
             echo "unrecognized OS type: $_ostype"

--- a/install.sh
+++ b/install.sh
@@ -105,8 +105,17 @@ append_path_to_dotfiles() {
             if grep -q -x "export PATH=\$PATH:$1" "$profile_file"; then
                 echo "Directory already in PATH in $profile_file."
             else
-                # Append the directory to the PATH variable in the profile file
-                echo "export PATH=\$PATH:$1" >> "$profile_file"
+                # Append the directory to the PATH variable in the dotfile
+                # It will only be appended if the directory is not already in the PATH
+                echo ""                                         >> "$profile_file"
+                echo "### FLOW CLI"                             >> "$profile_file"
+                echo "case \":\$PATH:\" in"                     >> "$profile_file"
+                echo " *\":$TARGET_PATH:\"*);;"                 >> "$profile_file"
+                echo "  *)"                                     >> "$profile_file"
+                echo "    export PATH=\"\$PATH:$TARGET_PATH\""  >> "$profile_file"
+                echo "esac"                                     >> "$profile_file"
+                echo "### END"                                  >> "$profile_file"
+                ### END
                 echo "Directory appended to PATH in $profile_file."
             fi
         fi


### PR DESCRIPTION
Closes #1116 

This PR appends Flow CLI to the PATH in any found shell configuration files/profile files automatically.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
