### PR TITLE
Remove os dir code in `generate` tests

### DIFF
--- a/internal/super/generate_test.go
+++ b/internal/super/generate_test.go
@@ -19,7 +19,6 @@
 package super
 
 import (
-	"os"
 	"testing"
 
 	"github.com/onflow/flow-cli/internal/util"
@@ -30,19 +29,11 @@ import (
 )
 
 func TestGenerateNewContract(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(dir)
-
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
 	logger := output.NewStdoutLogger(output.NoneLog)
 	_, state, _ := util.TestMocks(t)
 
 	// Test contract generation
-	_, err = generateNew([]string{"TestContract"}, "contract", logger, state)
+	_, err := generateNew([]string{"TestContract"}, "contract", logger, state)
 	assert.NoError(t, err, "Failed to generate contract")
 
 	fileContent, err := state.ReaderWriter().ReadFile("cadence/contracts/TestContract.cdc")
@@ -64,19 +55,11 @@ contract TestContract {
 }
 
 func TestGenerateNewContractFileAlreadyExists(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(dir)
-
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
 	logger := output.NewStdoutLogger(output.NoneLog)
 	_, state, _ := util.TestMocks(t)
 
 	// Test contract generation
-	_, err = generateNew([]string{"TestContract"}, "contract", logger, state)
+	_, err := generateNew([]string{"TestContract"}, "contract", logger, state)
 	assert.NoError(t, err, "Failed to generate contract")
 
 	//// Check if the file exists in the correct directory
@@ -91,18 +74,10 @@ func TestGenerateNewContractFileAlreadyExists(t *testing.T) {
 }
 
 func TestGenerateNewContractWithFileExtension(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(dir)
-
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
 	logger := output.NewStdoutLogger(output.NoneLog)
 	_, state, _ := util.TestMocks(t)
 
-	_, err = generateNew([]string{"TestContract.cdc"}, "contract", logger, state)
+	_, err := generateNew([]string{"TestContract.cdc"}, "contract", logger, state)
 	assert.NoError(t, err, "Failed to generate contract")
 
 	// Check file exists
@@ -112,18 +87,10 @@ func TestGenerateNewContractWithFileExtension(t *testing.T) {
 }
 
 func TestGenerateNewScript(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(dir)
-
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
 	logger := output.NewStdoutLogger(output.NoneLog)
 	_, state, _ := util.TestMocks(t)
 
-	_, err = generateNew([]string{"TestScript"}, "script", logger, state)
+	_, err := generateNew([]string{"TestScript"}, "script", logger, state)
 	assert.NoError(t, err, "Failed to generate contract")
 
 	content, err := state.ReaderWriter().ReadFile("cadence/scripts/TestScript.cdc")
@@ -138,18 +105,10 @@ fun main() {
 }
 
 func TestGenerateNewTransaction(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(dir)
-
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
 	logger := output.NewStdoutLogger(output.NoneLog)
 	_, state, _ := util.TestMocks(t)
 
-	_, err = generateNew([]string{"TestTransaction"}, "transaction", logger, state)
+	_, err := generateNew([]string{"TestTransaction"}, "transaction", logger, state)
 	assert.NoError(t, err, "Failed to generate contract")
 
 	content, err := state.ReaderWriter().ReadFile("cadence/transactions/TestTransaction.cdc")
@@ -165,21 +124,13 @@ func TestGenerateNewTransaction(t *testing.T) {
 }
 
 func TestGenerateNewWithDirFlag(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	assert.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(dir)
-
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
 	logger := output.NewStdoutLogger(output.NoneLog)
 	_, state, _ := util.TestMocks(t)
 
 	// Set a custom directory
 	generateFlags.Directory = "customDir"
 
-	_, err = generateNew([]string{"TestContract"}, "contract", logger, state)
+	_, err := generateNew([]string{"TestContract"}, "contract", logger, state)
 	assert.NoError(t, err, "Failed to generate contract")
 
 	content, err := state.ReaderWriter().ReadFile("customDir/TestContract.cdc")


### PR DESCRIPTION
This code is not necessary with ReaderWriter. Remove to simplify tests.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
