### PR TITLE
Update to latest Cadence Language Server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/logrusorgru/aurora/v4 v4.0.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/onflow/cadence v0.42.10
-	github.com/onflow/cadence-tools/languageserver v0.33.5-0.20240412233530-f5cf3a868fc6
+	github.com/onflow/cadence-tools/languageserver v0.33.5
 	github.com/onflow/cadence-tools/lint v0.14.2
 	github.com/onflow/cadence-tools/test v0.14.7
 	github.com/onflow/fcl-dev-wallet v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,8 @@ github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
 github.com/onflow/cadence v0.42.10 h1:3oC5ceeXhdCrhHcf9H0yYXQKW3Tw/vkSXLe+PUZa4i0=
 github.com/onflow/cadence v0.42.10/go.mod h1:1wFd+LiNiN6qoZXof3MBdpM6d8BsxbVIxOA77LbIYmE=
-github.com/onflow/cadence-tools/languageserver v0.33.5-0.20240412233530-f5cf3a868fc6 h1:6XjFYV1qa3FJgZSkBEvS7T9IHRz/PZoc2SpCNZTFfrQ=
-github.com/onflow/cadence-tools/languageserver v0.33.5-0.20240412233530-f5cf3a868fc6/go.mod h1:euGucPAVixPrlTyYGnsZTHg65u7C6zdmfRJlVwRgMaI=
+github.com/onflow/cadence-tools/languageserver v0.33.5 h1:Tg2YniU+ZJPI9RlTOuguqkLriUaFXue6FNXM+Ewijgo=
+github.com/onflow/cadence-tools/languageserver v0.33.5/go.mod h1:euGucPAVixPrlTyYGnsZTHg65u7C6zdmfRJlVwRgMaI=
 github.com/onflow/cadence-tools/lint v0.14.2 h1:WGh6ARN9MRVeYID3OnlalPtDTeYkliteHHR+ITCh/J4=
 github.com/onflow/cadence-tools/lint v0.14.2/go.mod h1:PlYwSF4wwpCtQJKs1cQAb80AG90a4rhADTitCogQ4UE=
 github.com/onflow/cadence-tools/test v0.14.7 h1:o4tHQLvxLGlG6mFyDl2vFYFtoTLCFJVxuJQ16ab+3u4=


### PR DESCRIPTION
## Description

Last Friday there was a bit of a rush to make a release to fix a semi-urgent bug, so a commit hash was used for the Cadence Language Server in order to push this through quickly.  Now that a new tagged release has been made (albeit identical to the commit hash used) we should use this instead.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
