### PR TITLE
Fix state leaking between test files

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -214,10 +214,6 @@ func testCode(
 		return network.Host, true
 	}
 
-	runner := cdcTests.NewTestRunner().
-		WithLogger(logger).
-		WithNetworkResolver(resolveNetworkFromState)
-
 	// Configure fork mode if requested
 	var effectiveForkHost string
 
@@ -257,7 +253,6 @@ func testCode(
 			ForkHeight: flags.ForkHeight,
 		}
 		forkCfg = &cfg
-		runner = runner.WithFork(cfg)
 
 		// Map chain ID to a sensible network label if not provided explicitly
 		if strings.TrimSpace(flags.Fork) == "" {
@@ -269,9 +264,6 @@ func testCode(
 			}
 		}
 	}
-
-	// Apply the network label on the base runner now that it is known
-	runner = runner.WithNetworkLabel(networkLabel)
 
 	var coverageReport *runtime.CoverageReport
 	if flags.Cover {
@@ -287,16 +279,13 @@ func testCode(
 				},
 			)
 		}
-		runner = runner.WithCoverageReport(coverageReport)
 	}
 
 	var seed int64
 	if flags.Seed > 0 {
 		seed = flags.Seed
-		runner = runner.WithRandomSeed(seed)
 	} else if flags.Random {
 		seed = int64(rand.Intn(150000))
-		runner = runner.WithRandomSeed(seed)
 	}
 
 	testResults := make(map[string]cdcTests.Results, 0)
@@ -305,7 +294,12 @@ func testCode(
 		// Set current test file for network resolution tracking
 		currentTestFile = scriptPath
 
-		fileRunner := runner.
+		// Create a new test runner per file to ensure complete isolation.
+		// Each file gets its own runner with its own backend state.
+		fileRunner := cdcTests.NewTestRunner().
+			WithLogger(logger).
+			WithNetworkResolver(resolveNetworkFromState).
+			WithNetworkLabel(networkLabel).
 			WithImportResolver(importResolver(scriptPath, state)).
 			WithFileResolver(fileResolver(scriptPath, state)).
 			WithContractAddressResolver(func(network string, contractName string) (common.Address, error) {
@@ -328,10 +322,14 @@ func testCode(
 				return common.Address{}, fmt.Errorf("no address for contract %s on network %s", contractName, network)
 			})
 
-		// Ensure the file runner has the correct network label and fork config
-		fileRunner = fileRunner.WithNetworkLabel(networkLabel)
 		if forkCfg != nil {
 			fileRunner = fileRunner.WithFork(*forkCfg)
+		}
+		if coverageReport != nil {
+			fileRunner = fileRunner.WithCoverageReport(coverageReport)
+		}
+		if seed > 0 {
+			fileRunner = fileRunner.WithRandomSeed(seed)
 		}
 
 		if flags.Name != "" {


### PR DESCRIPTION
## Description

Flow CLI v2.11.0 introduced an issue where state leaked between test files and caused undefined errors, this was because some of the guarantees around isolation changed in the upstream package.  This fix fully isolates each test file's execution to a single runner per test file.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
