### PR TITLE
Add missing `is-validated` command

### DIFF
--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -37,6 +37,7 @@ func init() {
 	stageContractCommand.AddToParent(Cmd)
 	unstageContractCommand.AddToParent(Cmd)
 	stateCommand.AddToParent(Cmd)
+	IsValidatedCommand.AddToParent(Cmd)
 }
 
 var Cmd = &cobra.Command{


### PR DESCRIPTION
Closes #???

## Description

The `is-validated` command is currently missing from the lastest CLI release.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
