### PR TITLE
Notify user if missing flag args on create account

### DIFF
--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -57,12 +57,18 @@ var createCommand = &command.Command{
 
 func create(
 	_ []string,
-	_ command.GlobalFlags,
-	_ output.Logger,
+	globalFlags command.GlobalFlags,
+	logger output.Logger,
 	flow flowkit.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
 	if len(createFlags.Keys) == 0 { // if user doesn't provide any flags go into interactive mode
+
+		// if user has flags, but doesn't provide any keys, notify them before switching into interactive mode
+		if len(createFlags.SigAlgo) > 0 || globalFlags.Network != "" {
+			logger.Info("Warning: You provided flags as arguments but no key. Switching to interactive mode.")
+		}
+
 		return createInteractive(state)
 	} else {
 		return createManual(state, flow)

--- a/internal/accounts/create.go
+++ b/internal/accounts/create.go
@@ -64,12 +64,12 @@ func create(
 ) (command.Result, error) {
 	if len(createFlags.Keys) == 0 { // if user doesn't provide any flags go into interactive mode
 
-		// if user has flags, but doesn't provide any keys, notify them before switching into interactive mode
 		if len(createFlags.SigAlgo) > 0 || globalFlags.Network != "" {
-			logger.Info("Warning: You provided flags as arguments but no key. Switching to interactive mode.")
+			return nil, fmt.Errorf("You provided flags, but no key. A key is required to create an account in manual mode. Remove flags if you'd like to use interactive mode.")
+		} else {
+			return createInteractive(state)
 		}
 
-		return createInteractive(state)
 	} else {
 		return createManual(state, flow)
 	}


### PR DESCRIPTION
Closes #1658 

## Description

Manual mode requires a key. Warn a user if they are missing the key flag before switching to interactive mode.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
