### PR TITLE
fix: ensure that stopProgress is deferred on all code paths where Sta…

### DIFF
--- a/flowkit/flowkit.go
+++ b/flowkit/flowkit.go
@@ -220,7 +220,6 @@ func (f *Flowkit) prepareTransaction(
 	tx *transactions.Transaction,
 	account *accounts.Account,
 ) (*transactions.Transaction, error) {
-
 	block, err := f.gateway.GetLatestBlock()
 	if err != nil {
 		return nil, err
@@ -308,6 +307,7 @@ func (f *Flowkit) AddContract(
 	}
 
 	f.logger.StartProgress(fmt.Sprintf("Checking contract '%s' on account '%s'...", name, account.Address))
+	defer f.logger.StopProgress()
 
 	// check if contract exists on account
 	flowAccount, err := f.gateway.GetAccount(account.Address)
@@ -549,7 +549,7 @@ func makeEventQueries(
 ) []grpc.EventRangeQuery {
 	var queries []grpc.EventRangeQuery
 	for startHeight <= endHeight {
-		suggestedEndHeight := startHeight + blockCount - 1 //since we are inclusive
+		suggestedEndHeight := startHeight + blockCount - 1 // since we are inclusive
 		end := endHeight
 		if suggestedEndHeight < endHeight {
 			end = suggestedEndHeight
@@ -564,7 +564,6 @@ func makeEventQueries(
 		startHeight = suggestedEndHeight + 1
 	}
 	return queries
-
 }
 
 // GenerateKey using the signature algorithm and optional seed. If seed is not provided a random safe seed will be generated.
@@ -854,6 +853,7 @@ func (f *Flowkit) GetTransactionByID(
 
 	if waitSeal {
 		f.logger.StartProgress("Waiting for transaction to be sealed...")
+		defer f.logger.StopProgress()
 	}
 
 	result, err := f.gateway.GetTransactionResult(ID, waitSeal)
@@ -1025,6 +1025,7 @@ func (f *Flowkit) SendTransaction(
 
 	f.logger.Info(fmt.Sprintf("Transaction ID: %s", tx.FlowTransaction().ID()))
 	f.logger.StartProgress("Sending transaction...")
+	defer f.logger.StopProgress()
 
 	sentTx, err := f.gateway.SendSignedTransaction(tx.FlowTransaction())
 	if err != nil {

--- a/internal/accounts/create-interactive.go
+++ b/internal/accounts/create-interactive.go
@@ -67,6 +67,7 @@ func createInteractive(state *flowkit.State) error {
 	}
 
 	log.StartProgress(fmt.Sprintf("Creating account %s on %s...", name, networkName))
+	defer log.StopProgress()
 
 	var account *accounts.Account
 	if selectedNetwork == config.EmulatorNetwork {

--- a/internal/snapshot/save.go
+++ b/internal/snapshot/save.go
@@ -50,6 +50,7 @@ func save(
 	fileName := args[0]
 
 	logger.StartProgress("Downloading protocol snapshot...")
+	defer logger.StopProgress()
 	if !flow.Gateway().SecureConnection() {
 		logger.Info(fmt.Sprintf("%s warning: using insecure client connection to download snapshot, you should use a secure network configuration...", output.WarningEmoji()))
 	}

--- a/internal/super/setup.go
+++ b/internal/super/setup.go
@@ -81,7 +81,6 @@ func create(
 	}
 
 	scaffolds, err := getScaffolds()
-
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +106,11 @@ func create(
 	}
 
 	logger.StartProgress(fmt.Sprintf("Creating your project %s", targetDir))
+	defer logger.StopProgress()
 	err = cloneScaffold(targetDir, pickedScaffold)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating scaffold %w", err)
 	}
-	logger.StopProgress()
 
 	return &setupResult{targetDir: targetDir}, nil
 }


### PR DESCRIPTION



## Description

Does not fix all that @sideninja suggest in #1022 but it does ensure that the loggers are deferred stopped on all codepaths. 

The reason this is important is because if you use flowkit in a multithreaded enivronment and stopProgress is not called it will cause all sorts of havoc.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
