### PR TITLE
Fix `access(account)` bug in contract update validator

### DIFF
--- a/internal/migrate/staging_validator.go
+++ b/internal/migrate/staging_validator.go
@@ -104,6 +104,9 @@ func (v *stagingValidator) ValidateContractUpdate(
 	// Code of the updated contract
 	updatedCode []byte,
 ) error {
+	v.sourceCodeLocation = sourceCodeLocation
+	v.targetLocation = location
+
 	// Resolve all system contract code & add to cache
 	v.loadSystemContracts()
 

--- a/internal/migrate/staging_validator.go
+++ b/internal/migrate/staging_validator.go
@@ -401,6 +401,8 @@ func (v *stagingValidator) resolveAccountAccess(checker *sema.Checker, memberLoc
 		return false
 	}
 
+	// If the source code of the update is being checked, we should check account access based on the
+	// targetted network location of the contract & not the source code location
 	if checkerLocation == v.sourceCodeLocation && memberAddressLocation.Address == v.targetLocation.Address {
 		return true
 	}

--- a/internal/migrate/staging_validator.go
+++ b/internal/migrate/staging_validator.go
@@ -391,6 +391,10 @@ func (v *stagingValidator) resolveLocation(
 }
 
 func (v *stagingValidator) resolveAccountAccess(checker *sema.Checker, memberLocation common.Location) bool {
+	if checker == nil {
+		return false
+	}
+
 	checkerLocation, ok := checker.Location.(common.StringLocation)
 	if !ok {
 		return false
@@ -403,11 +407,7 @@ func (v *stagingValidator) resolveAccountAccess(checker *sema.Checker, memberLoc
 
 	// If the source code of the update is being checked, we should check account access based on the
 	// targeted network location of the contract & not the source code location
-	if checkerLocation == v.sourceCodeLocation && memberAddressLocation.Address == v.targetLocation.Address {
-		return true
-	}
-
-	return false
+	return checkerLocation == v.sourceCodeLocation && memberAddressLocation.Address == v.targetLocation.Address
 }
 
 func (v *stagingValidator) resolveAddressContractNames(address common.Address) ([]string, error) {

--- a/internal/migrate/staging_validator.go
+++ b/internal/migrate/staging_validator.go
@@ -402,7 +402,7 @@ func (v *stagingValidator) resolveAccountAccess(checker *sema.Checker, memberLoc
 	}
 
 	// If the source code of the update is being checked, we should check account access based on the
-	// targetted network location of the contract & not the source code location
+	// targeted network location of the contract & not the source code location
 	if checkerLocation == v.sourceCodeLocation && memberAddressLocation.Address == v.targetLocation.Address {
 		return true
 	}


### PR DESCRIPTION
Closes #1524

## Description

Fixes bug related to `access(account)` not resolving properly due to use of string location for the staged contract checker.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
