### PR TITLE
Use .zip archives for Windows releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,9 @@ archives:
       - flow-cli
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
     wrap_in_directory: false
 snapshot:
   name_template: "{{ .Tag }}"


### PR DESCRIPTION
When the new build process was added, it was overlooked that Windows builds were placed in .zip and not .tar.gz.  This overrides the behaviour for Windows builds to restore original functionality.

All previous builds have been replaced with .zip & checksums have been updated.