### PR TITLE
do not force the use of a noop logger, it can be changed in the builder

### DIFF
--- a/flowkit/gateway/emulator.go
+++ b/flowkit/gateway/emulator.go
@@ -59,7 +59,6 @@ func NewEmulatorGateway(key *EmulatorKey) *EmulatorGateway {
 }
 
 func NewEmulatorGatewayWithOpts(key *EmulatorKey, opts ...func(*EmulatorGateway)) *EmulatorGateway {
-
 	noopLogger := zerolog.Nop()
 	gateway := &EmulatorGateway{
 		ctx:             context.Background(),
@@ -71,9 +70,8 @@ func NewEmulatorGatewayWithOpts(key *EmulatorKey, opts ...func(*EmulatorGateway)
 	}
 
 	gateway.emulator = newEmulator(key, gateway.emulatorOptions...)
-	logger := zerolog.Nop()
-	gateway.adapter = adapters.NewSDKAdapter(&logger, gateway.emulator)
-	gateway.accessAdapter = adapters.NewAccessAdapter(&logger, gateway.emulator)
+	gateway.adapter = adapters.NewSDKAdapter(gateway.logger, gateway.emulator)
+	gateway.accessAdapter = adapters.NewAccessAdapter(gateway.logger, gateway.emulator)
 	gateway.emulator.EnableAutoMine()
 	return gateway
 }


### PR DESCRIPTION
This was overlooked in a refactoring, the functional builder loop can change the logger and the zerolog.Nop() line reverts changes to the logger. 