### PR TITLE
Add .env to generated .gitignore

### DIFF
--- a/internal/super/setup.go
+++ b/internal/super/setup.go
@@ -115,7 +115,7 @@ func updateGitignore(targetDir string) error {
 	}
 	defer f.Close()
 
-	_, err = f.WriteString("\n# flow\nemulator-account.pkey\nimports\n")
+	_, err = f.WriteString("\n# flow\nemulator-account.pkey\nimports\n.env\n")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #???

## Description

Solidity developers will expect the tools to generate a .gitignore with .env in it.

They may not realize it is not present and commit a private key for a wallet.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
