### PR TITLE
use assert.Contains for result.OneLiner() check to fix flaky test

### DIFF
--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -640,10 +640,18 @@ Seed: 1521
 		assert.NoError(t, result.Results[scriptPassing.Filename][0].Error)
 		assert.Error(t, result.Results[scriptFailing.Filename][0].Error)
 		assert.ErrorAs(t, result.Results[scriptFailing.Filename][0].Error, &stdlib.AssertionError{})
-		assert.Equal(
+
+		assert.Contains(
 			t,
-			"Test results: \"./testScriptSimple.cdc\"\n- PASS: testSimple\nTest results: \"./testScriptSimpleFailing.cdc\"\n- FAIL: testSimple\n\t\tExecution failed:\n\t\t\terror: assertion failed\n\t\t\t --> 7465737400000000000000000000000000000000000000000000000000000000:5:12\n\t\t\t\n",
 			result.Oneliner(),
+			"Test results: \"./testScriptSimple.cdc\"\n- PASS: testSimple",
+		)
+		assert.Contains(
+			t,
+			result.Oneliner(),
+			"Test results: \"./testScriptSimpleFailing.cdc\"\n- FAIL: "+
+				"testSimple\n\t\tExecution failed:\n\t\t\terror: assertion failed\n"+
+				"\t\t\t --> 7465737400000000000000000000000000000000000000000000000000000000:5:12",
 		)
 	})
 


### PR DESCRIPTION
Closes #???

## Description

use assert.Contains for result.OneLiner() check to fix flaky test, as sometimes it would run out of order

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
