### PR TITLE
err on malformed json config

### DIFF
--- a/flowkit/config/json/config_test.go
+++ b/flowkit/config/json/config_test.go
@@ -34,43 +34,6 @@ func keys() []crypto.PrivateKey {
 	return keys
 }
 
-func Test_SimpleInvalidContractConfig(t *testing.T) {
-	b := []byte(`{
-	"networks": {
-		"emulator": "127.0.0.1:3569",
-		"mainnet": "access.mainnet.nodes.onflow.org:9000",
-		"testnet": "access.devnet.nodes.onflow.org:9000"
-	},
-	"contracts": {
-		"DapperWalletRestrictions": "./contracts/DapperWalletRestrictions.cdc",
-	},
-	"accounts": {
-		"emulator-account": {
-			"address": "f8d6e0586b0a20c7",
-			"key": "2e8a599d996182262b49b2dbacf15d4ce103044d74ca003e5959ab3d64608947"
-		}
-	},
-	"deployments": {
-		"emulator": {
-			"emulator-account": [
-				"DapperWalletRestrictions"
-			]
-		}
-	}
-}`)
-
-	parser := NewParser()
-	conf, err := parser.Deserialize(b)
-
-	assert.NoError(t, err)
-	assert.Len(t, conf.Accounts, 1)
-	assert.Equal(t, "emulator-account", conf.Accounts[0].Name)
-	assert.Equal(t, "0x11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Key.PrivateKey.String())
-	network, err := conf.Networks.ByName("emulator")
-	assert.NoError(t, err)
-	assert.Equal(t, "127.0.0.1:3569", network.Host)
-}
-
 func Test_SimpleJSONConfig(t *testing.T) {
 	b := []byte(`{
 		"emulators": {

--- a/flowkit/config/json/config_test.go
+++ b/flowkit/config/json/config_test.go
@@ -34,6 +34,43 @@ func keys() []crypto.PrivateKey {
 	return keys
 }
 
+func Test_SimpleInvalidContractConfig(t *testing.T) {
+	b := []byte(`{
+	"networks": {
+		"emulator": "127.0.0.1:3569",
+		"mainnet": "access.mainnet.nodes.onflow.org:9000",
+		"testnet": "access.devnet.nodes.onflow.org:9000"
+	},
+	"contracts": {
+		"DapperWalletRestrictions": "./contracts/DapperWalletRestrictions.cdc",
+	},
+	"accounts": {
+		"emulator-account": {
+			"address": "f8d6e0586b0a20c7",
+			"key": "2e8a599d996182262b49b2dbacf15d4ce103044d74ca003e5959ab3d64608947"
+		}
+	},
+	"deployments": {
+		"emulator": {
+			"emulator-account": [
+				"DapperWalletRestrictions"
+			]
+		}
+	}
+}`)
+
+	parser := NewParser()
+	conf, err := parser.Deserialize(b)
+
+	assert.NoError(t, err)
+	assert.Len(t, conf.Accounts, 1)
+	assert.Equal(t, "emulator-account", conf.Accounts[0].Name)
+	assert.Equal(t, "0x11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7", conf.Accounts[0].Key.PrivateKey.String())
+	network, err := conf.Networks.ByName("emulator")
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:3569", network.Host)
+}
+
 func Test_SimpleJSONConfig(t *testing.T) {
 	b := []byte(`{
 		"emulators": {

--- a/flowkit/config/loader.go
+++ b/flowkit/config/loader.go
@@ -113,7 +113,11 @@ func (l *Loader) loadConfig(confPath string) (*Config, error) {
 		return nil, err
 	}
 
-	preProcessed := l.preprocess(raw)
+	preProcessed, err := l.preprocess(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to preprocess config: %w", err)
+	}
+
 	configParser := l.configParsers.FindForFormat(filepath.Ext(confPath))
 	if configParser == nil {
 		return nil, fmt.Errorf("parser not found for config: %s", confPath)
@@ -170,7 +174,7 @@ func (l *Loader) Load(paths []string) (*Config, error) {
 }
 
 // preprocess does all manipulations to the raw configuration format happens here.
-func (l *Loader) preprocess(raw []byte) []byte {
+func (l *Loader) preprocess(raw []byte) ([]byte, error) {
 	return processorRun(raw)
 }
 

--- a/flowkit/config/processor.go
+++ b/flowkit/config/processor.go
@@ -20,10 +20,11 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // processorRun all pre-processors.
-func processorRun(raw []byte) []byte {
+func processorRun(raw []byte) ([]byte, error) {
 	type config struct {
 		Accounts    map[string]map[string]any `json:"accounts,omitempty"`
 		Contracts   any                       `json:"contracts,omitempty"`
@@ -33,8 +34,15 @@ func processorRun(raw []byte) []byte {
 	}
 
 	var conf config
-	_ = json.Unmarshal(raw, &conf)
+	err := json.Unmarshal(raw, &conf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config JSON: %w", err)
+	}
 
-	raw, _ = json.Marshal(conf)
-	return raw
+	raw, err = json.Marshal(conf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	return raw, nil
 }

--- a/flowkit/config/processor_test.go
+++ b/flowkit/config/processor_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_PrivateConfigFileAccounts(t *testing.T) {
@@ -45,6 +46,9 @@ func Test_PrivateConfigFileAccounts(t *testing.T) {
 		}
 	}`)
 
+	processorRunRes, err := processorRun(b)
+	require.NoError(t, err)
+
 	assert.JSONEq(t, `{
 		"emulators": {
 			"default": {
@@ -63,5 +67,5 @@ func Test_PrivateConfigFileAccounts(t *testing.T) {
 					"key": "11c5dfdeb0ff03a7a73ef39788563b62c89adea67bbb21ab95e5f710bd1d40b7"
 				}
 			}
-		}`, string(processorRun(b)))
+		}`, string(processorRunRes))
 }


### PR DESCRIPTION
Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

flow-cli silences the json unmarshal error at preprocess stage when the flow.json is malformed. this PR re-surfaces the error

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
