### PR TITLE
Update EVM Gateway to latest version & add Previewnet chain ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onflow/flixkit-go v1.2.1-cadence-v1-preview.10
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240402184019-90048578066e
 	github.com/onflow/flow-emulator v1.0.0-preview.18
-	github.com/onflow/flow-evm-gateway v0.5.1-0.20240412143816-f27b2f135b79
+	github.com/onflow/flow-evm-gateway v0.5.1-0.20240414162736-e85fa156688b
 	github.com/onflow/flow-go v0.34.0-crescendo-preview.10.0.20240412141002-8081bde9d8a7
 	github.com/onflow/flow-go-sdk v1.0.0-preview.18
 	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.14

--- a/go.sum
+++ b/go.sum
@@ -2098,8 +2098,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240402184019-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240402184019-90048578066e/go.mod h1:CA6ON8bUZWkZnlhYNsvs3Pox1G6dFtBp/wPZSQA7ivQ=
 github.com/onflow/flow-emulator v1.0.0-preview.18 h1:ZrlUzPTF1gYjMsg8k6x5DvgnCjcHJrvvio9K8ImlNXY=
 github.com/onflow/flow-emulator v1.0.0-preview.18/go.mod h1:GSJ8GCxNMdjBEpeg77KM19mFxIQL9dg98KJgLG0/2DI=
-github.com/onflow/flow-evm-gateway v0.5.1-0.20240412143816-f27b2f135b79 h1:bNHudrSCSejR7LBWkmiujNv02SbmuzkhxPVy59Xqo78=
-github.com/onflow/flow-evm-gateway v0.5.1-0.20240412143816-f27b2f135b79/go.mod h1:AGZhLWHmsQSWCk96FC6xQ6gjcxlIN2Bng3RRrtkRa7M=
+github.com/onflow/flow-evm-gateway v0.5.1-0.20240414162736-e85fa156688b h1:YDw6ikc3sW7Jzezf59VXuoKEKCSi5GuX+R2MelPNM10=
+github.com/onflow/flow-evm-gateway v0.5.1-0.20240414162736-e85fa156688b/go.mod h1:AGZhLWHmsQSWCk96FC6xQ6gjcxlIN2Bng3RRrtkRa7M=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240402160548-a9c331660956 h1:WbG97gmdbgfYZT8YCyye0fAwz4k5vditXcPGoy63m9M=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240402160548-a9c331660956/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956 h1:Ef9UKtwNcHVG2R8YskYiwRoaTZFhAVmQ0ZN3c0eDUGU=

--- a/internal/evm/gateway.go
+++ b/internal/evm/gateway.go
@@ -56,7 +56,7 @@ type gatewayFlag struct {
 	RPCPort            int    `flag:"rpc-port" default:"3000" info:"port for the RPC API server"`
 	AccessNodeGRPCHost string `flag:"access-node-grpc-host" default:"localhost:3569" info:"host to the flow access node gRPC API"`
 	InitCadenceHeight  uint64 `flag:"init-cadence-height" default:"0" info:"init cadence block height from where the event ingestion will start. WARNING: you should only provide this if there are no existing values in the database, otherwise an error will be thrown"`
-	EVMNetworkID       string `flag:"evm-network-id" default:"testnet" info:"EVM network ID (testnet, mainnet)"`
+	EVMNetworkID       string `flag:"evm-network-id" default:"testnet" info:"EVM network ID (testnet, mainnet, previewnet)"`
 	FlowNetworkID      string `flag:"flow-network-id" default:"emulator" info:"EVM network ID (emulator, previewnet)"`
 	Coinbase           string `flag:"coinbase" default:"" info:"coinbase address to use for fee collection"`
 	GasPrice           string `flag:"gas-price" default:"1" info:"static gas price used for EVM transactions"`
@@ -123,6 +123,8 @@ var gatewayCommand = &command.Command{
 			cfg.EVMNetworkID = types.FlowEVMTestNetChainID
 		case "mainnet":
 			cfg.EVMNetworkID = types.FlowEVMMainNetChainID
+		case "previewnet":
+			cfg.EVMNetworkID = types.FlowEVMPreviewNetChainID
 		default:
 			return nil, fmt.Errorf("EVM network ID not supported")
 		}

--- a/internal/evm/gateway.go
+++ b/internal/evm/gateway.go
@@ -56,7 +56,7 @@ type gatewayFlag struct {
 	RPCPort            int    `flag:"rpc-port" default:"3000" info:"port for the RPC API server"`
 	AccessNodeGRPCHost string `flag:"access-node-grpc-host" default:"localhost:3569" info:"host to the flow access node gRPC API"`
 	InitCadenceHeight  uint64 `flag:"init-cadence-height" default:"0" info:"init cadence block height from where the event ingestion will start. WARNING: you should only provide this if there are no existing values in the database, otherwise an error will be thrown"`
-	EVMNetworkID       string `flag:"evm-network-id" default:"testnet" info:"EVM network ID (testnet, mainnet, previewnet)"`
+	EVMNetworkID       string `flag:"evm-network-id" default:"previewnet" info:"EVM network ID (testnet, mainnet, previewnet)"`
 	FlowNetworkID      string `flag:"flow-network-id" default:"emulator" info:"EVM network ID (emulator, previewnet)"`
 	Coinbase           string `flag:"coinbase" default:"" info:"coinbase address to use for fee collection"`
 	GasPrice           string `flag:"gas-price" default:"1" info:"static gas price used for EVM transactions"`


### PR DESCRIPTION
## Description

Some cleanup from the release last week where we had to use a commit hash to update the gateway to be compatible with `flow-go` & adds previewnet EVM chain ID.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
