### PR TITLE
[Stable Cadence] Fix dependency: use proper version of core contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onflow/fcl-dev-wallet v0.7.4
 	github.com/onflow/flixkit-go v1.1.1-0.20240131170156-cd4c454e4b0d
 	github.com/onflow/flow-cli/flowkit v1.11.1-0.20240130210637-a22f7c578d37
-	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f
+	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125214229-b7a95136dd0d
 	github.com/onflow/flow-emulator v1.0.0-M1
 	github.com/onflow/flow-go-sdk v1.0.0-M1
 	github.com/onflowser/flowser/v3 v3.2.1-0.20240131200229-7d4d22715f48

--- a/go.sum
+++ b/go.sum
@@ -2060,8 +2060,8 @@ github.com/onflow/flixkit-go v1.1.1-0.20240131170156-cd4c454e4b0d h1:gVjuB2yWSzs
 github.com/onflow/flixkit-go v1.1.1-0.20240131170156-cd4c454e4b0d/go.mod h1:tAoH8I1IbSb/vimvtsCb41QOe4I50znJin4H8Xw0iNI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125214229-b7a95136dd0d h1:Afcfk/9jAQZ1v5PLGdP68FG/0yPPM60fn9Eq8ChBGS0=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125214229-b7a95136dd0d/go.mod h1:Ts/HN+N0RaYJ6oPCqR1JPaMVFiVaMdKTSUH4OdSjjs0=
-github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f h1:Ep+Mpo2miWMe4pjPGIaEvEzshRep30dvNgxqk+//FrQ=
-github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f/go.mod h1:ZeLxwaBkzuSInESGjL8/IPZWezF+YOYsYbMrZlhN+q4=
+github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125214229-b7a95136dd0d h1:IQJpP3VLLjT4R8ItBpr+Mmp0IOnC/8iBcM0/67JNB9c=
+github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125214229-b7a95136dd0d/go.mod h1:MZ2j5YVTQiSE0B99zuaYhxvGG5GcvimWpQK1Fw/1QBg=
 github.com/onflow/flow-emulator v1.0.0-M1 h1:0hBEmvm73F+5HhN5ugkOP3UyN+Ea9yGWflEmoeGzgdw=
 github.com/onflow/flow-emulator v1.0.0-M1/go.mod h1:JFJCeQVyhCQVD2Tq4QhctIXK6j5U6aU15yoEwMJt5AQ=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240125205519-2e80d9b4bd01 h1:8iKk5RuFvhe7NQyAO3c+xiVvv38RB/yopHdWxp4AbL8=

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -38,9 +38,6 @@ import (
 func TestExecutingTests(t *testing.T) {
 	t.Parallel()
 
-	// TODO:
-	t.Skip("TODO")
-
 	aliases := config.Aliases{{
 		Network: "testing",
 		Address: flowsdk.HexToAddress("0x0000000000000007"),
@@ -662,7 +659,7 @@ Seed: 1521
 			result.Oneliner(),
 			"Test results: \"./testScriptSimpleFailing.cdc\"\n- FAIL: "+
 				"testSimple\n\t\tExecution failed:\n\t\t\terror: assertion failed\n"+
-				"\t\t\t --> 7465737400000000000000000000000000000000000000000000000000000000:5:12",
+				"\t\t\t --> ./testScriptSimpleFailing.cdc:5:12",
 		)
 	})
 


### PR DESCRIPTION
Resolve the remaining problem encountered in #1366: Use the correct core contract templates, which were not automatically picked by Go because the core contracts repo was mistagged at some point.