### PR TITLE
Fix goreleaser build

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -4,23 +4,30 @@ on:
   release:
     types: [published]
 
-env:
-  GO_VERSION: "1.25"
-
 jobs:
   release:
     name: Release Go Binary
     runs-on: ubuntu-latest
     steps:
       # See https://github.com/onflow/flow-cli/pull/1431 for more information
-      - name: Delete unnecessary cache
-        run: rm -rf ${RUNNER_TOOL_CACHE}
+      - name: Free up disk space
+        run: |
+          sudo rm -rf ${RUNNER_TOOL_CACHE}
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo docker image prune --all --force
+          sudo apt-get clean
+          df -h
       - uses: actions/checkout@v5
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
       - name: Codebase security check
         continue-on-error: true
         uses: snyk/actions/golang@master
-        with:
-          go-version: ${{ env.GO_VERSION }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Setup Release Environment


### PR DESCRIPTION
Closes #2191 

## Description

The goreleaser build has failed as our docker has run out of disk space, likely related to dep updates.  We should increase the number of dependencies we trim during init.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
