### PR TITLE
Fix `flow version` output bug

### DIFF
--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -153,6 +153,11 @@ func main() {
 
 	cmd.SetUsageTemplate(command.UsageTemplate)
 
+	// Don't print usage on error
+	cmd.SilenceUsage = true
+	// Don't print errors on error (we handle them)
+	cmd.SilenceErrors = true
+
 	if err := cmd.Execute(); err != nil {
 		util.Exit(1, err.Error())
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,6 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"runtime/debug"
 	"strings"
 
@@ -45,12 +44,12 @@ func (c versionCmd) Print(format string) error {
 		txtBuilder.WriteString(fmt.Sprintf("Version: %s\n", c.Version))
 		txtBuilder.WriteString(fmt.Sprintf("Commit: %s\n", c.Commit))
 
-		txtBuilder.WriteString(fmt.Sprintf("\nFlow Package Dependencies \n"))
+		txtBuilder.WriteString("\nFlow Package Dependencies \n")
 		for _, dep := range c.Dependencies {
 			txtBuilder.WriteString(fmt.Sprintf("%s %s\n", dep.Path, dep.Version))
 		}
 
-		log.Println(txtBuilder.String())
+		fmt.Println(txtBuilder.String())
 
 		return nil
 
@@ -60,7 +59,7 @@ func (c versionCmd) Print(format string) error {
 			return err
 		}
 
-		log.Println(string(jsonRes))
+		fmt.Println(string(jsonRes))
 
 		return nil
 
@@ -99,7 +98,7 @@ func (c *versionCmd) MarshalJSON() ([]byte, error) {
 var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "View version and commit information",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		semver := build.Semver()
 		commit := build.Commit()
 
@@ -110,8 +109,7 @@ var Cmd = &cobra.Command{
 
 		bi, ok := debug.ReadBuildInfo()
 		if !ok {
-			log.Printf("Failed to read build info")
-			return
+			return fmt.Errorf("failed to read build info")
 		}
 
 		// only add dependencies from github.com/onflow
@@ -122,8 +120,9 @@ var Cmd = &cobra.Command{
 		}
 
 		if err := v.Print(command.Flags.Format); err != nil {
-			log.Printf("Failed to print version information: %s", err)
-			return
+			return err
 		}
+
+		return nil
 	},
 }


### PR DESCRIPTION
Closes #1489 

## Description

Fix flow version output to use stdout instead & remove log package use (not necessary, can be done via `RunE` in cobra, & this way exit code is also correct, was returning exit 0 always previously)

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
