### PR TITLE
[stable cadence] migrate to use flowkit v2.0.0-stable-cadence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125214229-b7a95136dd0d
 	github.com/onflow/flow-emulator v1.0.0-M1
 	github.com/onflow/flow-go-sdk v1.0.0-M1
-	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.2
+	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.2
 	github.com/onflowser/flowser/v3 v3.2.1-0.20240131200229-7d4d22715f48
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/onflow/cadence-tools/test v1.0.0-M1
 	github.com/onflow/fcl-dev-wallet v0.8.0-stable-cadence.1
 	github.com/onflow/flixkit-go v1.1.1-0.20240131170156-cd4c454e4b0d
-	github.com/onflow/flow-cli/flowkit v1.11.1-0.20240130210637-a22f7c578d37
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125214229-b7a95136dd0d
 	github.com/onflow/flow-emulator v1.0.0-M1
 	github.com/onflow/flow-go-sdk v1.0.0-M1
+	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.1
 	github.com/onflowser/flowser/v3 v3.2.1-0.20240131200229-7d4d22715f48
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
@@ -175,9 +175,11 @@ require (
 	github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f // indirect
 	github.com/onflow/cadence-tools/lint v1.0.0-M1 // indirect
 	github.com/onflow/crypto v0.25.0 // indirect
+	github.com/onflow/flow-cli/flowkit v1.11.1-0.20240130210637-a22f7c578d37 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125214229-b7a95136dd0d // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240125205519-2e80d9b4bd01 // indirect
 	github.com/onflow/flow-go v0.33.2-0.20240126211806-97279f96695f // indirect
+	github.com/onflow/flow-go/crypto v0.24.7 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2 // indirect
 	github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125214229-b7a95136dd0d
 	github.com/onflow/flow-emulator v1.0.0-M1
 	github.com/onflow/flow-go-sdk v1.0.0-M1
-	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.1
+	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.2
 	github.com/onflowser/flowser/v3 v3.2.1-0.20240131200229-7d4d22715f48
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
@@ -179,7 +179,6 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125214229-b7a95136dd0d // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240125205519-2e80d9b4bd01 // indirect
 	github.com/onflow/flow-go v0.33.2-0.20240126211806-97279f96695f // indirect
-	github.com/onflow/flow-go/crypto v0.24.7 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2 // indirect
 	github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba // indirect

--- a/go.sum
+++ b/go.sum
@@ -2070,11 +2070,15 @@ github.com/onflow/flow-go v0.33.2-0.20240126211806-97279f96695f h1:F1y95CpteZn0i
 github.com/onflow/flow-go v0.33.2-0.20240126211806-97279f96695f/go.mod h1:9q+c+fuTpc/emueM/2bI/Ih2jw3V+9WS3Eu+pWBuLW0=
 github.com/onflow/flow-go-sdk v1.0.0-M1 h1:mke/ebYwNRRWPZqcwCV56Alx0A8psew43ZbSEUQ4TL8=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
+github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
+github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad h1:I6LD9BOsilGbiqhGjP86FIIXJe0YdUz75d/oWdHFzDI=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2 h1:+rT+UsfTR39JZO8ht2+4fkaWfHw74SCj1fyz1lWuX8A=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.1 h1:2el2VrZkWxXJ8P9U6foX6cLSp4OEhL5rVJZotT7MGiE=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.1/go.mod h1:axquKu/JubE4n1NNBIUeO+gWz9ojuVSWXT8dGcIEl0I=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba h1:rIehuhO6bj4FkwE4VzwEjX7MoAlOhUJENBJLqDqVxAo=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba/go.mod h1:F0dj0EyHC55kknLkeD10js4mo14yTdMotnWMslPirrU=
 github.com/onflow/wal v0.0.0-20230529184820-bc9f8244608d h1:gAEqYPn3DS83rHIKEpsajnppVD1+zwuYPFyeDVFaQvg=

--- a/go.sum
+++ b/go.sum
@@ -2070,15 +2070,13 @@ github.com/onflow/flow-go v0.33.2-0.20240126211806-97279f96695f h1:F1y95CpteZn0i
 github.com/onflow/flow-go v0.33.2-0.20240126211806-97279f96695f/go.mod h1:9q+c+fuTpc/emueM/2bI/Ih2jw3V+9WS3Eu+pWBuLW0=
 github.com/onflow/flow-go-sdk v1.0.0-M1 h1:mke/ebYwNRRWPZqcwCV56Alx0A8psew43ZbSEUQ4TL8=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
-github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad h1:I6LD9BOsilGbiqhGjP86FIIXJe0YdUz75d/oWdHFzDI=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2 h1:+rT+UsfTR39JZO8ht2+4fkaWfHw74SCj1fyz1lWuX8A=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.1 h1:2el2VrZkWxXJ8P9U6foX6cLSp4OEhL5rVJZotT7MGiE=
-github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.1/go.mod h1:axquKu/JubE4n1NNBIUeO+gWz9ojuVSWXT8dGcIEl0I=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.2 h1:wMaOvYpoLW/sC64Ne+YRu4HQFzK5mpymV4yTRC+f32k=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.2/go.mod h1:Bd0GCEtHBzs0+YVSLTnBSsoywg8cjC0icUaZjrKQ4gM=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba h1:rIehuhO6bj4FkwE4VzwEjX7MoAlOhUJENBJLqDqVxAo=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba/go.mod h1:F0dj0EyHC55kknLkeD10js4mo14yTdMotnWMslPirrU=
 github.com/onflow/wal v0.0.0-20230529184820-bc9f8244608d h1:gAEqYPn3DS83rHIKEpsajnppVD1+zwuYPFyeDVFaQvg=

--- a/go.sum
+++ b/go.sum
@@ -2075,8 +2075,8 @@ github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240125205553-d2b571fb3fad
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2 h1:+rT+UsfTR39JZO8ht2+4fkaWfHw74SCj1fyz1lWuX8A=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.2 h1:wMaOvYpoLW/sC64Ne+YRu4HQFzK5mpymV4yTRC+f32k=
-github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.2/go.mod h1:Bd0GCEtHBzs0+YVSLTnBSsoywg8cjC0icUaZjrKQ4gM=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.2 h1:w6juFHpcK8j1MzlCZ9932MkKA5bwM8T8lGlQXmiOY9k=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence.2/go.mod h1:Bd0GCEtHBzs0+YVSLTnBSsoywg8cjC0icUaZjrKQ4gM=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba h1:rIehuhO6bj4FkwE4VzwEjX7MoAlOhUJENBJLqDqVxAo=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba/go.mod h1:F0dj0EyHC55kknLkeD10js4mo14yTdMotnWMslPirrU=
 github.com/onflow/wal v0.0.0-20230529184820-bc9f8244608d h1:gAEqYPn3DS83rHIKEpsajnppVD1+zwuYPFyeDVFaQvg=

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onflow/flow-cli/flowkit/accounts"
+	"github.com/onflow/flowkit/v2/accounts"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -31,10 +31,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 func Test_DeployContract(t *testing.T) {

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -31,10 +31,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func Test_DeployContract(t *testing.T) {

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -28,10 +28,11 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/arguments"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type deployContractFlags struct {

--- a/internal/accounts/contract-add.go
+++ b/internal/accounts/contract-add.go
@@ -28,10 +28,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/arguments"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/arguments"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type deployContractFlags struct {

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -26,9 +26,10 @@ import (
 
 	"github.com/onflow/flow-cli/internal/util"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsRemoveContract struct {

--- a/internal/accounts/contract-remove.go
+++ b/internal/accounts/contract-remove.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/onflow/flow-cli/internal/util"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsRemoveContract struct {

--- a/internal/accounts/create-interactive.go
+++ b/internal/accounts/create-interactive.go
@@ -35,12 +35,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/accounts"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/gateway"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/gateway"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 // createInteractive is used when user calls a default account create command without any provided values.

--- a/internal/accounts/create-interactive.go
+++ b/internal/accounts/create-interactive.go
@@ -159,7 +159,7 @@ func createNetworkAccount(
 	return &accounts.Account{
 		Name:    name,
 		Address: *address[0],
-		Key:     accounts.NewFileKey(privateFile, 0, defaultSignAlgo, defaultHashAlgo),
+		Key:     accounts.NewFileKey(privateFile, 0, defaultSignAlgo, defaultHashAlgo, state.ReaderWriter()),
 	}, nil
 }
 

--- a/internal/accounts/create-interactive.go
+++ b/internal/accounts/create-interactive.go
@@ -35,12 +35,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/accounts"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/gateway"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 // createInteractive is used when user calls a default account create command without any provided values.

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -28,9 +28,10 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsCreate struct {

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -23,14 +23,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/onflow/flow-cli/flowkit/accounts"
+	"github.com/onflow/flowkit/v2/accounts"
 
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsCreate struct {

--- a/internal/accounts/fund.go
+++ b/internal/accounts/fund.go
@@ -27,9 +27,9 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsFund struct {

--- a/internal/accounts/fund.go
+++ b/internal/accounts/fund.go
@@ -27,9 +27,10 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsFund struct {

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -25,9 +25,9 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsGet struct {

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -25,9 +25,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsGet struct {

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -28,10 +28,11 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsStakingInfo struct{}

--- a/internal/accounts/staking-info.go
+++ b/internal/accounts/staking-info.go
@@ -28,10 +28,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsStakingInfo struct{}

--- a/internal/blocks/blocks_test.go
+++ b/internal/blocks/blocks_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func Test_GetBlock(t *testing.T) {

--- a/internal/blocks/blocks_test.go
+++ b/internal/blocks/blocks_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 func Test_GetBlock(t *testing.T) {

--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -24,9 +24,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsBlocks struct {

--- a/internal/blocks/get.go
+++ b/internal/blocks/get.go
@@ -24,9 +24,9 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsBlocks struct {

--- a/internal/collections/get.go
+++ b/internal/collections/get.go
@@ -25,9 +25,9 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsCollections struct{}

--- a/internal/collections/get.go
+++ b/internal/collections/get.go
@@ -25,9 +25,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsCollections struct{}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -39,12 +39,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-cli/build"
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/gateway"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/settings"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/gateway"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 // run the command with arguments.

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -38,13 +38,14 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/build"
-	"github.com/onflow/flow-cli/internal/settings"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/gateway"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/build"
+	"github.com/onflow/flow-cli/internal/settings"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 // run the command with arguments.

--- a/internal/command/global_flags.go
+++ b/internal/command/global_flags.go
@@ -25,8 +25,8 @@ import (
 	"github.com/psiemens/sconfig"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit/config"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2/config"
 )
 
 // Flags initialized to default values.

--- a/internal/command/global_flags.go
+++ b/internal/command/global_flags.go
@@ -25,8 +25,9 @@ import (
 	"github.com/psiemens/sconfig"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2/config"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 // Flags initialized to default values.

--- a/internal/command/result.go
+++ b/internal/command/result.go
@@ -30,8 +30,8 @@ import (
 	"github.com/spf13/afero"
 	"golang.org/x/exp/maps"
 
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 // Result interface describes all the formats for the result output.

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -28,11 +28,12 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsAddAccount struct {

--- a/internal/config/add-account.go
+++ b/internal/config/add-account.go
@@ -22,17 +22,17 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/onflow/flow-cli/flowkit/accounts"
+	"github.com/onflow/flowkit/v2/accounts"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsAddAccount struct {

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -24,11 +24,11 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsAddContract struct {

--- a/internal/config/add-contract.go
+++ b/internal/config/add-contract.go
@@ -24,11 +24,12 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsAddContract struct {

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsAddDeployment struct {

--- a/internal/config/add-deployment.go
+++ b/internal/config/add-deployment.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsAddDeployment struct {

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsAddNetwork struct {

--- a/internal/config/add-network.go
+++ b/internal/config/add-network.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsAddNetwork struct {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -25,11 +25,12 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsInit struct {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -25,11 +25,11 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsInit struct {

--- a/internal/config/remove-account.go
+++ b/internal/config/remove-account.go
@@ -21,10 +21,10 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsRemoveAccount struct{}

--- a/internal/config/remove-account.go
+++ b/internal/config/remove-account.go
@@ -21,10 +21,11 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsRemoveAccount struct{}

--- a/internal/config/remove-contract.go
+++ b/internal/config/remove-contract.go
@@ -21,10 +21,10 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsRemoveContract struct{}

--- a/internal/config/remove-contract.go
+++ b/internal/config/remove-contract.go
@@ -21,10 +21,11 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsRemoveContract struct{}

--- a/internal/config/remove-deployment.go
+++ b/internal/config/remove-deployment.go
@@ -21,10 +21,10 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsRemoveDeployment struct{}

--- a/internal/config/remove-deployment.go
+++ b/internal/config/remove-deployment.go
@@ -21,10 +21,11 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsRemoveDeployment struct{}

--- a/internal/config/remove-network.go
+++ b/internal/config/remove-network.go
@@ -21,10 +21,11 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsRemoveNetwork struct{}

--- a/internal/config/remove-network.go
+++ b/internal/config/remove-network.go
@@ -21,10 +21,10 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsRemoveNetwork struct{}

--- a/internal/dependencymanager/add.go
+++ b/internal/dependencymanager/add.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type addFlagsCollection struct {

--- a/internal/dependencymanager/add.go
+++ b/internal/dependencymanager/add.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type addFlagsCollection struct {

--- a/internal/dependencymanager/dependencyinstaller.go
+++ b/internal/dependencymanager/dependencyinstaller.go
@@ -28,16 +28,16 @@ import (
 
 	"github.com/onflow/flow-cli/internal/util"
 
-	"github.com/onflow/flow-cli/flowkit/gateway"
+	"github.com/onflow/flowkit/v2/gateway"
 
-	"github.com/onflow/flow-cli/flowkit/project"
+	"github.com/onflow/flowkit/v2/project"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 
-	"github.com/onflow/flow-cli/flowkit/config"
+	"github.com/onflow/flowkit/v2/config"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type DependencyInstaller struct {

--- a/internal/dependencymanager/dependencyinstaller_test.go
+++ b/internal/dependencymanager/dependencyinstaller_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/gateway"
-	"github.com/onflow/flow-cli/flowkit/gateway/mocks"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/gateway"
+	"github.com/onflow/flowkit/v2/gateway/mocks"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 func TestDependencyInstallerInstall(t *testing.T) {

--- a/internal/dependencymanager/dependencyinstaller_test.go
+++ b/internal/dependencymanager/dependencyinstaller_test.go
@@ -26,12 +26,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/gateway"
 	"github.com/onflow/flowkit/v2/gateway/mocks"
 	"github.com/onflow/flowkit/v2/output"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func TestDependencyInstallerInstall(t *testing.T) {

--- a/internal/dependencymanager/install.go
+++ b/internal/dependencymanager/install.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type installFlagsCollection struct{}

--- a/internal/dependencymanager/install.go
+++ b/internal/dependencymanager/install.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type installFlagsCollection struct{}

--- a/internal/emulator/snapshot.go
+++ b/internal/emulator/snapshot.go
@@ -29,10 +29,11 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type SnapshotFlag struct{}

--- a/internal/emulator/snapshot.go
+++ b/internal/emulator/snapshot.go
@@ -29,10 +29,10 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type SnapshotFlag struct{}

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -30,10 +30,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
 )
 
 var Cmd *cobra.Command

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -30,10 +30,11 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 var Cmd *cobra.Command

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func Test_Get(t *testing.T) {

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 func Test_Get(t *testing.T) {

--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -24,9 +24,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsEvents struct {

--- a/internal/events/get.go
+++ b/internal/events/get.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsEvents struct {

--- a/internal/keys/decode.go
+++ b/internal/keys/decode.go
@@ -27,9 +27,10 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsDecode struct {

--- a/internal/keys/decode.go
+++ b/internal/keys/decode.go
@@ -27,9 +27,9 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsDecode struct {

--- a/internal/keys/derive.go
+++ b/internal/keys/derive.go
@@ -24,9 +24,9 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsDerive struct {

--- a/internal/keys/derive.go
+++ b/internal/keys/derive.go
@@ -24,9 +24,10 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsDerive struct {

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -25,9 +25,10 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsGenerate struct {

--- a/internal/keys/generate.go
+++ b/internal/keys/generate.go
@@ -25,9 +25,9 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsGenerate struct {

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -26,8 +26,9 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -26,8 +26,8 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/project/deploy.go
+++ b/internal/project/deploy.go
@@ -27,12 +27,12 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/project"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/project"
 )
 
 type flagsDeploy struct {

--- a/internal/project/deploy.go
+++ b/internal/project/deploy.go
@@ -27,12 +27,13 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
 	"github.com/onflow/flowkit/v2/project"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsDeploy struct {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -25,11 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/accounts"
 	"github.com/onflow/flowkit/v2/config"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func Test_ProjectDeploy(t *testing.T) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/accounts"
-	"github.com/onflow/flow-cli/flowkit/config"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/onflow/flowkit/v2/config"
 )
 
 func Test_ProjectDeploy(t *testing.T) {

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsRun struct {

--- a/internal/quick/run.go
+++ b/internal/quick/run.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsRun struct {

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -26,10 +26,11 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/arguments"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type Flags struct {

--- a/internal/scripts/execute.go
+++ b/internal/scripts/execute.go
@@ -26,10 +26,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/arguments"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/arguments"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type Flags struct {

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 func Test_Execute(t *testing.T) {

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func Test_Execute(t *testing.T) {

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -27,10 +27,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsGenerate struct {

--- a/internal/signatures/generate.go
+++ b/internal/signatures/generate.go
@@ -23,14 +23,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onflow/flow-cli/flowkit/accounts"
+	"github.com/onflow/flowkit/v2/accounts"
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsGenerate struct {

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -27,10 +27,11 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsVerify struct {

--- a/internal/signatures/verify.go
+++ b/internal/signatures/verify.go
@@ -27,10 +27,10 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsVerify struct {

--- a/internal/snapshot/save.go
+++ b/internal/snapshot/save.go
@@ -24,9 +24,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 var saveCommand = &command.Command{

--- a/internal/snapshot/save.go
+++ b/internal/snapshot/save.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 var saveCommand = &command.Command{

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsStatus struct {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsStatus struct {

--- a/internal/super/dev.go
+++ b/internal/super/dev.go
@@ -27,9 +27,10 @@ import (
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsDev struct{}

--- a/internal/super/dev.go
+++ b/internal/super/dev.go
@@ -27,9 +27,9 @@ import (
 	"github.com/onflow/cadence/runtime/parser"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsDev struct{}

--- a/internal/super/files.go
+++ b/internal/super/files.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/radovskyb/watcher"
 
-	"github.com/onflow/flow-cli/flowkit/config"
+	"github.com/onflow/flowkit/v2/config"
 )
 
 const (

--- a/internal/super/flix.go
+++ b/internal/super/flix.go
@@ -28,12 +28,12 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/scripts"
 	"github.com/onflow/flow-cli/internal/transactions"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flixFlags struct {

--- a/internal/super/flix.go
+++ b/internal/super/flix.go
@@ -28,12 +28,13 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/scripts"
-	"github.com/onflow/flow-cli/internal/transactions"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/scripts"
+	"github.com/onflow/flow-cli/internal/transactions"
 )
 
 type flixFlags struct {

--- a/internal/super/flix_test.go
+++ b/internal/super/flix_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/onflow/flixkit-go/flixkit"
 	"github.com/onflow/flow-go-sdk/crypto"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/mocks"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/mocks"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 type MockFlixService struct {

--- a/internal/super/flix_test.go
+++ b/internal/super/flix_test.go
@@ -29,13 +29,14 @@ import (
 	"github.com/onflow/flixkit-go/flixkit"
 	"github.com/onflow/flow-go-sdk/crypto"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/mocks"
 	"github.com/onflow/flowkit/v2/output"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type MockFlixService struct {

--- a/internal/super/generate.go
+++ b/internal/super/generate.go
@@ -27,8 +27,9 @@ import (
 
 	"github.com/onflow/flowkit/v2"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/super/generate.go
+++ b/internal/super/generate.go
@@ -23,12 +23,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/onflow/flow-cli/flowkit/config"
+	"github.com/onflow/flowkit/v2/config"
 
-	"github.com/onflow/flow-cli/flowkit"
+	"github.com/onflow/flowkit/v2"
 
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2/output"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/super/generate_test.go
+++ b/internal/super/generate_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/onflow/flow-cli/flowkit/output"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 func TestGenerateNewContract(t *testing.T) {

--- a/internal/super/output.go
+++ b/internal/super/output.go
@@ -31,9 +31,9 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
-	flowkitProject "github.com/onflow/flow-cli/flowkit/project"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
+	flowkitProject "github.com/onflow/flowkit/v2/project"
 )
 
 func printDeployment(deployed []*flowkitProject.Contract, err error, contractPathNames map[string]string) {

--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -25,11 +25,11 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/pkg/errors"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/accounts"
-	"github.com/onflow/flow-cli/flowkit/config"
-	flowkitProject "github.com/onflow/flow-cli/flowkit/project"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/onflow/flowkit/v2/config"
+	flowkitProject "github.com/onflow/flowkit/v2/project"
 )
 
 var emulator = config.EmulatorNetwork.Name

--- a/internal/super/project.go
+++ b/internal/super/project.go
@@ -25,11 +25,12 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/pkg/errors"
 
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/accounts"
 	"github.com/onflow/flowkit/v2/config"
 	flowkitProject "github.com/onflow/flowkit/v2/project"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 var emulator = config.EmulatorNetwork.Name

--- a/internal/super/setup.go
+++ b/internal/super/setup.go
@@ -32,10 +32,11 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsSetup struct {

--- a/internal/super/setup.go
+++ b/internal/super/setup.go
@@ -32,10 +32,10 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsSetup struct {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -32,11 +32,12 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 // The key where meta information for a test report in JSON

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -32,11 +32,11 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 // The key where meta information for a test report in JSON

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/tests"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 func TestExecutingTests(t *testing.T) {

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -30,9 +30,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/tests"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func TestExecutingTests(t *testing.T) {

--- a/internal/tools/flowser.go
+++ b/internal/tools/flowser.go
@@ -26,12 +26,12 @@ import (
 	"github.com/onflowser/flowser/v3/pkg/flowser"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/settings"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsFlowser struct{}

--- a/internal/tools/flowser.go
+++ b/internal/tools/flowser.go
@@ -26,12 +26,13 @@ import (
 	"github.com/onflowser/flowser/v3/pkg/flowser"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/settings"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/settings"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsFlowser struct{}

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -25,9 +25,10 @@ import (
 	devWallet "github.com/onflow/fcl-dev-wallet/go/wallet"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsWallet struct {

--- a/internal/tools/wallet.go
+++ b/internal/tools/wallet.go
@@ -25,9 +25,9 @@ import (
 	devWallet "github.com/onflow/fcl-dev-wallet/go/wallet"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsWallet struct {

--- a/internal/transactions/build.go
+++ b/internal/transactions/build.go
@@ -26,12 +26,12 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/arguments"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/transactions"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/arguments"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/transactions"
 )
 
 type flagsBuild struct {

--- a/internal/transactions/build.go
+++ b/internal/transactions/build.go
@@ -26,12 +26,13 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/arguments"
 	"github.com/onflow/flowkit/v2/output"
 	"github.com/onflow/flowkit/v2/transactions"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsBuild struct {

--- a/internal/transactions/decode.go
+++ b/internal/transactions/decode.go
@@ -21,13 +21,13 @@ package transactions
 import (
 	"fmt"
 
-	"github.com/onflow/flow-cli/flowkit/transactions"
+	"github.com/onflow/flowkit/v2/transactions"
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsDecode struct {

--- a/internal/transactions/decode.go
+++ b/internal/transactions/decode.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsDecode struct {

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -25,9 +25,9 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsGet struct {

--- a/internal/transactions/get.go
+++ b/internal/transactions/get.go
@@ -25,9 +25,10 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type flagsGet struct {

--- a/internal/transactions/send-signed.go
+++ b/internal/transactions/send-signed.go
@@ -22,14 +22,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onflow/flow-cli/flowkit/transactions"
+	"github.com/onflow/flowkit/v2/transactions"
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsSendSigned struct {

--- a/internal/transactions/send-signed.go
+++ b/internal/transactions/send-signed.go
@@ -26,10 +26,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsSendSigned struct {

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -25,12 +25,12 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/accounts"
-	"github.com/onflow/flow-cli/flowkit/arguments"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/transactions"
 	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/onflow/flowkit/v2/arguments"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/transactions"
 )
 
 type Flags struct {

--- a/internal/transactions/send.go
+++ b/internal/transactions/send.go
@@ -25,12 +25,13 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/accounts"
 	"github.com/onflow/flowkit/v2/arguments"
 	"github.com/onflow/flowkit/v2/output"
 	"github.com/onflow/flowkit/v2/transactions"
+
+	"github.com/onflow/flow-cli/internal/command"
 )
 
 type Flags struct {

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -34,10 +34,11 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 type flagsSign struct {

--- a/internal/transactions/sign.go
+++ b/internal/transactions/sign.go
@@ -27,17 +27,17 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/onflow/flow-cli/flowkit/transactions"
+	"github.com/onflow/flowkit/v2/transactions"
 
-	"github.com/onflow/flow-cli/flowkit/accounts"
+	"github.com/onflow/flowkit/v2/accounts"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 type flagsSign struct {

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -27,10 +27,10 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-cli/flowkit/output"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/events"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -27,10 +27,11 @@ import (
 	"github.com/onflow/flow-go-sdk"
 	"github.com/spf13/cobra"
 
+	"github.com/onflow/flowkit/v2/output"
+
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/events"
 	"github.com/onflow/flow-cli/internal/util"
-	"github.com/onflow/flowkit/v2/output"
 )
 
 var Cmd = &cobra.Command{

--- a/internal/transactions/transactions_test.go
+++ b/internal/transactions/transactions_test.go
@@ -29,14 +29,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/internal/command"
-	"github.com/onflow/flow-cli/internal/util"
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/accounts"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/output"
 	"github.com/onflow/flowkit/v2/tests"
 	"github.com/onflow/flowkit/v2/transactions"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 func Test_Build(t *testing.T) {

--- a/internal/transactions/transactions_test.go
+++ b/internal/transactions/transactions_test.go
@@ -29,14 +29,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/accounts"
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/tests"
-	"github.com/onflow/flow-cli/flowkit/transactions"
 	"github.com/onflow/flow-cli/internal/command"
 	"github.com/onflow/flow-cli/internal/util"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/tests"
+	"github.com/onflow/flowkit/v2/transactions"
 )
 
 func Test_Build(t *testing.T) {

--- a/internal/util/prompt.go
+++ b/internal/util/prompt.go
@@ -33,8 +33,8 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
-	"github.com/onflow/flow-cli/flowkit/config"
-	"github.com/onflow/flow-cli/flowkit/output"
+	"github.com/onflow/flowkit/v2/config"
+	"github.com/onflow/flowkit/v2/output"
 )
 
 func ApproveTransactionForSigningPrompt(transaction *flow.Transaction) bool {

--- a/internal/util/test.go
+++ b/internal/util/test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-cli/flowkit"
-	"github.com/onflow/flow-cli/flowkit/mocks"
-	"github.com/onflow/flow-cli/flowkit/output"
-	"github.com/onflow/flow-cli/flowkit/tests"
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/mocks"
+	"github.com/onflow/flowkit/v2/output"
+	"github.com/onflow/flowkit/v2/tests"
 )
 
 var NoLogger = output.NewStdoutLogger(output.NoneLog)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -30,7 +30,7 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 
-	"github.com/onflow/flow-cli/flowkit"
+	"github.com/onflow/flowkit/v2"
 )
 
 const EnvPrefix = "FLOW"


### PR DESCRIPTION
Closes #???

## Description

update branch to use new `flowkit v2.0.0-stable-cadence` from `github.com/onflow/flowkit`

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
