### PR TITLE
Use custom flag if no state is available

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -195,9 +195,14 @@ func resolveHost(state *flowkit.State, hostFlag, networkKeyFlag, networkFlag str
 				return nil, fmt.Errorf("invalid network key %s: %w", networkKeyFlag, err)
 			}
 		}
-		_, err := state.Networks().ByName(networkFlag)
-		if err != nil {
-			return nil, fmt.Errorf("network with name %s does not exist in configuration", networkFlag)
+
+		if state != nil {
+			_, err := state.Networks().ByName(networkFlag)
+			if err != nil {
+				return nil, fmt.Errorf("network with name %s does not exist in configuration", networkFlag)
+			}
+		} else {
+			networkFlag = "custom"
 		}
 
 		return &config.Network{Name: networkFlag, Host: hostFlag, Key: networkKeyFlag}, nil


### PR DESCRIPTION
Closes #1160 

## Description

Use previous "custom" flag if no state is available like it was before the change that broke it: https://github.com/onflow/flow-cli/commit/3af5cf585bd32b37219d74cf5b42a00e3b3cd148#diff-69d3575d337e6861d23e877e04bbdb99f437a82661f706f055a50e82b1e8282aL204
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
