### PR TITLE
refactor: use strings.builder

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
@@ -91,21 +92,21 @@ func (e *EventResult) String() string {
 }
 
 func (e *EventResult) Oneliner() string {
-	result := ""
+	var result strings.Builder
 	for _, blockEvent := range e.BlockEvents {
 		if len(blockEvent.Events) > 0 {
-			result += fmt.Sprintf("Events Block #%v: [", blockEvent.Height)
+			result.WriteString(fmt.Sprintf("Events Block #%v: [", blockEvent.Height))
 			for _, event := range blockEvent.Events {
-				result += fmt.Sprintf(
+				result.WriteString(fmt.Sprintf(
 					"Index: %v, Type: %v, TxID: %s, Value: %v",
 					event.EventIndex, event.Type, event.TransactionID, event.Value,
-				)
+				))
 			}
-			result += "] "
+			result.WriteString("] ")
 		}
 	}
 
-	return result
+	return result.String()
 }
 
 func eventsString(writer io.Writer, events []flow.Event) {


### PR DESCRIPTION
Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The modernize has added an analyzer for using strings.Builder for string construction. strings.Builder has fewer memory allocations and better performance.

More info: https://github.com/golang/go/issues/75190

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
