### PR TITLE
Add alias configuration command

### DIFF
--- a/internal/config/add-alias.go
+++ b/internal/config/add-alias.go
@@ -1,0 +1,118 @@
+/*
+ * Flow CLI
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-cli/internal/prompt"
+
+	"github.com/onflow/flow-go-sdk"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+)
+
+type flagsAddAlias struct {
+	Contract string `flag:"contract" info:"Name of the contract to add alias for"`
+	Network  string `flag:"network" info:"Network name for the alias"`
+	Address  string `flag:"address" info:"Address for the alias"`
+}
+
+var addAliasFlags = flagsAddAlias{}
+
+var addAliasCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:     "alias",
+		Short:   "Add alias to contract configuration",
+		Example: "flow config add alias --contract MyContract --network testnet --address 0x1234567890abcdef",
+		Args:    cobra.NoArgs,
+	},
+	Flags: &addAliasFlags,
+	RunS:  addAlias,
+}
+
+func addAlias(
+	_ []string,
+	globalFlags command.GlobalFlags,
+	_ output.Logger,
+	_ flowkit.Services,
+	state *flowkit.State,
+) (command.Result, error) {
+	raw, flagsProvided, err := flagsToAliasData(addAliasFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	if !flagsProvided {
+		raw = prompt.NewAliasPrompt()
+	}
+
+	contract, err := state.Contracts().ByName(raw.Contract)
+	if err != nil {
+		return nil, fmt.Errorf("contract %s not found in configuration: %w", raw.Contract, err)
+	}
+
+	contract.Aliases.Add(
+		raw.Network,
+		flow.HexToAddress(raw.Address),
+	)
+
+	state.Contracts().AddOrUpdate(*contract)
+
+	err = state.SaveEdited(globalFlags.ConfigPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result{
+		result: fmt.Sprintf("Alias for contract %s on network %s added to the configuration", raw.Contract, raw.Network),
+	}, nil
+}
+
+func flagsToAliasData(flags flagsAddAlias) (*prompt.AliasData, bool, error) {
+	if flags.Contract == "" && flags.Network == "" && flags.Address == "" {
+		return nil, false, nil
+	}
+
+	if flags.Contract == "" {
+		return nil, true, fmt.Errorf("contract name must be provided")
+	}
+
+	if flags.Network == "" {
+		return nil, true, fmt.Errorf("network name must be provided")
+	}
+
+	if flags.Address == "" {
+		return nil, true, fmt.Errorf("address must be provided")
+	}
+
+	if flow.HexToAddress(flags.Address) == flow.EmptyAddress {
+		return nil, true, fmt.Errorf("invalid address")
+	}
+
+	return &prompt.AliasData{
+		Contract: flags.Contract,
+		Network:  flags.Network,
+		Address:  flags.Address,
+	}, true, nil
+}

--- a/internal/config/add.go
+++ b/internal/config/add.go
@@ -23,7 +23,7 @@ import (
 )
 
 var addCmd = &cobra.Command{
-	Use:              "add <account|contract|deployment|network>",
+	Use:              "add <account|contract|deployment|network|alias>",
 	Short:            "Add resource to configuration",
 	Example:          "flow config add account",
 	Args:             cobra.ExactArgs(1),
@@ -32,6 +32,7 @@ var addCmd = &cobra.Command{
 
 func init() {
 	addAccountCommand.AddToParent(addCmd)
+	addAliasCommand.AddToParent(addCmd)
 	addContractCommand.AddToParent(addCmd)
 	addDeploymentCommand.AddToParent(addCmd)
 	addNetworkCommand.AddToParent(addCmd)

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -374,6 +374,34 @@ func NewNetworkPrompt() map[string]string {
 	return networkData
 }
 
+func NewAliasPrompt() *AliasData {
+	alias := &AliasData{
+		Contract: NamePrompt(),
+	}
+
+	alias.Network, _ = RunTextInputWithValidation(
+		"Enter network name",
+		"testnet",
+		"",
+		func(s string) error {
+			if len(s) < 1 {
+				return fmt.Errorf("network name cannot be empty")
+			}
+			return nil
+		},
+	)
+
+	alias.Address = addressPrompt("Enter address for alias", "invalid address", false)
+
+	return alias
+}
+
+type AliasData struct {
+	Contract string
+	Network  string
+	Address  string
+}
+
 type DeploymentData struct {
 	Network   string
 	Account   string


### PR DESCRIPTION
Adds `flow config add alias` command to add contract aliases to configuration. Supports both interactive and flag-based modes.