### PR TITLE
add new flowkit-release workflow

### DIFF
--- a/.github/workflows/flowkit-release.yml
+++ b/.github/workflows/flowkit-release.yml
@@ -1,0 +1,18 @@
+name: Flowkit Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  flowkit-release:
+    if: "!github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: tag flowkit release
+        env:
+          FLOWKIT_RELEASE_TAG: flowkit/${{ github.event.release.tag_name }}
+        run: |
+          git tag "$FLOWKIT_RELEASE_TAG" 
+          git push origin "$FLOWKIT_RELEASE_TAG"


### PR DESCRIPTION
Closes #1130 

## Description

Create new github actions workflow that will automatically tag `flowkit/$VERSION` on a published release

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
