### PR TITLE
Add tx alias for transactions subcommand #2086

### DIFF
--- a/internal/transactions/transactions.go
+++ b/internal/transactions/transactions.go
@@ -38,7 +38,8 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:              "transactions",
-	Short:            "Build, sign, send and retrieve transactions",
+	Aliases:          []string{"tx"},
+	Short:            "Build, sign, send and retrieve transactions (alias: tx)",
 	TraverseChildren: true,
 	GroupID:          "interactions",
 }


### PR DESCRIPTION
Closes #2086

## Description

This PR adds a tx alias to the transactions subcommand in order to improve developer experience.
Developers can now use either transactions or tx as shorthand.

______

For contributor use:

- [x ] Targeted PR against `master` branch
- [x ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
