### PR TITLE
Add back updated project scaffolds

### DIFF
--- a/scaffolds.json
+++ b/scaffolds.json
@@ -5,5 +5,17 @@
     "description": "Simple TypeScript web application using next.js, FCL, and Cadence.",
     "commit": "3a5d4f87eef72cebf45f1c48c51c2b786b28f7b6",
     "type": "web"
+  },
+  {
+    "name": "Simple Cadence Project",
+    "repo": "https://github.com/sideninja/flow-basic-scaffold.git",
+    "description": "Scaffold contains required folder structure as well as some example Cadence code.",
+    "commit": "todo define commit"
+  },
+  {
+    "name": "Cadence NFT Project",
+    "repo": "https://github.com/nvdtf/flow-nft-scaffold.git",
+    "description": "Scaffold contains the ExampleNFT sample NFT contract.",
+    "commit": "todo define commit"
   }
 ]


### PR DESCRIPTION
## Description

Adds back project scaffolds that were migrated to Cadence v1.0. This is in draft, since the dependant PRs haven't been merged yet, so the commit hash is not yet known.

Depends on:
- https://github.com/sideninja/flow-basic-scaffold/pull/2
- https://github.com/nvdtf/flow-nft-scaffold/pull/6

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
