### PR TITLE
Add testnet/mainnet to EVM gateway

### DIFF
--- a/internal/evm/gateway.go
+++ b/internal/evm/gateway.go
@@ -56,8 +56,8 @@ type gatewayFlag struct {
 	RPCPort           int    `flag:"rpc-port" default:"3000" info:"port for the RPC API server"`
 	AccessNodeHost    string `flag:"access-node-host" default:"localhost:3569" info:"host to the flow access node gRPC API"`
 	InitCadenceHeight uint64 `flag:"init-cadence-height" default:"0" info:"init cadence block height from where the event ingestion will start. WARNING: you should only provide this if there are no existing values in the database, otherwise an error will be thrown"`
-	EVMNetworkID      string `flag:"evm-network-id" default:"previewnet" info:"EVM network ID (testnet, mainnet, previewnet)"`
-	FlowNetworkID     string `flag:"flow-network-id" default:"emulator" info:"EVM network ID (emulator, previewnet)"`
+	EVMNetworkID      string `flag:"evm-network-id" default:"testnet" info:"EVM network ID (testnet, mainnet, previewnet)"`
+	FlowNetworkID     string `flag:"flow-network-id" default:"emulator" info:"EVM network ID (emulator, previewnet, testnet, mainnet)"`
 	Coinbase          string `flag:"coinbase" default:"" info:"coinbase address to use for fee collection"`
 	GasPrice          string `flag:"gas-price" default:"1" info:"static gas price used for EVM transactions"`
 	COAAddress        string `flag:"coa-address" default:"" info:"Flow address that holds COA account used for submitting transactions"`
@@ -110,12 +110,16 @@ var gatewayCommand = &command.Command{
 		cfg.COAKey = pkey
 
 		switch flagGateway.FlowNetworkID {
+		case "mainnet":
+			cfg.FlowNetworkID = flowGo.Mainnet
+		case "testnet":
+			cfg.FlowNetworkID = flowGo.Testnet
 		case "previewnet":
 			cfg.FlowNetworkID = flowGo.Previewnet
 		case "emulator":
 			cfg.FlowNetworkID = flowGo.Emulator
 		default:
-			return nil, fmt.Errorf("flow network ID not supported, only possible to specify 'previewnet' or 'emulator'")
+			return nil, fmt.Errorf("flow network ID not supported, only possible to specify emulator, testnet, previewnet, mainnet")
 		}
 
 		switch flagGateway.EVMNetworkID {


### PR DESCRIPTION
Closes #???

## Description

Add EVM Gateway options for `testnet` & `mainnet`

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
