### PR TITLE
State migration: Handle missing contract names flag

### DIFF
--- a/internal/migrate/state.go
+++ b/internal/migrate/state.go
@@ -59,12 +59,19 @@ var stateCommand = &command.Command{
 }
 
 func migrateState(
-	args []string,
+	_ []string,
 	globalFlags command.GlobalFlags,
 	_ output.Logger,
-	flow flowkit.Services,
+	_ flowkit.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
+
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+
+	if len(stateFlags.Contracts) == 0 {
+		logger.Warn().Msg("no contract names provided, no contracts will be migrated! Use --contracts flag to specify contracts to migrate")
+	}
+
 	if globalFlags.Network != config.EmulatorNetwork.Name {
 		return nil, fmt.Errorf("state migration is only supported for the emulator network")
 	}
@@ -78,8 +85,6 @@ func migrateState(
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
-
-	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
 
 	// Create a report writer factory if a report path is provided
 	var rwf reporters.ReportWriterFactory


### PR DESCRIPTION

## Description

When no contract names are provided, the state is still migrated, but none of the user's contracts are migrated. Users might not know of the flag or expect that by default all contracts are updated.
See for example https://discord.com/channels/613813861610684416/1276096924906291222.

Improve the UX by defaulting to all contract names of all deployments. If there still no contract names, warn that the state migration is run without any (user) contracts being updated.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
