### PR TITLE
Restore Windows Release

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,6 +9,7 @@ jobs:
     name: Release Go Binary
     runs-on: ubuntu-latest
     steps:
+      # See https://github.com/onflow/flow-cli/pull/1431 for more information
       - name: Delete unnecessary cache
         run: rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v3

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,6 +9,8 @@ jobs:
     name: Release Go Binary
     runs-on: ubuntu-latest
     steps:
+      - name: Delete unnecessary cache
+        run: rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v3
       - name: Codebase security check
         continue-on-error: true
@@ -17,9 +19,6 @@ jobs:
           go-version: '1.20'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.20"
       - name: Setup Release Environment
         run: |-
           echo 'MIXPANEL_PROJECT_TOKEN=${{ secrets.MIXPANEL_PROJECT_TOKEN }}' > .release-env

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Delete unnecessary cache
         run: |-
-          du -sh file_path
+          du -sh /opt/hostedtoolcache
           rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v3
       - name: Codebase security check

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # See https://github.com/onflow/flow-cli/pull/1431 for more information
       - name: Delete unnecessary cache
-        run: rm -rf /opt/hostedtoolcache
+        run: rm -rf ${RUNNER_TOOL_CACHE}
       - uses: actions/checkout@v3
       - name: Codebase security check
         continue-on-error: true

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete unnecessary cache
-        run: rm -rf /opt/hostedtoolcache
+        run: |-
+          du -sh file_path
+          rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v3
       - name: Codebase security check
         continue-on-error: true

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete unnecessary cache
-        run: |-
-          du -sh /opt/hostedtoolcache
-          rm -rf /opt/hostedtoolcache
+        run: rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v3
       - name: Codebase security check
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - run: du -sh /opt/hostedtoolcache
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: du -sh /opt/hostedtoolcache
+      - run: du -sh ${RUNNER_TOOL_CACHE}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: du -sh ${RUNNER_TOOL_CACHE}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,8 +25,8 @@ builds:
       - CXX_linux_arm64=aarch64-linux-gnu-g++
       - CC_windows_amd64=x86_64-w64-mingw32-gcc
       - CXX_windows_amd64=x86_64-w64-mingw32-g++
-      - CC_windows_arm64=aarch64-w64-mingw32-gcc
-      - CXX_windows_arm64=aarch64-w64-mingw32-g++
+      - CC_windows_arm64=/llvm-mingw/bin/aarch64-w64-mingw32-gcc
+      - CXX_windows_arm64=/llvm-mingw/bin/aarch64-w64-mingw32-g++
       - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
       - 'CXX={{ index .Env (print "CXX_" .Os "_" .Arch) }}'
     flags:


### PR DESCRIPTION
Restores Windows release now that downstream `flow-go` update has been picked up.  It was temporarily disabled on `feature/stable-cadence` branch

**NOTE**

The release has issues with it failing due to running out of disk space... https://github.com/onflow/flow-cli/actions/runs/8055491721/job/22002476997

Removing unnecessary tools in the GH Actions runner fixes this since everything runs in a docker container anyways https://github.com/onflow/flow-cli/actions/runs/8055802296/job/22003465082.

Maybe there's a better workaround (ie. just getting a larger actions runner) but this seems acceptable at least for the time being.
