### PR TITLE
Added ci property to understand if a command is run by CI

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -385,6 +385,7 @@ func UsageMetrics(command *cobra.Command, wg *sync.WaitGroup) {
 			"network": Flags.Network,
 			"version": build.Semver(),
 			"os":      runtime.GOOS,
+			"ci":      os.Getenv("CI") != "", // CI is commonly set by CI providers
 		},
 	})
 	wg.Done()


### PR DESCRIPTION
Closes #1926 

## Description

Added "ci" property to data sent to mixpanel while running a command, to understand if the command is run by a ci provider or not.