### PR TITLE
Add check for latest Cadence 1.0 release

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -318,11 +318,11 @@ func checkVersionCadence1(logger output.Logger) {
 
 	var latestVersion string
 	for _, tag := range tags {
-		if tag["name"] == nil {
+		tagName, ok := tag["name"].(string)
+		if !ok {
 			continue
 		}
 
-		tagName := tag["name"].(string)
 		if strings.Contains(tagName, "cadence-v1.0.0") {
 			latestVersion = tagName
 			break

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -337,7 +337,7 @@ func checkVersionCadence1(logger output.Logger) {
 	if currentVersion != latestVersion && latestVersion != "" {
 		logger.Info(fmt.Sprintf(
 			"\n%s  Version warning: a new version of Flow CLI is available (%s).\n"+
-				"   Read the installation guide for upgrade instructions: https://docs.onflow.org/flow-cli/install\n",
+				"   Read the installation guide for upgrade instructions: https://cadence-lang.org/docs/cadence-migration-guide#install-cadence-10-cli\n",
 			output.WarningEmoji(),
 			strings.ReplaceAll(latestVersion, "\n", ""),
 		))

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -262,12 +262,9 @@ func createLogger(logFlag string, formatFlag string) output.Logger {
 // checkVersion fetches latest version and compares it to local.
 func checkVersion(logger output.Logger) {
 	currentVersion := build.Semver()
-	if isDevelopment() {
-		return // avoid warning in local development
-	}
 
 	// If using cadence-v1.0.0 pre-release, check for cadence-v1.0.0 releases instead
-	if strings.Contains(currentVersion, "cadence-v1.0.0") {
+	if strings.Contains(currentVersion, "cadence-v1.0.0") || true {
 		checkVersionCadence1(logger)
 		return
 	}
@@ -300,7 +297,7 @@ func checkVersion(logger output.Logger) {
 // checkVersionCadence1 fetches latest version of cadence-v1.0.0 and compares it to local.
 // This is a special case for cadence-v1.0.0 pre-release & should be removed when cadence-v1.0.0 branch is merged.
 func checkVersionCadence1(logger output.Logger) {
-	resp, err := http.Get("https://api.github.com/repos/onflow/flow-cli/releases?per_page=100")
+	resp, err := http.Get("https://api.github.com/repos/onflow/flow-cli/tags?per_page=100")
 	if err != nil || resp.StatusCode >= 400 {
 		return
 	}
@@ -313,20 +310,19 @@ func checkVersionCadence1(logger output.Logger) {
 	}(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
-	//parse json
-	var releases []map[string]interface{}
-	err = json.Unmarshal(body, &releases)
+	var tags []map[string]interface{}
+	err = json.Unmarshal(body, &tags)
 	if err != nil {
 		return
 	}
 
 	var latestVersion string
-	for _, release := range releases {
-		if release["tag_name"] == nil {
+	for _, tag := range tags {
+		if tag["name"] == nil {
 			continue
 		}
 
-		tagName := release["tag_name"].(string)
+		tagName := tag["name"].(string)
 		if strings.Contains(tagName, "cadence-v1.0.0") {
 			latestVersion = tagName
 			break

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -297,7 +297,8 @@ func checkVersion(logger output.Logger) {
 	}
 }
 
-// checkVersion fetches latest version and compares it to local.
+// checkVersionCadence1 fetches latest version of cadence-v1.0.0 and compares it to local.
+// This is a special case for cadence-v1.0.0 pre-release & should be removed when cadence-v1.0.0 branch is merged.
 func checkVersionCadence1(logger output.Logger) {
 	resp, err := http.Get("https://api.github.com/repos/onflow/flow-cli/releases?per_page=100")
 	if err != nil || resp.StatusCode >= 400 {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -262,9 +262,12 @@ func createLogger(logFlag string, formatFlag string) output.Logger {
 // checkVersion fetches latest version and compares it to local.
 func checkVersion(logger output.Logger) {
 	currentVersion := build.Semver()
+	if isDevelopment() {
+		return // avoid warning in local development
+	}
 
 	// If using cadence-v1.0.0 pre-release, check for cadence-v1.0.0 releases instead
-	if strings.Contains(currentVersion, "cadence-v1.0.0") || true {
+	if strings.Contains(currentVersion, "cadence-v1.0.0") {
 		checkVersionCadence1(logger)
 		return
 	}


### PR DESCRIPTION
Closes #1411

## Description

Adds a check for latest cadence 1.0 release.  We should remove this when `feature/stable-cadence` is merged into master, but if this is forgotten about, it shouldn't cause any issues either.

It's probably a good idea to have this so developers don't run into resolved issues since it's hard to track latest CLI versions/if you're using outdated CLI.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
