### PR TITLE
Resolve `--network` name even with `--host`

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -186,11 +186,6 @@ func createGateway(network config.Network) (gateway.Gateway, error) {
 // 3. if conf is not initialized and network flag is provided resolve to coded value for that network
 // 4. default to emulator network
 func resolveHost(state *flowkit.State, hostFlag, networkKeyFlag, networkFlag string) (*config.Network, error) {
-	// don't allow both network and host flag as the host might be different
-	if networkFlag != config.EmulatorNetwork.Name && hostFlag != "" {
-		return nil, fmt.Errorf("shouldn't use both host and network flags, better to use network flag")
-	}
-
 	// host flag has the highest priority
 	if hostFlag != "" {
 		// if network-key was provided validate it

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -200,8 +200,12 @@ func resolveHost(state *flowkit.State, hostFlag, networkKeyFlag, networkFlag str
 				return nil, fmt.Errorf("invalid network key %s: %w", networkKeyFlag, err)
 			}
 		}
+		_, err := state.Networks().ByName(networkFlag)
+		if err != nil {
+			return nil, fmt.Errorf("network with name %s does not exist in configuration", networkFlag)
+		}
 
-		return &config.Network{Name: "custom", Host: hostFlag, Key: networkKeyFlag}, nil
+		return &config.Network{Name: networkFlag, Host: hostFlag, Key: networkKeyFlag}, nil
 	}
 
 	// network flag with project initialized is next


### PR DESCRIPTION
Closes #1121 
## Description

Make flow-cli use `--network` flag ( or default "emulator") instead of the implicit value of "custom" for the network name when running commands with `--host` flag.

This fixes `flow deploy` command to work with `--host`.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
