### PR TITLE
Fix EVM contract migration

### DIFF
--- a/internal/migrate/state.go
+++ b/internal/migrate/state.go
@@ -96,7 +96,8 @@ func migrateState(
 	err = emulatorMigrate.MigrateCadence1(
 		store,
 		stateFlags.SaveReport,
-		migrations.EVMContractChangeNone,
+		// Should match https://github.com/onflow/flow-go/blob/2a1e71eb64e200c7d82e8e31602c397f1939c893/cmd/util/cmd/execution-state-extract/cmd.go#L380-L381
+		migrations.EVMContractChangeDeployMinimalAndUpdateFull,
 		migrations.BurnerContractChangeDeploy,
 		contracts,
 		rwf,


### PR DESCRIPTION
Ref: https://discord.com/channels/613813861610684416/621847426201944074/1276096924906291222

## Description

Deploy the minimal EVM contract and update to the full contract, as the protocol (flow-go / Emulator) now performs heartbeats and needs the contract to exist.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
