### PR TITLE
Use Homebrew latest version instead of version.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ You can also release manually although this is not recommended:
 
 To make the new version the default version that is installed
 
-- Change `version.txt` and commit it
+- **DEPRECATED** Change `version.txt` and commit it.  (This file is no longer user for versions of the Flow CLI later than v1.18.0, although it should still be maintained to support older versions of the CLI for a while)
 
 ## Adding a scaffold
 You can add your own scaffold by creating a GitHub repository containing the scaffold content and then making a PR 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -21,6 +21,7 @@ package command
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -260,7 +261,7 @@ func createLogger(logFlag string, formatFlag string) output.Logger {
 
 // checkVersion fetches latest version and compares it to local.
 func checkVersion(logger output.Logger) {
-	resp, err := http.Get("https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt")
+	resp, err := http.Get("https://formulae.brew.sh/api/formula/flow-cli.json")
 	if err != nil || resp.StatusCode >= 400 {
 		return
 	}
@@ -273,7 +274,21 @@ func checkVersion(logger output.Logger) {
 	}(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
-	latestVersion := strings.TrimSpace(string(body))
+	var data map[string]interface{}
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return
+	}
+
+	versions, ok := data["versions"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	latestVersion, ok := versions["stable"].(string)
+	if !ok {
+		return
+	}
 
 	currentVersion := build.Semver()
 	if isDevelopment() {
@@ -282,7 +297,7 @@ func checkVersion(logger output.Logger) {
 
 	if currentVersion != latestVersion {
 		logger.Info(fmt.Sprintf(
-			"\n%s  Version warning: a new version of Flow CLI is available (%s).\n"+
+			"\n%s  Version warning: a new version of Flow CLI is available (v%s).\n"+
 				"   Read the installation guide for upgrade instructions: https://docs.onflow.org/flow-cli/install\n",
 			output.WarningEmoji(),
 			strings.ReplaceAll(latestVersion, "\n", ""),


### PR DESCRIPTION
Closes #1542 

## Description

goodbye version.txt 🫡

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
