### PR TITLE
Auto update to onflow/cadence v0.39.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/manifoldco/promptui v0.9.0
 	github.com/onflow/cadence v0.39.14
-	github.com/onflow/cadence-tools/languageserver v0.30.0
+	github.com/onflow/cadence-tools/languageserver v0.30.1
 	github.com/onflow/cadence-tools/test v0.9.2
 	github.com/onflow/fcl-dev-wallet v0.7.2
-	github.com/onflow/flow-cli/flowkit v1.3.1
+	github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3
 	github.com/onflow/flow-emulator v0.52.0
 	github.com/onflow/flow-go-sdk v0.41.9
@@ -144,7 +144,7 @@ require (
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/onflow/atree v0.6.0 // indirect
-	github.com/onflow/cadence-tools/lint v0.9.0 // indirect
+	github.com/onflow/cadence-tools/lint v0.10.1 // indirect
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/onflow/cadence v0.39.14
 	github.com/onflow/cadence-tools/languageserver v0.30.1
-	github.com/onflow/cadence-tools/test v0.9.2
+	github.com/onflow/cadence-tools/test v0.9.3
 	github.com/onflow/fcl-dev-wallet v0.7.2
 	github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -772,10 +772,10 @@ github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
 github.com/onflow/cadence v0.39.14 h1:YoR3YFUga49rqzVY1xwI6I2ZDBmvwGh13jENncsleC8=
 github.com/onflow/cadence v0.39.14/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
-github.com/onflow/cadence-tools/languageserver v0.30.0 h1:ipKV76Y4t7bFEmpLxwnI9vlIhno0DpPBltH1ldOvzNY=
-github.com/onflow/cadence-tools/languageserver v0.30.0/go.mod h1:DeBmz0tDkJZow85avPuPYDpQxnO+lO63oRP7Eahyipg=
-github.com/onflow/cadence-tools/lint v0.9.0 h1:hGYL1608rhk1ALCFShg/4BDacmUYk54nfIC7tstEIoY=
-github.com/onflow/cadence-tools/lint v0.9.0/go.mod h1:mmULh2XMBId55Flv9gaMGThqgDTSMkt96arfpqeaz8I=
+github.com/onflow/cadence-tools/languageserver v0.30.1 h1:bLomSlGv3ktnJELbf74izldc6GrFEwwaiLqIZHhiXLo=
+github.com/onflow/cadence-tools/languageserver v0.30.1/go.mod h1:+UIkgEGqAJpIggS/P5dnhWLBRFtDJg3+R2otL5Lv5Q0=
+github.com/onflow/cadence-tools/lint v0.10.1 h1:EAtLDiwtA7gnZ1grwmQkiCu487dTpH1H9v57UaoBPGk=
+github.com/onflow/cadence-tools/lint v0.10.1/go.mod h1:Rz3QhLseu6SnvZgBvyeJ0qzzz38Wxlev1lFwLiZtoPQ=
 github.com/onflow/cadence-tools/test v0.9.2 h1:tb+4/ZyOYGhH4+lFnrkGfEYiT29CkE24z2+gmJAzHDg=
 github.com/onflow/cadence-tools/test v0.9.2/go.mod h1:Cb2uu5u4eKgITDBTl4b13pa9Fa5M053Yi2Mdr7Ib3W0=
 github.com/onflow/fcl-dev-wallet v0.7.2 h1:ZwhpzDakcZn9rHiIr52LwkdPh1MpUPbxA/PwCVaZ2SA=

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,8 @@ github.com/onflow/cadence-tools/languageserver v0.30.1 h1:bLomSlGv3ktnJELbf74izl
 github.com/onflow/cadence-tools/languageserver v0.30.1/go.mod h1:+UIkgEGqAJpIggS/P5dnhWLBRFtDJg3+R2otL5Lv5Q0=
 github.com/onflow/cadence-tools/lint v0.10.1 h1:EAtLDiwtA7gnZ1grwmQkiCu487dTpH1H9v57UaoBPGk=
 github.com/onflow/cadence-tools/lint v0.10.1/go.mod h1:Rz3QhLseu6SnvZgBvyeJ0qzzz38Wxlev1lFwLiZtoPQ=
-github.com/onflow/cadence-tools/test v0.9.2 h1:tb+4/ZyOYGhH4+lFnrkGfEYiT29CkE24z2+gmJAzHDg=
-github.com/onflow/cadence-tools/test v0.9.2/go.mod h1:Cb2uu5u4eKgITDBTl4b13pa9Fa5M053Yi2Mdr7Ib3W0=
+github.com/onflow/cadence-tools/test v0.9.3 h1:Sez6EIZ6Hk2OoyIFWQG5sOWu8eght6LR+Bp9ipIpW+Q=
+github.com/onflow/cadence-tools/test v0.9.3/go.mod h1:yQdIAX49QP7WWpk7uZZ4Hxoqnb03nlOKExC7XFp9hDA=
 github.com/onflow/fcl-dev-wallet v0.7.2 h1:ZwhpzDakcZn9rHiIr52LwkdPh1MpUPbxA/PwCVaZ2SA=
 github.com/onflow/fcl-dev-wallet v0.7.2/go.mod h1:kc42jkiuoPJmxMRFjfbRO9XvnR/3XLheaOerxVMDTiw=
 github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc h1:C4ZniFeOv+pHlDLJdGc/4e3NklSjVuvaXKN47980gnY=


### PR DESCRIPTION
## Description

Automatically update to:
- [onflow/cadence v0.39.14](https://github.com/onflow/cadence/releases/tag/v0.39.14)
- [onflow/flow-go-sdk v0.41.9](https://github.com/onflow/flow-go-sdk/releases/tag/v0.41.9)
- [onflow/flow-go 82d6e5f45ca1](https://github.com/onflow/flow-go/releases/tag/82d6e5f45ca1)
- [onflow/flow-emulator v0.52.0](https://github.com/onflow/flow-emulator/releases/tag/v0.52.0)
- [onflow/cadence-tools/test v0.9.3](https://github.com/onflow/cadence-tools/releases/tag/test%2Fv0.9.3)
- [onflow/cadence-tools/lint v0.10.1](https://github.com/onflow/cadence-tools/releases/tag/lint%2Fv0.10.1)
- [onflow/cadence-tools/languageserver v0.30.1](https://github.com/onflow/cadence-tools/releases/tag/languageserver%2Fv0.30.1)

