### PR TITLE
Switch to goreleaser & add support for CGO cross-compilation

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -17,9 +17,10 @@ jobs:
           go-version: '1.20'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - name: setup dependencies
-        uses: actions/setup-go@v2
-      - name: setup release environment
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+      - name: Setup Release Environment
         run: |-
           echo 'MIXPANEL_PROJECT_TOKEN=${{ secrets.MIXPANEL_PROJECT_TOKEN }}' > .release-env
           echo 'LILICO_TOKEN=${{ secrets.LILICO_TOKEN }}' >> .release-env
@@ -29,5 +30,5 @@ jobs:
           echo 'COMMIT=${{ github.sha }}' >> .release-env 
           echo 'CGO_FLAGS="-O2 -D__BLST_PORTABLE__"' >> .release-env
           echo 'GITHUB_TOKEN=${{ secrets.FLOW_CLI_RELEASE }}' >> .release-env
-      - name: release publish
+      - name: Build and Release
         run: make release

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,3 +1,5 @@
+name: Build Release
+
 on:
   release:
     types: [published]

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,21 +1,11 @@
-name: Build Release
-
 on:
   release:
     types: [published]
 
 jobs:
-  releases-matrix:
+  release:
     name: Release Go Binary
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
-        goos: [ linux, windows, darwin ]
-        goarch: [ amd64, arm64 ]
-        exclude:
-          - goarch: arm64
-            goos: windows
     steps:
       - uses: actions/checkout@v3
       - name: Codebase security check
@@ -25,19 +15,17 @@ jobs:
           go-version: '1.20'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - uses: wangyoucao577/go-release-action@v1.40
-        env:
-          MIXPANEL_PROJECT_TOKEN: ${{ secrets.MIXPANEL_PROJECT_TOKEN }}
-          LILICO_TOKEN: ${{ secrets.LILICO_TOKEN }}
-          APP_VERSION: $(basename ${GITHUB_REF})
-          BUILD_TIME: $(date --iso-8601=seconds)
-          VERSION: ${{github.ref_name}}
-          COMMIT: ${{ github.sha }}
-        with:
-          pre_command: make generate
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: "1.20"
-          project_path: "./cmd/flow"
-          ldflags: -X "github.com/onflow/flow-cli/build.commit=${{ env.COMMIT }}" -X "github.com/onflow/flow-cli/build.semver=${{ env.VERSION }}" -X "github.com/onflow/flow-cli/internal/command.mixpanelToken=${{ env.MIXPANEL_PROJECT_TOKEN }}" -X "github.com/onflow/flow-cli/internal/accounts.accountToken=${{ env.LILICO_TOKEN }}"
+      - name: setup dependencies
+        uses: actions/setup-go@v2
+      - name: setup release environment
+        run: |-
+          echo 'MIXPANEL_PROJECT_TOKEN=${{ secrets.MIXPANEL_PROJECT_TOKEN }}' > .release-env
+          echo 'LILICO_TOKEN=${{ secrets.LILICO_TOKEN }}' >> .release-env
+          echo 'APP_VERSION=$(basename ${GITHUB_REF})' >> .release-env
+          echo 'BUILD_TIME=$(date --iso-8601=seconds)' >> .release-env
+          echo 'VERSION=${{ github.ref_name }}' >> .release-env
+          echo 'COMMIT=${{ github.sha }}' >> .release-env 
+          echo 'CGO_FLAGS="-O2 -D__BLST_PORTABLE__"' >> .release-env
+          echo 'GITHUB_TOKEN=${{ secrets.FLOW_CLI_RELEASE }}' >> .release-env
+      - name: release publish
+        run: make release

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -28,8 +28,6 @@ jobs:
           echo 'BUILD_TIME=$(date --iso-8601=seconds)' >> .release-env
           echo 'VERSION=${{ github.ref_name }}' >> .release-env
           echo 'COMMIT=${{ github.sha }}' >> .release-env 
-          echo 'CGO_FLAGS="-O2 -D__BLST_PORTABLE__"' >> .release-env
-          echo 'CGO_ENABLED=1' >> .release-env
           echo 'GITHUB_TOKEN=${{ secrets.FLOW_CLI_RELEASE }}' >> .release-env
       - name: Build and Release
         run: make release

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -29,6 +29,7 @@ jobs:
           echo 'VERSION=${{ github.ref_name }}' >> .release-env
           echo 'COMMIT=${{ github.sha }}' >> .release-env 
           echo 'CGO_FLAGS="-O2 -D__BLST_PORTABLE__"' >> .release-env
+          echo 'CGO_ENABLED=1' >> .release-env
           echo 'GITHUB_TOKEN=${{ secrets.FLOW_CLI_RELEASE }}' >> .release-env
       - name: Build and Release
         run: make release

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ main
 
 # Local development file generation folder
 imports
+
+# Goreleaser .env
+.release-env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - make generate
+    - export LD_FLAGS="-X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}"
 
 builds:
   - id: darwin-amd64
@@ -15,7 +16,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+      - {{ .Env.LD_FLAGS }}
 
   - id: darwin-arm64
     main: ./cmd/flow
@@ -29,7 +30,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+      - {{ .Env.LD_FLAGS }}
 
   - id: linux-amd64
     main: ./cmd/flow
@@ -43,7 +44,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+      - {{ .Env.LD_FLAGS }}
 
   - id: linux-arm64
     main: ./cmd/flow
@@ -57,7 +58,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+      - {{ .Env.LD_FLAGS }}
 
 archives:
   - id: golang-cross
@@ -68,8 +69,10 @@ archives:
       - linux-arm64
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
+    wrap_in_directory: false
 checksum:
-  disable: true
+  name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}.md5"
+  algorithm: md5
 snapshot:
   name_template: "{{ .Tag }}"
 changelog:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,8 @@ snapshot:
   name_template: "{{ .Tag }}"
 changelog:
   skip: true
+checksum:
+  name_template: "checksums.txt"
 release:
   github:
     owner: onflow

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,110 @@
+builds:
+  - id: darwin-amd64
+    main: ./cmd/flow
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+
+  - id: darwin-arm64
+    main: ./cmd/flow
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+
+  - id: linux-amd64
+    main: ./cmd/flow
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=oa64-x86_64-linux-gnu-g++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+
+  - id: linux-arm64
+    main: ./cmd/flow
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=oa64-aarch64-linux-gnu-g++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+
+  - id: windows-amd64
+    main: ./cmd/flow
+    goos:
+      - windows
+    goarch:
+      - amd64
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=oa64-x86_64-w64-mingw32-g++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+
+  - id: windows-arm64
+    main: ./cmd/flow
+    goos:
+      - windows
+    goarch:
+      - arm64
+    env:
+      - CC=/llvm-mingw/bin/aarch64-w64-mingw32-gcc
+      - CXX=/llvm-mingw/bin/aarch64-w64-mingw32-g++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
+
+archives:
+  - id: golang-cross
+    builds:
+      - darwin-amd64
+      - darwin-arm64
+      - linux-amd64
+      - linux-arm64
+      - windows-amd64
+      - windows-arm64
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: tar.gz
+checksum:
+  disable: true
+snapshot:
+  name_template: "{{ .Tag }}"
+changelog:
+  disable: true
+readme:
+  disable: true
+release:
+  github:
+    owner: onflow
+    name: flow-cli
+  prerelease: auto
+  draft: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,57 +3,30 @@ before:
     - make generate
 
 builds:
-  - id: darwin-amd64
+  - id: flow-cli
     main: ./cmd/flow
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    flags:
-      - -mod=readonly
-    ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
-
-  - id: darwin-arm64
-    main: ./cmd/flow
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
-    flags:
-      - -mod=readonly
-    ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
-
-  - id: linux-amd64
-    main: ./cmd/flow
-    goos:
-      - linux
-    goarch:
-      - amd64
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=oa64-x86_64-linux-gnu-g++
-    flags:
-      - -mod=readonly
-    ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
-
-  - id: linux-arm64
-    main: ./cmd/flow
-    goos:
-      - linux
-    goarch:
-      - arm64
-    env:
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=oa64-aarch64-linux-gnu-g++
+      - >-
+        {{- if eq .Os "darwin" }}
+          {{- if eq .Arch "amd64"}}CC=o64-clang{{- end }}
+          {{- if eq .Arch "arm64"}}CC=oa64-clang{{- end }}
+        {{- end }}
+        {{ if eq .Os "linux" }}
+          {{- if eq .Arch "amd64" }}CC=x86_64-linux-gnu-gcc{{- end }}
+          {{- if eq .Arch "arm64" }}CC=aarch64-linux-gnu-gcc{{- end }}
+        {{- end }}
+        {{- if eq .Os "windows" }}
+          {{- if eq .Arch "amd64" }}CC=x86_64-w64-mingw32-gcc{{- end }}
+          {{- if eq .Arch "arm64" }}CC=aarch64-w64-mingw32-gcc{{- end }}
+        {{- end }}
     flags:
       - -mod=readonly
     ldflags:
@@ -62,10 +35,7 @@ builds:
 archives:
   - id: golang-cross
     builds:
-      - darwin-amd64
-      - darwin-arm64
-      - linux-amd64
-      - linux-arm64
+      - flow-cli
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     wrap_in_directory: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,16 +16,16 @@ builds:
       - CXX=o64-clang++
       - >-
         {{- if eq .Os "darwin" }}
-          {{- if eq .Arch "amd64"}}CC=o64-clang{{- end }}
-          {{- if eq .Arch "arm64"}}CC=oa64-clang{{- end }}
+          {{- if eq .Arch "amd64"}}CC=o64-clang CXX=o64-clang++{{- end }}
+          {{- if eq .Arch "arm64"}}CC=oa64-clang CXX=oa64-clang++{{- end }}
         {{- end }}
         {{ if eq .Os "linux" }}
-          {{- if eq .Arch "amd64" }}CC=x86_64-linux-gnu-gcc{{- end }}
-          {{- if eq .Arch "arm64" }}CC=aarch64-linux-gnu-gcc{{- end }}
+          {{- if eq .Arch "amd64" }}CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++{{- end }}
+          {{- if eq .Arch "arm64" }}CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++{{- end }}
         {{- end }}
         {{- if eq .Os "windows" }}
-          {{- if eq .Arch "amd64" }}CC=x86_64-w64-mingw32-gcc{{- end }}
-          {{- if eq .Arch "arm64" }}CC=aarch64-w64-mingw32-gcc{{- end }}
+          {{- if eq .Arch "amd64" }}CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++{{- end }}
+          {{- if eq .Arch "arm64" }}CC=aarch64-w64-mingw32-gcc CXX=aarch64-w64-mingw32-g++{{- end }}
         {{- end }}
     flags:
       - -mod=readonly

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,7 @@
+before:
+  hooks:
+    - make generate
+
 builds:
   - id: darwin-amd64
     main: ./cmd/flow
@@ -69,9 +73,7 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}"
 changelog:
-  disable: true
-readme:
-  disable: true
+  skip: true
 release:
   github:
     owner: onflow

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,6 @@
 before:
   hooks:
     - make generate
-    - export LD_FLAGS="-X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}"
 
 builds:
   - id: darwin-amd64
@@ -16,7 +15,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - {{ .Env.LD_FLAGS }}
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
 
   - id: darwin-arm64
     main: ./cmd/flow
@@ -30,7 +29,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - {{ .Env.LD_FLAGS }}
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
 
   - id: linux-amd64
     main: ./cmd/flow
@@ -44,7 +43,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - {{ .Env.LD_FLAGS }}
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
 
   - id: linux-arm64
     main: ./cmd/flow
@@ -58,7 +57,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - {{ .Env.LD_FLAGS }}
+      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
 
 archives:
   - id: golang-cross

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,34 +55,6 @@ builds:
     ldflags:
       - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
 
-  - id: windows-amd64
-    main: ./cmd/flow
-    goos:
-      - windows
-    goarch:
-      - amd64
-    env:
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=oa64-x86_64-w64-mingw32-g++
-    flags:
-      - -mod=readonly
-    ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
-
-  - id: windows-arm64
-    main: ./cmd/flow
-    goos:
-      - windows
-    goarch:
-      - arm64
-    env:
-      - CC=/llvm-mingw/bin/aarch64-w64-mingw32-gcc
-      - CXX=/llvm-mingw/bin/aarch64-w64-mingw32-g++
-    flags:
-      - -mod=readonly
-    ldflags:
-      - -X github.com/onflow/flow-cli/build.commit={{ .Env.COMMIT }} -X github.com/onflow/flow-cli/build.semver={{ .Env.VERSION }} -X github.com/onflow/flow-cli/internal/command.mixpanelToken={{ .Env.MIXPANEL_PROJECT_TOKEN }} -X github.com/onflow/flow-cli/internal/accounts.accountToken={{ .Env.LILICO_TOKEN }}
-
 archives:
   - id: golang-cross
     builds:
@@ -90,8 +62,6 @@ archives:
       - darwin-arm64
       - linux-amd64
       - linux-arm64
-      - windows-amd64
-      - windows-arm64
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,8 +12,6 @@ builds:
       - amd64
       - arm64
     env:
-      - CC=o64-clang
-      - CXX=o64-clang++
       - >-
         {{- if eq .Os "darwin" }}
           {{- if eq .Arch "amd64"}}CC=o64-clang CXX=o64-clang++{{- end }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,9 +69,6 @@ archives:
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     wrap_in_directory: false
-checksum:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}.md5"
-  algorithm: md5
 snapshot:
   name_template: "{{ .Tag }}"
 changelog:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,19 +12,22 @@ builds:
       - amd64
       - arm64
     env:
-      - >-
-        {{- if eq .Os "darwin" }}
-          {{- if eq .Arch "amd64"}}CC=o64-clang CXX=o64-clang++{{- end }}
-          {{- if eq .Arch "arm64"}}CC=oa64-clang CXX=oa64-clang++{{- end }}
-        {{- end }}
-        {{ if eq .Os "linux" }}
-          {{- if eq .Arch "amd64" }}CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++{{- end }}
-          {{- if eq .Arch "arm64" }}CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++{{- end }}
-        {{- end }}
-        {{- if eq .Os "windows" }}
-          {{- if eq .Arch "amd64" }}CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++{{- end }}
-          {{- if eq .Arch "arm64" }}CC=aarch64-w64-mingw32-gcc CXX=aarch64-w64-mingw32-g++{{- end }}
-        {{- end }}
+      - CGO_FLAGS="-O2 -D__BLST_PORTABLE__"
+      - CGO_ENABLED=1
+      - CC_darwin_amd64=o64-clang
+      - CXX_darwin_amd64=o64-clang+
+      - CC_darwin_arm64=oa64-clang
+      - CXX_darwin_arm64=oa64-clang++
+      - CC_linux_amd64=x86_64-linux-gnu-gcc
+      - CXX_linux_amd64=x86_64-linux-gnu-g++
+      - CC_linux_arm64=aarch64-linux-gnu-gcc
+      - CXX_linux_arm64=aarch64-linux-gnu-g++
+      - CC_windows_amd64=x86_64-w64-mingw32-gcc
+      - CXX_windows_amd64=x86_64-w64-mingw32-g++
+      - CC_windows_arm64=aarch64-w64-mingw32-gcc
+      - CXX_windows_arm64=aarch64-w64-mingw32-g++
+      - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
+      - 'CXX={{ index .Env (print "CXX_" .Os "_" .Arch) }}'
     flags:
       - -mod=readonly
     ldflags:

--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,7 @@ endif
 ci: install-tools generate test coverage
 
 $(BINARY):
-	if [ "$(GOARCH)" = "arm64" ]; then \
-		export CC=aarch64-linux-gnu-gcc; \
-	elif [ "$(GOARCH)" = "amd64" ]; then \
-		export CC=x86_64-linux-gnu-gcc; \
-	fi; \
-	GO111MODULE=on \
-    CGO_ENABLED=1 \
-    CGO_FLAGS="-O2 -D__BLST_PORTABLE__" \
-	go build \
+	GO111MODULE=on go build \
 		-trimpath \
 		-ldflags \
 		"-X github.com/onflow/flow-cli/build.commit=$(COMMIT) -X github.com/onflow/flow-cli/build.semver=$(VERSION) -X github.com/onflow/flow-cli/internal/accounts.accountToken=${ACCOUNT_TOKEN}"\

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ generate: install-tools
 release:
 	docker run \
 		--rm \
+		-e CGO_ENABLED=1 \
 		--env-file .release-env \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -115,18 +115,6 @@ check-tidy:
 generate: install-tools
 	go generate ./...
 
-.PHONY: release-dry-run
-release-dry-run:
-	@docker run \
-		--rm \
-		-e CGO_ENABLED=1 \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v `pwd`:/go/src/$(PACKAGE_NAME) \
-		-v `pwd`/sysroot:/sysroot \
-		-w /go/src/$(PACKAGE_NAME) \
-		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip=validate --skip=publish
-
 .PHONY: release
 release:
 	docker run \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Configuration for goreleaser
 PACKAGE_NAME := github.com/onflow/flow-cli
 GOLANG_CROSS_VERSION ?= v1.20.0
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ generate: install-tools
 release:
 	docker run \
 		--rm \
-		-e CGO_ENABLED=1 \
 		--env-file .release-env \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Configuration for goreleaser
 PACKAGE_NAME := github.com/onflow/flow-cli
-GOLANG_CROSS_VERSION ?= v1.22.0
+GOLANG_CROSS_VERSION ?= v1.20.0
 
 # The short Git commit hash
 SHORT_COMMIT := $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Configuration for goreleaser
 PACKAGE_NAME := github.com/onflow/flow-cli
-GOLANG_CROSS_VERSION ?= v1.20.0
+GOLANG_CROSS_VERSION ?= v1.22.0
 
 # The short Git commit hash
 SHORT_COMMIT := $(shell git rev-parse --short HEAD)

--- a/go.mod
+++ b/go.mod
@@ -267,6 +267,3 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-// this is a woraround for the flow-go/crypto cross compliation issue
-replace github.com/onflow/crypto => github.com/onflow/crypto v0.24.9

--- a/go.sum
+++ b/go.sum
@@ -2057,8 +2057,8 @@ github.com/onflow/cadence-tools/test v1.0.0-M3 h1:ZbKoMhXsvafJIOO/MVE7lV5INXfq2I
 github.com/onflow/cadence-tools/test v1.0.0-M3/go.mod h1:Yk6OyiRMNseM6C13FpNUxTJ7GekYZMzdX5D2B10y4N8=
 github.com/onflow/contract-updater/lib/go/templates v1.0.1 h1:xPj898Y8OgLLbXH8+JeKVBV6J+nqPZjiLgGM3Abucto=
 github.com/onflow/contract-updater/lib/go/templates v1.0.1/go.mod h1:OXO6s0X7OW4Q6QTfAfnjoOmibEPgs0psOfMi+tPyzQE=
-github.com/onflow/crypto v0.24.9 h1:jYP1qdwid0qCineFzBFlxBchg710A7RuSWpTqxaOdog=
-github.com/onflow/crypto v0.24.9/go.mod h1:J/V7IEVaqjDajvF8K0B/SJPJDgAOP2G+LVLeb0hgmbg=
+github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
+github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/fcl-dev-wallet v0.8.0-stable-cadence.1 h1:IqdUzdqFCSW0klWmA3J9c17ZyQTab9SWcWSLouX6o0Q=
 github.com/onflow/fcl-dev-wallet v0.8.0-stable-cadence.1/go.mod h1:kc42jkiuoPJmxMRFjfbRO9XvnR/3XLheaOerxVMDTiw=
 github.com/onflow/flixkit-go v1.1.1-0.20240214222351-03b90f7d32ef h1:nPtuUuIMBcsl9T15qWzat8hYo6lU6ip2WKoYT2p9H4w=
@@ -2343,7 +2343,6 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
-github.com/supranational/blst v0.3.10/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
 github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=


### PR DESCRIPTION
### Description

Switches go-release-action to go-releaser & adds now cross compiles with `CGO_ENABLED=1`

Windows builds are excluded currently, pending a new flow-go release with https://github.com/onflow/flow-go/pull/5430

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
