### PR TITLE
Updated flixkit version, Added processing to create contract dependency structure for flix generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onflow/cadence-tools/languageserver v0.33.3
 	github.com/onflow/cadence-tools/test v0.14.5
 	github.com/onflow/fcl-dev-wallet v0.7.4
-	github.com/onflow/flixkit-go v1.1.1
+	github.com/onflow/flixkit-go v1.1.2
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f
 	github.com/onflow/flow-emulator v0.59.0
 	github.com/onflow/flow-go-sdk v0.41.17

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/onflow/cadence-tools/test v0.14.5 h1:u1kYkotKdwKEf9c3h65mI3VMevBkHY+7
 github.com/onflow/cadence-tools/test v0.14.5/go.mod h1:ix09Bb3GQ/fZMNpSR8E+vSFItGF54fzP9gFxU7AsOIw=
 github.com/onflow/fcl-dev-wallet v0.7.4 h1:vI6t3U0AO88R/Iitn5KsnniSpbN9Lqsqwvi9EJT4C0k=
 github.com/onflow/fcl-dev-wallet v0.7.4/go.mod h1:kc42jkiuoPJmxMRFjfbRO9XvnR/3XLheaOerxVMDTiw=
-github.com/onflow/flixkit-go v1.1.1 h1:ARgLsfWxc3LjgUHUAELildY5lxJ6kA4gVfAS2+ZRaCE=
-github.com/onflow/flixkit-go v1.1.1/go.mod h1:XkbRPv6drM8uQpvdKgZ5stShtOlOMiQ6Fy86D0EsW5U=
+github.com/onflow/flixkit-go v1.1.2 h1:pn8CtUr1qpHrZF+xbl6FXU+nVGtUgFKYm3XGaX0yKj8=
+github.com/onflow/flixkit-go v1.1.2/go.mod h1:XkbRPv6drM8uQpvdKgZ5stShtOlOMiQ6Fy86D0EsW5U=
 github.com/onflow/flow-cli/flowkit v1.11.0 h1:RSfKlla/l+ZJwqAmlvA5HPFbQ6ia2wzKSG0kJ8fqVa0=
 github.com/onflow/flow-cli/flowkit v1.11.0/go.mod h1:aH4shan7Ggxd0GIXZD2S4kYMemNfzP1rLWvzKnb6K3g=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20231016154253-a00dbf7c061f h1:S8yIZw9LFXfYD1V5H9BiixihHw3GrXVPrmfplSzYaww=


### PR DESCRIPTION
Updated version of flixkit, update processing state to create contract dependencies structure for flix generation

## Description

Noticed when generating flix for staging contracts that there was an issue creating all contracts dependencies based on user's flow.json. Added more specific processing to get all contracts.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
