### PR TITLE
Fix Windows tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install-tools:
 
 .PHONY: test
 test:
-	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) ./...
+	CGO_ENABLED=1 CGO_CFLAGS="-O2 -D__BLST_PORTABLE__ -std=gnu11" GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) ./...
 
 .PHONY: test-e2e-emulator
 test-e2e-emulator:


### PR DESCRIPTION
Newer C compilers made bool a reserved word, but our crypto library (onflow/crypto) tried to define it. So in the fix we tell the compiler to use an older C standard (C11) where bool wasn't reserved yet, so the code compiles successfully.