### PR TITLE
Hint to use --update when contract exists during deploy

### DIFF
--- a/internal/project/deploy.go
+++ b/internal/project/deploy.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-    "strings"
+	"strings"
 
 	"github.com/onflow/flow-cli/internal/prompt"
 
@@ -82,21 +82,21 @@ func deploy(
 	if err != nil {
 		var projectErr *flowkit.ProjectDeploymentError
 		if errors.As(err, &projectErr) {
-            showUpdateHint := false
-            for name, err := range projectErr.Contracts() {
+			showUpdateHint := false
+			for name, err := range projectErr.Contracts() {
 				logger.Info(fmt.Sprintf(
 					"%s Failed to deploy contract %s: %s",
 					output.ErrorEmoji(),
 					name,
 					err.Error(),
 				))
-                if !deployFlags.Update && (strings.Contains(err.Error(), "exists in account") || strings.Contains(err.Error(), "already exists")) {
-                    showUpdateHint = true
-                }
+				if !deployFlags.Update && (strings.Contains(err.Error(), "exists in account") || strings.Contains(err.Error(), "already exists")) {
+					showUpdateHint = true
+				}
 			}
-            if showUpdateHint {
-                logger.Info(fmt.Sprintf("%s Contract already exists. To update it, run: flow project deploy --update", output.TryEmoji()))
-            }
+			if showUpdateHint {
+				logger.Info(fmt.Sprintf("%s Contract already exists. To update it, run: flow project deploy --update", output.TryEmoji()))
+			}
 			return nil, fmt.Errorf("failed deploying all contracts")
 		}
 		return nil, err


### PR DESCRIPTION
Closes #2102 

## Description

Add hint to use --update when contract exists during deploy to reduce confusion.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
