### PR TITLE
include verbose flag for version call

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -30,6 +30,12 @@ import (
 	"github.com/onflow/flow-cli/internal/command"
 )
 
+var verboseFlag bool
+
+func init() {
+	Cmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Show detailed dependency information")
+}
+
 type versionCmd struct {
 	Version      string
 	Commit       string
@@ -44,9 +50,11 @@ func (c versionCmd) Print(format string) error {
 		txtBuilder.WriteString(fmt.Sprintf("Version: %s\n", c.Version))
 		txtBuilder.WriteString(fmt.Sprintf("Commit: %s\n", c.Commit))
 
-		txtBuilder.WriteString("\nFlow Package Dependencies \n")
-		for _, dep := range c.Dependencies {
-			txtBuilder.WriteString(fmt.Sprintf("%s %s\n", dep.Path, dep.Version))
+		if verboseFlag {
+			txtBuilder.WriteString("\nFlow Package Dependencies \n")
+			for _, dep := range c.Dependencies {
+				txtBuilder.WriteString(fmt.Sprintf("%s %s\n", dep.Path, dep.Version))
+			}
 		}
 
 		fmt.Println(txtBuilder.String())


### PR DESCRIPTION
Closes #1546 

## Description

![image](https://github.com/onflow/flow-cli/assets/6364887/48539e27-d8ef-4cb0-a6f6-2d688226af55)


- add a defaulted false `--verbose` flag to show dependenices on `version`
