### PR TITLE
Fix installation of gocov-html and mockery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ install-tools:
 	cd ${GOPATH}; \
 	mkdir -p ${GOPATH}; \
 	GO111MODULE=on go install github.com/axw/gocov/gocov@latest; \
-	GO111MODULE=on go install github.com/matm/gocov-html@latest; \
+	GO111MODULE=on go install github.com/matm/gocov-html/cmd/gocov-html@latest; \
 	GO111MODULE=on go install github.com/sanderhahn/gozip/cmd/gozip@latest; \
-	GO111MODULE=on go install github.com/vektra/mockery/v2@latest;
+	GO111MODULE=on go install github.com/vektra/mockery/v2@v2.38.0;
 
 .PHONY: test
 test:


### PR DESCRIPTION


## Description
Fix the installation of the tools used on CI:
- Use the correct module path for gocov-html, as suggested in its README. Fixes:

  ```
  go: github.com/matm/gocov-html@latest: module github.com/matm/gocov-html@latest found (v1.4.0), but does not contain package github.com/matm/gocov-html
  ```

- mockery v2.39.0 was just released, which suddenly started to require Go 1.21, in a non-backwards compatible way (`toolchain` statement in `go.mod` file).
  Keep using the latest version which was compatible with Go 1.20

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
