### PR TITLE
Bump `onflow/cadence-tools/test` to `v0.10.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/manifoldco/promptui v0.9.0
 	github.com/onflow/cadence v0.39.14
-	github.com/onflow/cadence-tools/languageserver v0.30.1
+	github.com/onflow/cadence-tools/languageserver v0.31.0
 	github.com/onflow/cadence-tools/test v0.10.0
 	github.com/onflow/fcl-dev-wallet v0.7.2
 	github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/onflow/cadence v0.39.14
 	github.com/onflow/cadence-tools/languageserver v0.30.1
-	github.com/onflow/cadence-tools/test v0.9.3
+	github.com/onflow/cadence-tools/test v0.10.0
 	github.com/onflow/fcl-dev-wallet v0.7.2
 	github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,8 @@ github.com/onflow/cadence-tools/languageserver v0.30.1 h1:bLomSlGv3ktnJELbf74izl
 github.com/onflow/cadence-tools/languageserver v0.30.1/go.mod h1:+UIkgEGqAJpIggS/P5dnhWLBRFtDJg3+R2otL5Lv5Q0=
 github.com/onflow/cadence-tools/lint v0.10.1 h1:EAtLDiwtA7gnZ1grwmQkiCu487dTpH1H9v57UaoBPGk=
 github.com/onflow/cadence-tools/lint v0.10.1/go.mod h1:Rz3QhLseu6SnvZgBvyeJ0qzzz38Wxlev1lFwLiZtoPQ=
-github.com/onflow/cadence-tools/test v0.9.3 h1:Sez6EIZ6Hk2OoyIFWQG5sOWu8eght6LR+Bp9ipIpW+Q=
-github.com/onflow/cadence-tools/test v0.9.3/go.mod h1:yQdIAX49QP7WWpk7uZZ4Hxoqnb03nlOKExC7XFp9hDA=
+github.com/onflow/cadence-tools/test v0.10.0 h1:tcNjOFXl7ZuuvgQ3uS36ENd8l3RkSBv4toC/J302rhY=
+github.com/onflow/cadence-tools/test v0.10.0/go.mod h1:eIvZOzFdi4JR2x6ekQfN8veQy04ZlZYbeeiQF/oZ0zM=
 github.com/onflow/fcl-dev-wallet v0.7.2 h1:ZwhpzDakcZn9rHiIr52LwkdPh1MpUPbxA/PwCVaZ2SA=
 github.com/onflow/fcl-dev-wallet v0.7.2/go.mod h1:kc42jkiuoPJmxMRFjfbRO9XvnR/3XLheaOerxVMDTiw=
 github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc h1:C4ZniFeOv+pHlDLJdGc/4e3NklSjVuvaXKN47980gnY=

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,8 @@ github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
 github.com/onflow/cadence v0.39.14 h1:YoR3YFUga49rqzVY1xwI6I2ZDBmvwGh13jENncsleC8=
 github.com/onflow/cadence v0.39.14/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
-github.com/onflow/cadence-tools/languageserver v0.30.1 h1:bLomSlGv3ktnJELbf74izldc6GrFEwwaiLqIZHhiXLo=
-github.com/onflow/cadence-tools/languageserver v0.30.1/go.mod h1:+UIkgEGqAJpIggS/P5dnhWLBRFtDJg3+R2otL5Lv5Q0=
+github.com/onflow/cadence-tools/languageserver v0.31.0 h1:OE5G63yQ/iJ3VzrOvWENeLFu9xEh36bIpWQaGUDBW2o=
+github.com/onflow/cadence-tools/languageserver v0.31.0/go.mod h1:e7u5+8DYt3UyqD6PwXOwDIIPshNxDrvjGg7tops0Ics=
 github.com/onflow/cadence-tools/lint v0.10.1 h1:EAtLDiwtA7gnZ1grwmQkiCu487dTpH1H9v57UaoBPGk=
 github.com/onflow/cadence-tools/lint v0.10.1/go.mod h1:Rz3QhLseu6SnvZgBvyeJ0qzzz38Wxlev1lFwLiZtoPQ=
 github.com/onflow/cadence-tools/test v0.10.0 h1:tcNjOFXl7ZuuvgQ3uS36ENd8l3RkSBv4toC/J302rhY=


### PR DESCRIPTION
## Description

Bumps the `cadence-tools/test` dependency to latest version.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
