### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/internal/cadence/lint.go
+++ b/internal/cadence/lint.go
@@ -219,7 +219,7 @@ func (r *lintResult) String() string {
 	return sb.String()
 }
 
-func (r *lintResult) JSON() interface{} {
+func (r *lintResult) JSON() any {
 	return r
 }
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -285,13 +285,13 @@ func checkVersion(logger output.Logger) {
 	}(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
-	var data map[string]interface{}
+	var data map[string]any
 	err = json.Unmarshal(body, &data)
 	if err != nil {
 		return
 	}
 
-	versions, ok := data["versions"].(map[string]interface{})
+	versions, ok := data["versions"].(map[string]any)
 	if !ok {
 		return
 	}

--- a/internal/emulator/start.go
+++ b/internal/emulator/start.go
@@ -137,7 +137,7 @@ func trackRequestMiddleware(next http.Handler) http.Handler {
 func init() {
 	// Configure zerolog to use console format matching the emulator's output
 	consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
-	consoleWriter.FormatMessage = func(i interface{}) string {
+	consoleWriter.FormatMessage = func(i any) string {
 		if i == nil {
 			return ""
 		}

--- a/internal/super/generator/contract_template.go
+++ b/internal/super/generator/contract_template.go
@@ -41,7 +41,7 @@ type ContractTemplate struct {
 	FileName     string // Optional: If set, use this for the file name instead of Name
 	Account      string
 	TemplatePath string
-	Data         map[string]interface{}
+	Data         map[string]any
 	SkipTests    bool
 	AddTestAlias bool
 	Aliases      config.Aliases // Optional: Custom aliases for the contract
@@ -64,8 +64,8 @@ func (c ContractTemplate) GetTemplatePath() string {
 	return c.TemplatePath
 }
 
-func (c ContractTemplate) GetData() map[string]interface{} {
-	data := map[string]interface{}{
+func (c ContractTemplate) GetData() map[string]any {
+	data := map[string]any{
 		"Name": c.Name,
 	}
 	maps.Copy(data, c.Data)
@@ -120,7 +120,7 @@ func (c ContractTemplate) GetChildren() []TemplateItem {
 		TestTemplate{
 			Name:         c.Name,
 			TemplatePath: "contract_init_test.cdc.tmpl",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"ContractName": c.Name,
 			},
 		},

--- a/internal/super/generator/file_template.go
+++ b/internal/super/generator/file_template.go
@@ -26,13 +26,13 @@ import (
 type FileTemplate struct {
 	TemplatePath string
 	TargetPath   string
-	Data         map[string]interface{}
+	Data         map[string]any
 }
 
 func NewFileTemplate(
 	templatePath string,
 	targetPath string,
-	data map[string]interface{},
+	data map[string]any,
 ) FileTemplate {
 	return FileTemplate{
 		TemplatePath: templatePath,
@@ -53,7 +53,7 @@ func (c FileTemplate) GetTemplatePath() string {
 }
 
 // GetData returns the data of the contract
-func (c FileTemplate) GetData() map[string]interface{} {
+func (c FileTemplate) GetData() map[string]any {
 	return c.Data
 }
 

--- a/internal/super/generator/generator.go
+++ b/internal/super/generator/generator.go
@@ -42,7 +42,7 @@ var templatesFS embed.FS
 type TemplateItem interface {
 	GetType() string
 	GetTemplatePath() string
-	GetData() map[string]interface{}
+	GetData() map[string]any
 	GetTargetPath() string
 }
 
@@ -107,7 +107,7 @@ func (g *Generator) generate(item TemplateItem) error {
 	templatePath := item.GetTemplatePath()
 	data := item.GetData()
 
-	fileData := make(map[string]interface{})
+	fileData := make(map[string]any)
 	maps.Copy(fileData, data)
 
 	outputContent, err := g.processTemplate(templatePath, fileData)
@@ -150,7 +150,7 @@ func (g *Generator) generate(item TemplateItem) error {
 
 // processTemplate reads a template file from the embedded filesystem and processes it with the provided data
 // If you don't need to provide data, pass nil
-func (g *Generator) processTemplate(templatePath string, data map[string]interface{}) (string, error) {
+func (g *Generator) processTemplate(templatePath string, data map[string]any) (string, error) {
 	resolvedPath := filepath.Join("templates", templatePath)
 	templateData, err := templatesFS.ReadFile(filepath.ToSlash(resolvedPath))
 	if err != nil {

--- a/internal/super/generator/generator_test.go
+++ b/internal/super/generator/generator_test.go
@@ -200,7 +200,7 @@ func TestGenerateTestTemplate(t *testing.T) {
 	err := g.Create(TestTemplate{
 		Name:         "Foobar",
 		TemplatePath: "contract_init_test.cdc.tmpl",
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"ContractName": "Foobar",
 		}},
 	)
@@ -234,18 +234,18 @@ func TestGenerateReadmeNoDeps(t *testing.T) {
 	err := g.Create(FileTemplate{
 		TemplatePath: "README.md.tmpl",
 		TargetPath:   "README.md",
-		Data: map[string]interface{}{
-			"Dependencies": []map[string]interface{}{},
-			"Contracts": []map[string]interface{}{
+		Data: map[string]any{
+			"Dependencies": []map[string]any{},
+			"Contracts": []map[string]any{
 				{"Name": "ExampleContract"},
 			},
-			"Transactions": []map[string]interface{}{
+			"Transactions": []map[string]any{
 				{"Name": "ExampleTransaction"},
 			},
-			"Scripts": []map[string]interface{}{
+			"Scripts": []map[string]any{
 				{"Name": "ExampleScript"},
 			},
-			"Tests": []map[string]interface{}{
+			"Tests": []map[string]any{
 				{"Name": "ExampleTest"},
 			},
 		},
@@ -268,21 +268,21 @@ func TestGenerateReadmeWithDeps(t *testing.T) {
 	err := g.Create(FileTemplate{
 		TemplatePath: "README.md.tmpl",
 		TargetPath:   "README.md",
-		Data: map[string]interface{}{
-			"Dependencies": []map[string]interface{}{
+		Data: map[string]any{
+			"Dependencies": []map[string]any{
 				{"Name": "FlowToken"},
 				{"Name": "FungibleToken"},
 			},
-			"Contracts": []map[string]interface{}{
+			"Contracts": []map[string]any{
 				{"Name": "ExampleContract"},
 			},
-			"Transactions": []map[string]interface{}{
+			"Transactions": []map[string]any{
 				{"Name": "ExampleTransaction"},
 			},
-			"Scripts": []map[string]interface{}{
+			"Scripts": []map[string]any{
 				{"Name": "ExampleScript"},
 			},
-			"Tests": []map[string]interface{}{
+			"Tests": []map[string]any{
 				{"Name": "ExampleTest"},
 			},
 		},

--- a/internal/super/generator/script_template.go
+++ b/internal/super/generator/script_template.go
@@ -31,7 +31,7 @@ const (
 type ScriptTemplate struct {
 	Name         string
 	TemplatePath string
-	Data         map[string]interface{}
+	Data         map[string]any
 }
 
 var _ TemplateItem = ScriptTemplate{}
@@ -48,7 +48,7 @@ func (o ScriptTemplate) GetTemplatePath() string {
 	return o.TemplatePath
 }
 
-func (o ScriptTemplate) GetData() map[string]interface{} {
+func (o ScriptTemplate) GetData() map[string]any {
 	return o.Data
 }
 

--- a/internal/super/generator/test_template.go
+++ b/internal/super/generator/test_template.go
@@ -31,7 +31,7 @@ const (
 type TestTemplate struct {
 	Name         string
 	TemplatePath string
-	Data         map[string]interface{}
+	Data         map[string]any
 }
 
 var _ TemplateItem = TestTemplate{}
@@ -50,7 +50,7 @@ func (t TestTemplate) GetTemplatePath() string {
 }
 
 // GetData returns the data of the script or transaction
-func (t TestTemplate) GetData() map[string]interface{} {
+func (t TestTemplate) GetData() map[string]any {
 	return t.Data
 }
 

--- a/internal/super/generator/transaction_template.go
+++ b/internal/super/generator/transaction_template.go
@@ -32,7 +32,7 @@ const (
 type TransactionTemplate struct {
 	Name         string
 	TemplatePath string
-	Data         map[string]interface{}
+	Data         map[string]any
 }
 
 var _ TemplateItem = TransactionTemplate{}
@@ -51,7 +51,7 @@ func (o TransactionTemplate) GetTemplatePath() string {
 }
 
 // GetData returns the data of the script or transaction
-func (o TransactionTemplate) GetData() map[string]interface{} {
+func (o TransactionTemplate) GetData() map[string]any {
 	return o.Data
 }
 

--- a/internal/super/projecttypes.go
+++ b/internal/super/projecttypes.go
@@ -235,12 +235,12 @@ func getProjectTemplates(projectType ProjectType, targetDir string, state *flowk
 			generator.ScriptTemplate{
 				Name:         "GetCounter",
 				TemplatePath: "script_counter.cdc.tmpl",
-				Data:         map[string]interface{}{"ContractName": "Counter"},
+				Data:         map[string]any{"ContractName": "Counter"},
 			},
 			generator.TransactionTemplate{
 				Name:         "IncrementCounter",
 				TemplatePath: "transaction_counter.cdc.tmpl",
-				Data:         map[string]interface{}{"ContractName": "Counter"},
+				Data:         map[string]any{"ContractName": "Counter"},
 			},
 			generator.TransactionTemplate{
 				Name:         "ScheduleIncrementCounter",
@@ -257,24 +257,24 @@ func getProjectTemplates(projectType ProjectType, targetDir string, state *flowk
 			generator.FileTemplate{
 				TemplatePath: "README_scheduled_transactions.md.tmpl",
 				TargetPath:   getReadmeFileName(targetDir),
-				Data: map[string]interface{}{
-					"Dependencies": (func() []map[string]interface{} {
-						contracts := []map[string]interface{}{}
+				Data: map[string]any{
+					"Dependencies": (func() []map[string]any {
+						contracts := []map[string]any{}
 						for _, dep := range *state.Dependencies() {
-							contracts = append(contracts, map[string]interface{}{
+							contracts = append(contracts, map[string]any{
 								"Name": dep.Name,
 							})
 						}
 						return contracts
 					})(),
-					"Contracts": []map[string]interface{}{
+					"Contracts": []map[string]any{
 						{"Name": "Counter"},
 						{"Name": "CounterTransactionHandler"},
 					},
-					"Scripts": []map[string]interface{}{
+					"Scripts": []map[string]any{
 						{"Name": "GetCounter"},
 					},
-					"Transactions": []map[string]interface{}{
+					"Transactions": []map[string]any{
 						{"Name": "IncrementCounter"},
 						{"Name": "ScheduleIncrementCounter"},
 						{"Name": "InitSchedulerManager"},
@@ -285,22 +285,22 @@ func getProjectTemplates(projectType ProjectType, targetDir string, state *flowk
 			generator.FileTemplate{
 				TemplatePath: "cursor/agent_rules.mdc.tmpl",
 				TargetPath:   ".cursor/rules/scheduledtransactions/agent-rules.mdc",
-				Data:         map[string]interface{}{},
+				Data:         map[string]any{},
 			},
 			generator.FileTemplate{
 				TemplatePath: "cursor/flip.md.tmpl",
 				TargetPath:   ".cursor/rules/scheduledtransactions/flip.md",
-				Data:         map[string]interface{}{},
+				Data:         map[string]any{},
 			},
 			generator.FileTemplate{
 				TemplatePath: "cursor/index.md.tmpl",
 				TargetPath:   ".cursor/rules/scheduledtransactions/index.md",
-				Data:         map[string]interface{}{},
+				Data:         map[string]any{},
 			},
 			generator.FileTemplate{
 				TemplatePath: "cursor/quick_checklist.md.tmpl",
 				TargetPath:   ".cursor/rules/scheduledtransactions/quick-checklist.md",
-				Data:         map[string]interface{}{},
+				Data:         map[string]any{},
 			},
 		}
 	case ProjectTypeDeFiActions:
@@ -330,7 +330,7 @@ func getProjectTemplates(projectType ProjectType, targetDir string, state *flowk
 			generator.FileTemplate{
 				TemplatePath: "README_defi_actions.md.tmpl",
 				TargetPath:   getReadmeFileName(targetDir),
-				Data:         map[string]interface{}{},
+				Data:         map[string]any{},
 			},
 		}
 	case ProjectTypeStablecoin:
@@ -403,7 +403,7 @@ func getProjectTemplates(projectType ProjectType, targetDir string, state *flowk
 			generator.FileTemplate{
 				TemplatePath: "README_stablecoin.md.tmpl",
 				TargetPath:   getReadmeFileName(targetDir),
-				Data:         map[string]interface{}{},
+				Data:         map[string]any{},
 			},
 		}
 	default:
@@ -416,33 +416,33 @@ func getProjectTemplates(projectType ProjectType, targetDir string, state *flowk
 			generator.ScriptTemplate{
 				Name:         "GetCounter",
 				TemplatePath: "script_counter.cdc.tmpl",
-				Data:         map[string]interface{}{"ContractName": "Counter"},
+				Data:         map[string]any{"ContractName": "Counter"},
 			},
 			generator.TransactionTemplate{
 				Name:         "IncrementCounter",
 				TemplatePath: "transaction_counter.cdc.tmpl",
-				Data:         map[string]interface{}{"ContractName": "Counter"},
+				Data:         map[string]any{"ContractName": "Counter"},
 			},
 			generator.FileTemplate{
 				TemplatePath: "README.md.tmpl",
 				TargetPath:   getReadmeFileName(targetDir),
-				Data: map[string]interface{}{
-					"Dependencies": (func() []map[string]interface{} {
-						contracts := []map[string]interface{}{}
+				Data: map[string]any{
+					"Dependencies": (func() []map[string]any {
+						contracts := []map[string]any{}
 						for _, dep := range *state.Dependencies() {
-							contracts = append(contracts, map[string]interface{}{
+							contracts = append(contracts, map[string]any{
 								"Name": dep.Name,
 							})
 						}
 						return contracts
 					})(),
-					"Contracts": []map[string]interface{}{
+					"Contracts": []map[string]any{
 						{"Name": "Counter"},
 					},
-					"Scripts": []map[string]interface{}{
+					"Scripts": []map[string]any{
 						{"Name": "GetCounter"},
 					},
-					"Transactions": []map[string]interface{}{
+					"Transactions": []map[string]any{
 						{"Name": "IncrementCounter"},
 					},
 				},


### PR DESCRIPTION
Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.


______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
