### PR TITLE
Handle transaction result errors in `flow migrate stage`

### DIFF
--- a/internal/migrate/staging_service.go
+++ b/internal/migrate/staging_service.go
@@ -211,7 +211,7 @@ func (s *stagingServiceImpl) stageContract(ctx context.Context, contract stagedC
 		return flow.Identifier{}, fmt.Errorf("failed to get account for contract %s: %w", contract.DeployLocation.Name, err)
 	}
 
-	tx, _, err := s.flow.SendTransaction(
+	_, res, err := s.flow.SendTransaction(
 		context.Background(),
 		transactions.SingleAccountRole(*account),
 		flowkit.Script{
@@ -224,7 +224,11 @@ func (s *stagingServiceImpl) stageContract(ctx context.Context, contract stagedC
 		return flow.Identifier{}, err
 	}
 
-	return tx.ID(), nil
+	if res.Error != nil {
+		return res.TransactionID, fmt.Errorf("failed to stage contract: %w", res.Error)
+	}
+
+	return res.TransactionID, nil
 }
 
 func (s *stagingServiceImpl) hasStagedContractChanged(contract stagedContractUpdate) bool {


### PR DESCRIPTION
## Description

Errors while staging a contract (related to a failed transaction) are not properly reported.  This handles that case.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
