### PR TITLE
Update flix tests and flixkit-go version used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onflow/cadence-tools/languageserver v0.33.3
 	github.com/onflow/cadence-tools/test v0.14.5
 	github.com/onflow/fcl-dev-wallet v0.7.4
-	github.com/onflow/flixkit-go v1.0.2
+	github.com/onflow/flixkit-go v1.1.0
 	github.com/onflow/flow-cli/flowkit v1.6.1-0.20231110211255-b41f57a8b8c7
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f
 	github.com/onflow/flow-emulator v0.59.0

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/onflow/cadence-tools/test v0.14.5 h1:u1kYkotKdwKEf9c3h65mI3VMevBkHY+7
 github.com/onflow/cadence-tools/test v0.14.5/go.mod h1:ix09Bb3GQ/fZMNpSR8E+vSFItGF54fzP9gFxU7AsOIw=
 github.com/onflow/fcl-dev-wallet v0.7.4 h1:vI6t3U0AO88R/Iitn5KsnniSpbN9Lqsqwvi9EJT4C0k=
 github.com/onflow/fcl-dev-wallet v0.7.4/go.mod h1:kc42jkiuoPJmxMRFjfbRO9XvnR/3XLheaOerxVMDTiw=
-github.com/onflow/flixkit-go v1.0.2 h1:6PVLLb8qQj9L6cs57HUO3wszzbgPD46pc9MAGWHnb1s=
-github.com/onflow/flixkit-go v1.0.2/go.mod h1:KGL7oMu4uzt7s0qsNkaqGBYIt+Z38Qbf0JG56qK/Sg0=
+github.com/onflow/flixkit-go v1.1.0 h1:yju2lotk2LQBXUwb0rZeOtVbHW2KVSzzRRu/3rPtzok=
+github.com/onflow/flixkit-go v1.1.0/go.mod h1:KGL7oMu4uzt7s0qsNkaqGBYIt+Z38Qbf0JG56qK/Sg0=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20231016154253-a00dbf7c061f h1:S8yIZw9LFXfYD1V5H9BiixihHw3GrXVPrmfplSzYaww=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20231016154253-a00dbf7c061f/go.mod h1:jM6GMAL+m0hjusUgiYDNrixPQ6b9s8xjoJQoEu5bHQI=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f h1:Ep+Mpo2miWMe4pjPGIaEvEzshRep30dvNgxqk+//FrQ=

--- a/internal/super/flix.go
+++ b/internal/super/flix.go
@@ -169,9 +169,9 @@ func packageCmd(
 	var gen flixkit.GenerateBinding
 	switch flags.Lang {
 	case "js", "javascript":
-		gen = flixkit.NewFclJSGenerator()
+		gen = flixkit.NewFclGeneratorJS()
 	case "ts", "typescript":
-		gen = flixkit.NewFclTSGenerator()
+		gen = flixkit.NewFclGeneratorTS()
 	default:
 		return nil, fmt.Errorf("language %s not supported", flags.Lang)
 	}

--- a/internal/super/flix_test.go
+++ b/internal/super/flix_test.go
@@ -112,7 +112,6 @@ func Test_ExecuteFlixTransaction(t *testing.T) {
 	result, err := executeFlixCmd([]string{"transfer-token"}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-
 }
 
 type MockFclGenerator struct {
@@ -162,7 +161,7 @@ func Test_GenerateFlix(t *testing.T) {
 	mockFlixService.On("GetTemplate", ctx, templateName).Return(template, nil)
 
 	mockGenerateTemplate := new(MockGenerateTemplate)
-	mockGenerateTemplate.On("Generate", cadenceCode, template).Return(template, nil)
+	mockGenerateTemplate.On("Generate", ctx, cadenceCode, "").Return(template, nil)
 
 	configJson := []byte(`{
 		"contracts": {},
@@ -241,5 +240,4 @@ func Test_GenerateFlixPrefill(t *testing.T) {
 	result, err := generateFlixCmd([]string{cadenceFile}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService, mockGenerateTemplate, flixFlags{PreFill: templateName})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-
 }

--- a/internal/super/flix_test.go
+++ b/internal/super/flix_test.go
@@ -19,17 +19,151 @@
 package super
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/onflow/flixkit-go/flixkit"
+	"github.com/onflow/flow-go-sdk/crypto"
 
 	"github.com/onflow/flow-cli/flowkit"
 	"github.com/onflow/flow-cli/flowkit/config"
+	"github.com/onflow/flow-cli/flowkit/mocks"
+	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/flowkit/tests"
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
-func Test_flix_generate(t *testing.T) {
+type MockFlixService struct {
+	mock.Mock
+}
+
+func (m *MockFlixService) GetTemplate(ctx context.Context, templateName string) (string, error) {
+	args := m.Called(ctx, templateName)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockFlixService) GetAndReplaceCadenceImports(ctx context.Context, templateName string, network string) (*flixkit.FlowInteractionTemplateExecution, error) {
+	result := &flixkit.FlowInteractionTemplateExecution{
+		Network:       "emulator",
+		IsTransaciton: false,
+		IsScript:      true,
+		Cadence:       "pub fun main() {\n    log(\"Hello, World!\")\n}",
+	}
+	return result, nil
+}
+func Test_ExecuteFlixScript(t *testing.T) {
+	ctx := context.Background()
+	logger := output.NewStdoutLogger(output.NoneLog)
+	srv, state, _ := util.TestMocks(t)
+	mockFlixService := new(MockFlixService)
+	testCadence := "pub fun main() {\n    log(\"Hello, World!\")\n}"
+	mockFlixService.On("GetAndReplaceCadenceImports", ctx, "templateName", "emulator").Return(&flixkit.FlowInteractionTemplateExecution{
+		Network:       "emulator",
+		IsTransaciton: false,
+		IsScript:      true,
+		Cadence:       testCadence,
+	}, nil)
+
+	// Set up a mock return value for the Network method
+	mockNetwork := config.Network{
+		Name: "emulator",
+		Host: "localhost:3569",
+	}
+	srv.Network.Run(func(args mock.Arguments) {}).Return(mockNetwork, nil)
+	srv.ExecuteScript.Run(func(args mock.Arguments) {
+		script := args.Get(1).(flowkit.Script)
+		assert.Equal(t, testCadence, string(script.Code))
+	}).Return(nil, nil)
+
+	result, err := executeFlixCmd([]string{"transfer-token"}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func Test_ExecuteFlixTransaction(t *testing.T) {
+	ctx := context.Background()
+	logger := output.NewStdoutLogger(output.NoneLog)
+	srv, state, _ := util.TestMocks(t)
+	mockFlixService := new(MockFlixService)
+	testCadence := "transaction { prepare(signer: AuthAccount) { /* prepare logic */ } execute { log(\"Hello, Cadence!\") } }"
+	mockFlixService.On("GetAndReplaceCadenceImports", ctx, "templateName", "emulator").Return(&flixkit.FlowInteractionTemplateExecution{
+		Network:       "emulator",
+		IsTransaciton: false,
+		IsScript:      true,
+		Cadence:       testCadence,
+	}, nil)
+
+	// Set up a mock return value for the Network method
+	mockNetwork := config.Network{
+		Name: "emulator",
+		Host: "localhost:3569",
+	}
+	srv.Network.Run(func(args mock.Arguments) {}).Return(mockNetwork, nil)
+	srv.SendTransaction.Run(func(args mock.Arguments) {
+		script := args.Get(2).(flowkit.Script)
+		assert.Equal(t, testCadence, string(script.Code))
+	}).Return(nil, nil)
+
+	result, err := executeFlixCmd([]string{"transfer-token"}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+}
+
+type MockFclGenerator struct {
+	mock.Mock
+}
+
+func (m *MockFclGenerator) Generate(flixString string, templateLocation string) (string, error) {
+	args := m.Called(flixString, templateLocation)
+	return args.String(0), args.Error(1)
+}
+
+func Test_PackageFlix(t *testing.T) {
+	ctx := context.Background()
+	logger := output.NewStdoutLogger(output.NoneLog)
+	srv, state, _ := util.TestMocks(t)
+	mockFlixService := new(MockFlixService)
+	template := "{ \"f_type\": \"InteractionTemplate\", \"f_version\": \"1.1.0\", \"id\": \"0ea\",}"
+	templateName := "templateName"
+	mockFlixService.On("GetTemplate", ctx, templateName).Return(template, nil)
+	jsCode := "export async function request() { const info = await fcl.query({ template: flixTemplate }); return info; }"
+	mockFclGenerator := new(MockFclGenerator)
+	mockFclGenerator.On("Generate", template, templateName).Return(jsCode, nil)
+
+	result, err := packageFlixCmd([]string{templateName}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService, mockFclGenerator)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, jsCode, result.String())
+}
+
+type MockGenerateTemplate struct {
+	mock.Mock
+}
+
+func (m *MockGenerateTemplate) Generate(ctx context.Context, code string, preFill string) (string, error) {
+	args := m.Called(ctx, code, preFill)
+	return args.String(0), args.Error(1)
+}
+func Test_GenerateFlix(t *testing.T) {
+	ctx := context.Background()
+	srv := mocks.DefaultMockServices()
+	template := "{ \"f_type\": \"InteractionTemplate\", \"f_version\": \"1.1.0\", \"id\": \"0ea\",}"
+	templateName := "templateName"
+	cadenceFile := "cadence.cdc"
+	cadenceCode := "pub fun main() {\n    log(\"Hello, World!\")\n}"
+
+	mockFlixService := new(MockFlixService)
+	mockFlixService.On("GetTemplate", ctx, templateName).Return(template, nil)
+
+	mockGenerateTemplate := new(MockGenerateTemplate)
+	mockGenerateTemplate.On("Generate", cadenceCode, template).Return(template, nil)
+
 	configJson := []byte(`{
 		"contracts": {},
 		"accounts": {
@@ -47,6 +181,8 @@ func Test_flix_generate(t *testing.T) {
 
 	af := afero.Afero{Fs: afero.NewMemMapFs()}
 	err := afero.WriteFile(af.Fs, "flow.json", configJson, 0644)
+	assert.NoError(t, err)
+	err = afero.WriteFile(af.Fs, cadenceFile, []byte(cadenceCode), 0644)
 	assert.NoError(t, err)
 	err = afero.WriteFile(af.Fs, tests.ContractHelloString.Filename, []byte(tests.ContractHelloString.Source), 0644)
 	assert.NoError(t, err)
@@ -73,13 +209,37 @@ func Test_flix_generate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(contracts))
 
-	cs := GetDeployedContracts(state)
-	assert.Equal(t, 1, len(cs))
-	networkContract := cs[tests.ContractHelloString.Name]
-	assert.NotNil(t, networkContract)
-	addr := networkContract["emulator"]
-	acct, err := state.Accounts().ByName("emulator-account")
+	logger := output.NewStdoutLogger(output.NoneLog)
+
+	result, err := generateFlixCmd([]string{cadenceFile}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService, mockGenerateTemplate, flixFlags{})
 	assert.NoError(t, err)
-	assert.Equal(t, acct.Address.String(), addr)
+	assert.NotNil(t, result)
+	assert.Equal(t, template, result.String())
+}
+
+func Test_GenerateFlixPrefill(t *testing.T) {
+	ctx := context.Background()
+	logger := output.NewStdoutLogger(output.NoneLog)
+	srv := mocks.DefaultMockServices()
+	template := "{ \"f_type\": \"InteractionTemplate\", \"f_version\": \"1.1.0\", \"id\": \"0ea\",}"
+	templateName := "templateName"
+	cadenceFile := "cadence.cdc"
+	cadenceCode := "pub fun main() {\n    log(\"Hello, World!\")\n}"
+
+	var mockFS = afero.NewMemMapFs()
+	var rw = afero.Afero{Fs: mockFS}
+	err := rw.WriteFile(cadenceFile, []byte(cadenceCode), 0644)
+	assert.NoError(t, err)
+	state, _ := flowkit.Init(rw, crypto.ECDSA_P256, crypto.SHA3_256)
+
+	mockFlixService := new(MockFlixService)
+	mockFlixService.On("GetTemplate", ctx, templateName).Return(template, nil)
+
+	mockGenerateTemplate := new(MockGenerateTemplate)
+	mockGenerateTemplate.On("Generate", ctx, cadenceCode, template).Return(template, nil)
+
+	result, err := generateFlixCmd([]string{cadenceFile}, command.GlobalFlags{}, logger, srv.Mock, state, mockFlixService, mockGenerateTemplate, flixFlags{PreFill: templateName})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 
 }


### PR DESCRIPTION
Closes https://github.com/onflow/flow-cli/issues/1335

## Description

Simplify flix logic in flow-cli
Reorganize flix.go to be mockable and add unit tests
Use new version of flixkit-go v1.1.0

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
