### PR TITLE
Add ability to get account by name

### DIFF
--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -262,7 +262,7 @@ func Test_Get(t *testing.T) {
 			srv.GetAccount.Return(tests.NewAccountWithAddress(inArgs[0]), nil)
 		})
 
-		result, err := get(inArgs, command.GlobalFlags{}, util.NoLogger, srv.Mock, state)
+		result, err := get(inArgs, command.GlobalFlags{Network: "emulator"}, util.NoLogger, srv.Mock, state)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	})
@@ -284,7 +284,7 @@ func Test_Get(t *testing.T) {
 			srv.GetAccount.Return(tests.NewAccountWithAddress(addr.Hex()), nil)
 		})
 
-		result, err := get(inArgs, command.GlobalFlags{}, util.NoLogger, srv.Mock, state)
+		result, err := get(inArgs, command.GlobalFlags{Network: "emulator"}, util.NoLogger, srv.Mock, state)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	})

--- a/internal/accounts/get.go
+++ b/internal/accounts/get.go
@@ -50,12 +50,12 @@ var getCommand = &command.Command{
 
 func get(
 	args []string,
-	_ command.GlobalFlags,
+	globalFlags command.GlobalFlags,
 	logger output.Logger,
 	flow flowkit.Services,
 	state *flowkit.State,
 ) (command.Result, error) {
-	address, err := util.ResolveAddressOrAccountNameForNetworks(args[0], state, []string{"mainnet", "testnet", "emulator"})
+	address, err := util.ResolveAddressOrAccountNameForNetworks(args[0], state, []string{globalFlags.Network})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #???

## Description

Support `flow accounts get my-account` and not just `flow accounts get 0x123`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
