### PR TITLE
Fix bug from `flow deps add` command missing Flags field

### DIFF
--- a/internal/dependencymanager/add.go
+++ b/internal/dependencymanager/add.go
@@ -20,6 +20,7 @@ package dependencymanager
 
 import (
 	"fmt"
+
 	"github.com/onflow/flow-cli/internal/util"
 
 	"github.com/spf13/cobra"
@@ -46,7 +47,8 @@ var addCommand = &command.Command{
 		Example: "flow dependencies add testnet://0afe396ebc8eee65.FlowToken",
 		Args:    cobra.ExactArgs(1),
 	},
-	RunS: add,
+	RunS:  add,
+	Flags: &struct{}{},
 }
 
 func init() {


### PR DESCRIPTION
## Description

There's a bug in dependency manager command flags causing an error to always be shown at startup.  This is a quick patch to work around it.

<img width="504" alt="Screenshot 2024-04-24 at 6 07 00 PM" src="https://github.com/onflow/flow-cli/assets/17958158/65ead006-f4c6-4b29-8162-8e619c0c2c7a">

It's displaying this "specification must be a struct pointer" message, probably coming from some reflection happening inside sconfig where it doesn't like missing flags.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
