### PR TITLE
Fix Readme doc links to Flow CLI, Flow Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@
 
 ## Installation
 
-To install the Flow CLI, follow the [installation instructions](https://developers.flow.com/next/tools/toolchains/flow-cli/install) on the Flow documentation website.
+To install the Flow CLI, follow the [installation instructions](https://developers.flow.com/tools/toolchains/flow-cli/install) on the Flow documentation website.
 
 ## Documentation
 
-You can find the CLI documentation on the [CLI documentation website](https://developers.flow.com/next/tools/toolchains/flow-cli).
+You can find the CLI documentation on the [CLI documentation website](https://developers.flow.com/tools/toolchains/flow-cli).
 
 ## Features
 The Flow CLI is a command line tool that allows you to interact with the Flow blockchain. 
-Read about supported commands in the [CLI documentation website](https://developers.flow.com/next/tools/toolchains/flow-cli).
+Read about supported commands in the [CLI documentation website](https://developers.flow.com/tools/toolchains/flow-cli).
 
 ```
 Usage:
@@ -55,7 +55,7 @@ Available Commands:
   version      View version and commit information
 ```
 
-The Flow CLI includes several commands to interact with Flow networks, such as querying account information, or sending transactions. It also includes the [Flow Emulator](https://developers.flow.com/next/tools/toolchains/emulator).
+The Flow CLI includes several commands to interact with Flow networks, such as querying account information, or sending transactions. It also includes the [Flow Emulator](https://developers.flow.com/tools/toolchains/emulator).
 
 
 ![Alt Text](./cli.gif)

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@
 
 ## Installation
 
-To install the Flow CLI, follow the [installation instructions](https://docs.onflow.org/flow-cli/install) on the Flow documentation website.
+To install the Flow CLI, follow the [installation instructions](https://developers.flow.com/next/tools/toolchains/flow-cli/install) on the Flow documentation website.
 
 ## Documentation
 
-You can find the CLI documentation on the [CLI documentation website](https://docs.onflow.org/flow-cli).
+You can find the CLI documentation on the [CLI documentation website](https://developers.flow.com/next/tools/toolchains/flow-cli).
 
 ## Features
 The Flow CLI is a command line tool that allows you to interact with the Flow blockchain. 
-Read about supported commands in the [CLI documentation website](https://docs.onflow.org/flow-cli).
+Read about supported commands in the [CLI documentation website](https://developers.flow.com/next/tools/toolchains/flow-cli).
 
 ```
 Usage:
@@ -55,7 +55,7 @@ Available Commands:
   version      View version and commit information
 ```
 
-The Flow CLI includes several commands to interact with Flow networks, such as querying account information, or sending transactions. It also includes the [Flow Emulator](https://docs.onflow.org/emulator/).
+The Flow CLI includes several commands to interact with Flow networks, such as querying account information, or sending transactions. It also includes the [Flow Emulator](https://developers.flow.com/next/tools/toolchains/emulator).
 
 
 ![Alt Text](./cli.gif)


### PR DESCRIPTION
## Description

Fixes links in README.md to docs for Flow CLI, Flow Emulator

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
