### PR TITLE
Fix alias adding in Dependency Manager if no dependency yet

### DIFF
--- a/internal/dependencymanager/dependencyinstaller.go
+++ b/internal/dependencymanager/dependencyinstaller.go
@@ -446,8 +446,15 @@ func (di *DependencyInstaller) handleFoundContract(networkName, contractAddr, as
 		}
 	}
 
+	err := di.updateDependencyState(networkName, contractAddr, assignedName, contractName, originalContractDataHash)
+	if err != nil {
+		di.Logger.Error(fmt.Sprintf("Error updating state: %v", err))
+		return err
+	}
+
 	// Needs to happen before handleFileSystem
 	if !di.contractFileExists(contractAddr, contractName) {
+		fmt.Println("Contract file does not exist")
 		err := di.handleAdditionalDependencyTasks(networkName, contractName)
 		if err != nil {
 			di.Logger.Error(fmt.Sprintf("Error handling additional dependency tasks: %v", err))
@@ -455,15 +462,9 @@ func (di *DependencyInstaller) handleFoundContract(networkName, contractAddr, as
 		}
 	}
 
-	err := di.handleFileSystem(contractAddr, contractName, contractData, networkName)
+	err = di.handleFileSystem(contractAddr, contractName, contractData, networkName)
 	if err != nil {
 		return fmt.Errorf("error handling file system: %w", err)
-	}
-
-	err = di.updateDependencyState(networkName, contractAddr, assignedName, contractName, originalContractDataHash)
-	if err != nil {
-		di.Logger.Error(fmt.Sprintf("Error updating state: %v", err))
-		return err
 	}
 
 	return nil

--- a/internal/dependencymanager/dependencyinstaller.go
+++ b/internal/dependencymanager/dependencyinstaller.go
@@ -454,7 +454,6 @@ func (di *DependencyInstaller) handleFoundContract(networkName, contractAddr, as
 
 	// Needs to happen before handleFileSystem
 	if !di.contractFileExists(contractAddr, contractName) {
-		fmt.Println("Contract file does not exist")
 		err := di.handleAdditionalDependencyTasks(networkName, contractName)
 		if err != nil {
 			di.Logger.Error(fmt.Sprintf("Error handling additional dependency tasks: %v", err))


### PR DESCRIPTION
Closes #1800 

## Description

Entering an alias was failing if the dependency didn't exist in flow.json yet. Changes the order of operations to add the dependency to the state before doing any additional tasks.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
