### PR TITLE
Free up more disk space for goreleaser action

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -14,10 +14,16 @@ jobs:
         run: |
           sudo rm -rf ${RUNNER_TOOL_CACHE}
           sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/vcpkg
+          sudo rm -rf /usr/local/share/miniconda
           sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker image prune --all --force
+          sudo docker builder prune -a -f
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v5
@@ -38,5 +44,9 @@ jobs:
           echo 'BUILD_TIME=$(date --iso-8601=seconds)' >> .release-env
           echo 'VERSION=${{ github.event.release.tag_name }}' >> .release-env
           echo 'GITHUB_TOKEN=${{ secrets.FLOW_CLI_RELEASE }}' >> .release-env
+          # Create temp dir in workspace; set container-visible paths
+          mkdir -p ${GITHUB_WORKSPACE}/tmp
+          echo "TMPDIR=/go/src/github.com/onflow/flow-cli/tmp" >> .release-env
+          echo "GOTMPDIR=/go/src/github.com/onflow/flow-cli/tmp" >> .release-env
       - name: Build and Release
         run: make release


### PR DESCRIPTION
## Description

The previous PR did not satisfy the requirements for the goreleaser build to succeed (ref https://github.com/onflow/flow-cli/pull/2190).  I have selected some more files which can be discarded in order to free enough space for the goreleaser build to pass.

Additionally, we set custom temporary paths for build artifacts because the size of /tmp is constrained on GitHub runners

_This is **not** urgent as I've made a manual build_

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
