### PR TITLE
Fix EVM gateway unsupported network

### DIFF
--- a/internal/evm/gateway.go
+++ b/internal/evm/gateway.go
@@ -129,10 +129,6 @@ var gatewayCommand = &command.Command{
 			return nil, fmt.Errorf("EVM network ID not supported")
 		}
 
-		if cfg.FlowNetworkID != "previewnet" && cfg.FlowNetworkID != "emulator" {
-			return nil, fmt.Errorf("flow network ID is invalid, only allowed to set 'emulator' and 'previewnet'")
-		}
-
 		ctx, cancel := context.WithCancel(context.Background())
 
 		err = bootstrap.Start(ctx, cfg)


### PR DESCRIPTION
Closes #1620 

## Description

There were two checks for networks, this removes the problematic one (was comparing `flow-emulator` to `emulator` so always failing)

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
