### PR TITLE
Default `flow test` behaviour to test `**/*_test.cdc`

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -74,10 +74,10 @@ var testFlags = flagsTests{}
 
 var TestCommand = &command.Command{
 	Cmd: &cobra.Command{
-		Use:     "test <filename>",
+		Use:     "test [filenames]",
 		Short:   "Run Cadence tests",
-		Example: `flow test script.cdc`,
-		Args:    cobra.MinimumNArgs(1),
+		Example: `flow test`,
+		Args:    cobra.ArbitraryArgs,
 		GroupID: "tools",
 	},
 	Flags: &testFlags,
@@ -101,8 +101,22 @@ func run(
 		)
 	}
 
+	var filenames []string
+	if len(args) == 0 {
+		filenames, err := filepath.Glob("**/*_test.cdc")
+		if err != nil {
+			return nil, fmt.Errorf("error loading script files: %w", err)
+		}
+
+		if len(filenames) == 0 {
+			return nil, fmt.Errorf("no test files found matching the pattern *_test.cdc")
+		}
+	} else {
+		filenames = args
+	}
+
 	testFiles := make(map[string][]byte, 0)
-	for _, filename := range args {
+	for _, filename := range filenames {
 		code, err := state.ReadFile(filename)
 		if err != nil {
 			return nil, fmt.Errorf("error loading script file: %w", err)

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -359,14 +359,18 @@ func (r *result) String() string {
 	var b bytes.Buffer
 	writer := util.CreateTabWriter(&b)
 
-	for scriptPath, testResult := range r.Results {
-		_, _ = fmt.Fprint(writer, cdcTests.PrettyPrintResults(testResult, scriptPath))
-	}
-	if r.CoverageReport != nil {
-		_, _ = fmt.Fprint(writer, r.CoverageReport.String())
-	}
-	if r.RandomSeed > 0 {
-		_, _ = fmt.Fprintf(writer, "\nSeed: %d", r.RandomSeed)
+	if len(r.Results) == 0 {
+		_, _ = fmt.Fprint(writer, "No tests found")
+	} else {
+		for scriptPath, testResult := range r.Results {
+			_, _ = fmt.Fprint(writer, cdcTests.PrettyPrintResults(testResult, scriptPath))
+		}
+		if r.CoverageReport != nil {
+			_, _ = fmt.Fprint(writer, r.CoverageReport.String())
+		}
+		if r.RandomSeed > 0 {
+			_, _ = fmt.Fprintf(writer, "\nSeed: %d", r.RandomSeed)
+		}
 	}
 
 	_ = writer.Flush()

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -110,13 +110,10 @@ func run(
 
 	var filenames []string
 	if len(args) == 0 {
-		filenames, err := filepath.Glob(defaultGlobPattern)
+		var err error
+		filenames, err = filepath.Glob(defaultGlobPattern)
 		if err != nil {
 			return nil, fmt.Errorf("error loading script files: %w", err)
-		}
-
-		if len(filenames) == 0 {
-			return nil, fmt.Errorf("no test files found matching the pattern *_test.cdc")
 		}
 	} else {
 		filenames = args

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -61,6 +61,9 @@ const helperScriptSubstr = "_helper"
 // scripts and transactions are excluded from coverage report.
 const contractsCoverCode = "contracts"
 
+// The default glob pattern to find test files.
+const defaultGlobPattern = "**/*_test.cdc"
+
 type flagsTests struct {
 	Cover        bool   `default:"false" flag:"cover" info:"Use the cover flag to calculate coverage report"`
 	CoverProfile string `default:"coverage.json" flag:"coverprofile" info:"Filename to write the calculated coverage report. Supported extensions are .json and .lcov"`
@@ -74,9 +77,13 @@ var testFlags = flagsTests{}
 
 var TestCommand = &command.Command{
 	Cmd: &cobra.Command{
-		Use:     "test [filenames]",
-		Short:   "Run Cadence tests",
-		Example: `flow test`,
+		Use:   "test [files...]",
+		Short: "Run Cadence tests",
+		Example: fmt.Sprintf(`# Run tests in files matching the default pattern %s
+flow test
+
+# Run tests in the specified files
+flow test test1.cdc test2.cdc`, defaultGlobPattern),
 		Args:    cobra.ArbitraryArgs,
 		GroupID: "tools",
 	},
@@ -103,7 +110,7 @@ func run(
 
 	var filenames []string
 	if len(args) == 0 {
-		filenames, err := filepath.Glob("**/*_test.cdc")
+		filenames, err := filepath.Glob(defaultGlobPattern)
 		if err != nil {
 			return nil, fmt.Errorf("error loading script files: %w", err)
 		}


### PR DESCRIPTION
Closes #1378 

## Description

Removes mandatory requirement for specifying test file names and defaults to `**/*_test.cdc` (not a breaking change).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
