### PR TITLE
Skip prompts on `flow dependencies install` with no args

### DIFF
--- a/internal/dependencymanager/install.go
+++ b/internal/dependencymanager/install.go
@@ -108,7 +108,7 @@ func install(
 	flow flowkit.Services,
 	state *flowkit.State,
 ) (result command.Result, err error) {
-	// If no arguments provided, automatically enable skip flags
+	// When installing existing dependencies from flow.json (no args), skip prompts for aliases and deployments
 	flags := installFlags
 	if len(args) == 0 {
 		flags.skipDeployments = true


### PR DESCRIPTION
Closes #???

## Description

If you’ve opened a new project and are not adding new dependencies with `flow dependencies install mainnet://0x123.ContractName`, then we should not prompt the user to add aliases or deployment accounts. They simply want to install the existing `flow.json` setup.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
