### PR TITLE
Fix homebrew release action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,5 +12,7 @@ jobs:
       - uses: mislav/bump-homebrew-formula-action@v1
         with:
           formula-name: flow-cli
+          # https://github.com/mislav/bump-homebrew-formula-action/issues/58
+          formula-path: Formula/f/flow-cli.rb
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Closes #1184

Homebrew recently sharded their formula directories which broke the GitHub action to release to homebrew.  This fixes that bug

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
