### PR TITLE
allow for flow json to have incomplete deployments in flow json

### DIFF
--- a/flowkit/config/config.go
+++ b/flowkit/config/config.go
@@ -77,8 +77,10 @@ func (c *Config) Validate() error {
 			}
 		}
 
-		if _, err := c.Accounts.ByName(d.Account); err != nil {
-			return fmt.Errorf("deployment contains nonexisting account %s", d.Account)
+		if d.Account != "" {
+			if _, err := c.Accounts.ByName(d.Account); err != nil {
+				return fmt.Errorf("deployment contains nonexisting account %s", d.Account)
+			}
 		}
 	}
 

--- a/flowkit/config/json/deploy.go
+++ b/flowkit/config/json/deploy.go
@@ -38,6 +38,12 @@ func (j jsonDeployments) transformToConfig() (config.Deployments, error) {
 	for networkName, deploys := range j {
 
 		var deploy config.Deployment
+		if networkName != "" && len(deploys) == 0 {
+			deploy = config.Deployment{
+				Network: networkName,
+			}
+			deployments = append(deployments, deploy)
+		}
 		for accountName, contracts := range deploys {
 			deploy = config.Deployment{
 				Network: networkName,

--- a/flowkit/config/json/deploy.go
+++ b/flowkit/config/json/deploy.go
@@ -134,6 +134,8 @@ func transformDeploymentsToJSON(configDeployments config.Deployments) jsonDeploy
 
 		if _, ok := jsonDeploys[d.Network]; ok {
 			jsonDeploys[d.Network][d.Account] = deployments
+		} else if d.Network != "" && d.Account == "" {
+			jsonDeploys[d.Network] = jsonDeployment{ }			
 		} else {
 			jsonDeploys[d.Network] = jsonDeployment{
 				d.Account: deployments,

--- a/flowkit/config/json/deploy_test.go
+++ b/flowkit/config/json/deploy_test.go
@@ -157,10 +157,6 @@ func Test_EmptyEmulatorDeployment(t *testing.T) {
 		"emulator": {}
 	}`)
 
-	result := []byte(`{
-		"emulator": {"":[]}
-	}`)
-
 	var jd jsonDeployments
 	err := json.Unmarshal(b, &jd)
 	assert.NoError(t, err)
@@ -168,7 +164,7 @@ func Test_EmptyEmulatorDeployment(t *testing.T) {
 	j := transformDeploymentsToJSON(deployments)
 	x, _ := json.Marshal(j)
 
-	assert.Equal(t, cleanSpecialChars(result), cleanSpecialChars(x))
+	assert.Equal(t, cleanSpecialChars(b), cleanSpecialChars(x))
 
 	var jd2 jsonDeployments
 	// use the result from above to test the reverse transformation
@@ -179,5 +175,5 @@ func Test_EmptyEmulatorDeployment(t *testing.T) {
 	j2 := transformDeploymentsToJSON(deployments2)
 	x2, _ := json.Marshal(j2)
 
-	assert.Equal(t, cleanSpecialChars(result), cleanSpecialChars(x2))
+	assert.Equal(t, cleanSpecialChars(b), cleanSpecialChars(x2))
 }

--- a/flowkit/config/json/deploy_test.go
+++ b/flowkit/config/json/deploy_test.go
@@ -138,12 +138,19 @@ func Test_DeploymentAdvanced(t *testing.T) {
 
 	deployments, err := jsonDeployments.transformToConfig()
 	assert.NoError(t, err)
-	j := transformDeploymentsToJSON(deployments)
-	x, _ := json.Marshal(j)
 
-	assert.Equal(t, cleanSpecialChars(b), cleanSpecialChars(x))
+	alice := deployments.ByAccountAndNetwork("alice", "emulator")
+	assert.NotNil(t, alice)
+	assert.Len(t, alice.Contracts, 2)
+	assert.Equal(t, "Kibble", alice.Contracts[0].Name)
+	assert.Len(t, alice.Contracts[0].Args, 3)
+	assert.Equal(t, `"Hello World"`, alice.Contracts[0].Args[0].String())
+	assert.Equal(t, "10", alice.Contracts[0].Args[1].String())
+	assert.Equal(t, "Bool", alice.Contracts[0].Args[2].Type().ID())
+	assert.False(t, alice.Contracts[0].Args[2].ToGoValue().(bool))
+	assert.Equal(t, "KittyItemsMarket", alice.Contracts[1].Name)
+	assert.Len(t, alice.Contracts[1].Args, 0)
 }
-
 
 func Test_EmptyEmulatorDeployment(t *testing.T) {
 	b := []byte(`{


### PR DESCRIPTION
Closes #1202 

## Description

Allow flow.json to keep partial filled out deployments. Previously it would remove deployments if an account wasn't present.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
