### PR TITLE
Fix command message for config add

### DIFF
--- a/internal/dependencymanager/add.go
+++ b/internal/dependencymanager/add.go
@@ -68,7 +68,7 @@ func add(
 	}
 
 	logger.Info("✅  Dependency installation complete. Check your flow.json")
-	logger.Info("Ensure you add any required dependencies to your 'deployments' section. This can be done using the 'flow add config deployment' command.")
+	logger.Info("Ensure you add any required dependencies to your 'deployments' section. This can be done using the 'flow config add deployment' command.")
 	logger.Info("Note: Core contracts do not need to be added to deployments. For reference, see this URL: https://github.com/onflow/flow-core-contracts")
 
 	return nil, nil


### PR DESCRIPTION
## Description

Message says `flow add config deployment` when it should say `flow config add deployment`
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
