### PR TITLE
Update to Cadence v1.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/onflow/flixkit-go/v2 v2.6.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.1
 	github.com/onflow/flow-emulator v1.9.0
-	github.com/onflow/flow-evm-gateway v1.3.3
+	github.com/onflow/flow-evm-gateway v1.3.5
 	github.com/onflow/flow-go v0.43.3-0.20251021182938-b0fef2c5ca47
 	github.com/onflow/flow-go-sdk v1.9.0
 	github.com/onflow/flowkit/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,8 @@ github.com/onflow/flow-emulator v1.9.0 h1:cAi64Xi7UROU2KNWXV0un009OZy+S6N2j4LCne
 github.com/onflow/flow-emulator v1.9.0/go.mod h1:Mxo1VjgerVyAbYVPdb6+21Gzng5Ckfufy5gzHgLXX3c=
 github.com/onflow/flow-evm-bridge v0.1.0 h1:7X2osvo4NnQgHj8aERUmbYtv9FateX8liotoLnPL9nM=
 github.com/onflow/flow-evm-bridge v0.1.0/go.mod h1:5UYwsnu6WcBNrwitGFxphCl5yq7fbWYGYuiCSTVF6pk=
-github.com/onflow/flow-evm-gateway v1.3.3 h1:kWAbo8Bz6JDX2pS3hET+wAStCUdCHqsOlqxuztA8oCA=
-github.com/onflow/flow-evm-gateway v1.3.3/go.mod h1:WKtVB2G1E1vMYIfDH3BIuNlfMOIfBnvcHsvCJe6N/mA=
+github.com/onflow/flow-evm-gateway v1.3.5 h1:2Nx5eCYwUsVBVOMNOMPab66PNKj8784t+SPgAckw2zk=
+github.com/onflow/flow-evm-gateway v1.3.5/go.mod h1:5ymHOoDadX1NxjOsFUwDBef9mkqII66Ks/LGaKL9LV0=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3SsEftzXG2JlmSe24=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -76,7 +76,8 @@ func TestExecutingTests(t *testing.T) {
 
 		err = result.Results[script.Filename][0].Error
 		require.Error(t, err)
-		assert.ErrorAs(t, err, &stdlib.AssertionError{})
+		var assertionErr *stdlib.AssertionError
+		assert.ErrorAs(t, err, &assertionErr)
 	})
 
 	t.Run("with import", func(t *testing.T) {
@@ -711,7 +712,8 @@ Seed: 1521
 		assert.Len(t, result.Results, 2)
 		assert.NoError(t, result.Results[scriptPassing.Filename][0].Error)
 		assert.Error(t, result.Results[scriptFailing.Filename][0].Error)
-		assert.ErrorAs(t, result.Results[scriptFailing.Filename][0].Error, &stdlib.AssertionError{})
+		var assertionErr *stdlib.AssertionError
+		assert.ErrorAs(t, result.Results[scriptFailing.Filename][0].Error, &assertionErr)
 
 		assert.Contains(
 			t,

--- a/internal/util/stdlib.go
+++ b/internal/util/stdlib.go
@@ -31,7 +31,7 @@ type StandardLibrary struct {
 
 var _ stdlib.StandardLibraryHandler = StandardLibrary{}
 
-func (StandardLibrary) ProgramLog(_ string, _ interpreter.LocationRange) error {
+func (StandardLibrary) ProgramLog(_ string) error {
 	// Implementation should never be called,
 	// only its definition is used for type-checking
 	panic(errors.NewUnreachableError())
@@ -105,7 +105,6 @@ func (StandardLibrary) GetAccountContractCode(_ common.AddressLocation) ([]byte,
 
 func (StandardLibrary) EmitEvent(
 	_ interpreter.ValueExportContext,
-	_ interpreter.LocationRange,
 	_ *sema.CompositeType,
 	_ []interpreter.Value,
 ) {


### PR DESCRIPTION
## Description

Automatically update to:
- [onflow/cadence v1.8.1](https://github.com/onflow/cadence/releases/tag/v1.8.1)
- [onflow/flow-go-sdk v1.9.0](https://github.com/onflow/flow-go-sdk/releases/tag/v1.9.0)
- [onflow/flow-go b0fef2c5ca47](https://github.com/onflow/flow-go/commit/b0fef2c5ca47)
- [onflow/flow-emulator v1.9.0](https://github.com/onflow/flow-emulator/releases/tag/v1.9.0)
- [onflow/cadence-tools/test v1.7.0](https://github.com/onflow/cadence-tools/test/releases/tag/v1.7.0)
- [onflow/cadence-tools/lint v1.6.0](https://github.com/onflow/cadence-tools/lint/releases/tag/v1.6.0)
- [onflow/cadence-tools/languageserver v1.7.0](https://github.com/onflow/cadence-tools/languageserver/releases/tag/v1.7.0)
- [onflow/flixkit-go/v2 v2.6.0](https://github.com/onflow/flixkit-go/v2/releases/tag/v2.6.0)
- [onflow/flowkit/v2 v2.7.0](https://github.com/onflow/flowkit/v2/releases/tag/v2.7.0)
- [onflow/flow-evm-gateway v1.3.5](https://github.com/onflow/flow-evm-gateway/releases/tag/v1.3.5)

