### PR TITLE
Coverage report map contract files

### DIFF
--- a/flowkit/state.go
+++ b/flowkit/state.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slices"
@@ -46,6 +47,22 @@ type State struct {
 	confLoader   *config.Loader
 	readerWriter ReaderWriter
 	accounts     *accounts.Accounts
+}
+
+func (p *State) CreateCoverageReport(network string) *runtime.CoverageReport {
+	coverageReport := runtime.NewCoverageReport()
+	contractsConfig := *p.Contracts()
+	locationMappings := make(map[string]string, len(contractsConfig))
+	for _, contract := range contractsConfig {
+		alias := contract.Aliases.ByNetwork(network)
+		if alias != nil {
+			locationMappings[contract.Name] = contract.Location
+		}
+	}
+
+	coverageReport.WithLocationMappings(locationMappings)
+
+	return coverageReport
 }
 
 // ReaderWriter retrieve current file reader writer.
@@ -86,7 +103,6 @@ func (p *State) SaveEdited(paths []string) error {
 func (p *State) Save(path string) error {
 	p.conf.Accounts = accounts.ToConfig(*p.accounts)
 	err := p.confLoader.Save(p.conf, path)
-
 	if err != nil {
 		return fmt.Errorf("failed to save project configuration to: %s", path)
 	}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -105,7 +105,6 @@ func run(
 	testFiles := make(map[string][]byte, 0)
 	for _, filename := range args {
 		code, err := state.ReadFile(filename)
-
 		if err != nil {
 			return nil, fmt.Errorf("error loading script file: %w", err)
 		}
@@ -153,7 +152,7 @@ func testCode(
 
 	var coverageReport *runtime.CoverageReport
 	if flags.Cover {
-		coverageReport = runtime.NewCoverageReport()
+		coverageReport = state.CreateCoverageReport("testing")
 		if flags.CoverCode == contractsCoverCode {
 			coverageReport.WithLocationFilter(
 				func(location common.Location) bool {
@@ -179,17 +178,11 @@ func testCode(
 
 	contractsConfig := *state.Contracts()
 	contracts := make(map[string]common.Address, len(contractsConfig))
-	locationMappings := make(map[string]string, len(contractsConfig))
 	for _, contract := range contractsConfig {
 		alias := contract.Aliases.ByNetwork("testing")
 		if alias != nil {
 			contracts[contract.Name] = common.Address(alias.Address)
-			locationMappings[contract.Name] = contract.Location
 		}
-	}
-
-	if coverageReport != nil {
-		coverageReport.WithLocationMappings(locationMappings)
 	}
 
 	testResults := make(map[string]cdcTests.Results, 0)
@@ -246,7 +239,6 @@ func importResolver(scriptPath string, state *flowkit.State) cdcTests.ImportReso
 	}
 
 	return func(location common.Location) (string, error) {
-
 		contract := config.Contract{}
 
 		switch location := location.(type) {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -177,12 +177,19 @@ func testCode(
 		runner = runner.WithRandomSeed(seed)
 	}
 
-	contracts := make(map[string]common.Address, 0)
-	for _, contract := range *state.Contracts() {
+	contractsConfig := *state.Contracts()
+	contracts := make(map[string]common.Address, len(contractsConfig))
+	locationMappings := make(map[string]string, len(contractsConfig))
+	for _, contract := range contractsConfig {
 		alias := contract.Aliases.ByNetwork("testing")
 		if alias != nil {
 			contracts[contract.Name] = common.Address(alias.Address)
+			locationMappings[contract.Name] = contract.Location
 		}
+	}
+
+	if coverageReport != nil {
+		coverageReport.WithLocationMappings(locationMappings)
 	}
 
 	testResults := make(map[string]cdcTests.Results, 0)

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -355,6 +355,12 @@ func TestExecutingTests(t *testing.T) {
 			result.String(),
 			"Coverage: 91.8% of statements",
 		)
+
+		lcovReport, _ := coverageReport.MarshalLCOV()
+		assert.Contains(t, string(lcovReport), "TN:\nSF:FooContract.cdc\n")
+
+		jsonReport, _ := coverageReport.MarshalJSON()
+		assert.Contains(t, string(jsonReport), `{"coverage":{"FooContract.cdc":{`)
 	})
 
 	t.Run("with code coverage for contracts only", func(t *testing.T) {
@@ -447,6 +453,12 @@ func TestExecutingTests(t *testing.T) {
 			result.String(),
 			"Coverage: 100.0% of statements",
 		)
+
+		lcovReport, _ := coverageReport.MarshalLCOV()
+		assert.Contains(t, string(lcovReport), "TN:\nSF:FooContract.cdc\n")
+
+		jsonReport, _ := coverageReport.MarshalJSON()
+		assert.Contains(t, string(jsonReport), `{"coverage":{"FooContract.cdc":{`)
 	})
 
 	t.Run("with random test case execution", func(t *testing.T) {


### PR DESCRIPTION
modified version of #1328 to add function to state in flowkit and also make it possible to creating coverage report with location mapping for different networks.

original work by @m-Peter i just added flowkit function. 