### PR TITLE
Add network to mixpanel metrics

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -378,16 +378,11 @@ func UsageMetrics(command *cobra.Command, wg *sync.WaitGroup) {
 	hash := sha256.Sum256([]byte(fmt.Sprintf("%s%s", usr.Username, usr.Uid)))
 	userID := base64.StdEncoding.EncodeToString(hash[:])
 
-	network := Flags.Network
-	if network == "" {
-		network = config.EmulatorNetwork.Name
-	}
-
 	_ = client.Track(userID, "cli-command", &mixpanel.Event{
 		IP: "0", // do not track IPs
 		Properties: map[string]any{
 			"command": command.CommandPath(),
-			"network": network,
+			"network": Flags.Network,
 			"version": build.Semver(),
 			"os":      runtime.GOOS,
 		},


### PR DESCRIPTION
Closes #1863 

## Description

Adds value of the network flag to metrics

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
