### PR TITLE
Add `flow config extract-key` command

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(addCmd)
 	Cmd.AddCommand(removeCmd)
+	extractKeyCommand.AddToParent(Cmd)
 }
 
 type result struct {

--- a/internal/config/extract-key.go
+++ b/internal/config/extract-key.go
@@ -1,0 +1,178 @@
+/*
+ * Flow CLI
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/onflow/flowkit/v2/output"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/prompt"
+	"github.com/onflow/flow-cli/internal/util"
+)
+
+type flagsExtractKey struct {
+	All bool `default:"false" flag:"all" info:"Extract keys for all accounts with inline keys"`
+}
+
+var extractKeyFlags = flagsExtractKey{}
+
+var extractKeyCommand = &command.Command{
+	Cmd: &cobra.Command{
+		Use:   "extract-key [account-name]",
+		Short: "Extract account private keys to separate key files",
+		Long: `Extracts inline private keys from flow.json to separate .pkey files for improved security.
+
+This converts accounts from the inline key format:
+  "my-account": { "address": "...", "key": "deadbeef..." }
+
+To the more secure file-based format:
+  "my-account": { "address": "...", "key": { "type": "file", "location": "./my-account.pkey" } }
+
+The private key files are automatically added to .gitignore and .cursorignore.`,
+		Example: `flow config extract-key my-account
+flow config extract-key --all`,
+		Args: cobra.MaximumNArgs(1),
+	},
+	Flags: &extractKeyFlags,
+	RunS:  extractKey,
+}
+
+func extractKey(
+	args []string,
+	globalFlags command.GlobalFlags,
+	logger output.Logger,
+	_ flowkit.Services,
+	state *flowkit.State,
+) (command.Result, error) {
+	hexKeyAccounts := findAccountsWithHexKeys(state)
+
+	var accountsToProcess []string
+	if len(args) == 1 {
+		accountName := args[0]
+
+		_, err := state.Accounts().ByName(accountName)
+		if err != nil {
+			return nil, fmt.Errorf("account '%s' not found in configuration", accountName)
+		}
+
+		if !slices.Contains(hexKeyAccounts, accountName) {
+			return nil, fmt.Errorf("account '%s' already uses a file-based key or has an unsupported key type", accountName)
+		}
+		accountsToProcess = []string{accountName}
+	} else if extractKeyFlags.All {
+		if len(hexKeyAccounts) == 0 {
+			return &result{result: "No accounts with inline keys found. All accounts already use file-based keys."}, nil
+		}
+		accountsToProcess = hexKeyAccounts
+	} else {
+		if len(hexKeyAccounts) == 0 {
+			return &result{result: "No accounts with inline keys found. All accounts already use file-based keys."}, nil
+		}
+		options := append(hexKeyAccounts, "all")
+		selected, err := prompt.RunSingleSelect(options, "Select an account to extract key (or 'all' for all accounts)")
+		if err != nil {
+			return nil, err
+		}
+		if selected == "all" {
+			accountsToProcess = hexKeyAccounts
+		} else {
+			accountsToProcess = []string{selected}
+		}
+	}
+
+	extractedFiles := make([]string, 0, len(accountsToProcess))
+	for _, accountName := range accountsToProcess {
+		keyFilePath, err := extractKeyForAccount(state, accountName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract key for '%s': %w", accountName, err)
+		}
+		extractedFiles = append(extractedFiles, keyFilePath)
+		logger.Info(fmt.Sprintf("%s Extracted key for account '%s' to %s", output.SuccessEmoji(), accountName, keyFilePath))
+	}
+
+	err := state.SaveEdited(globalFlags.ConfigPaths)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	return &result{
+		result: fmt.Sprintf("Successfully extracted keys for %d account(s). Key files added to .gitignore and .cursorignore.", len(accountsToProcess)),
+	}, nil
+}
+
+// findAccountsWithHexKeys returns account names that have inline hex keys (not file-based keys)
+func findAccountsWithHexKeys(state *flowkit.State) []string {
+	var hexKeyAccounts []string
+	for _, account := range *state.Accounts() {
+		// Check if the key is a HexKey (inline key) using type assertion
+		if _, isHexKey := account.Key.(*accounts.HexKey); isHexKey {
+			hexKeyAccounts = append(hexKeyAccounts, account.Name)
+		}
+	}
+	return hexKeyAccounts
+}
+
+func extractKeyForAccount(state *flowkit.State, accountName string) (string, error) {
+	account, err := state.Accounts().ByName(accountName)
+	if err != nil {
+		return "", fmt.Errorf("account '%s' not found", accountName)
+	}
+
+	privateKey, err := account.Key.PrivateKey()
+	if err != nil {
+		return "", fmt.Errorf("cannot extract key: %w", err)
+	}
+	if privateKey == nil {
+		return "", fmt.Errorf("account '%s' does not have a private key", accountName)
+	}
+
+	keyFilePath := accounts.PrivateKeyFile(accountName, "")
+
+	if _, err := state.ReaderWriter().ReadFile(keyFilePath); err == nil {
+		return "", fmt.Errorf("key file '%s' already exists. Please remove it first or choose a different account", keyFilePath)
+	}
+
+	err = state.ReaderWriter().WriteFile(keyFilePath, []byte((*privateKey).String()), os.FileMode(0600))
+	if err != nil {
+		return "", fmt.Errorf("failed to write key file: %w", err)
+	}
+
+	_ = util.AddToGitIgnore(keyFilePath, state.ReaderWriter())
+	_ = util.AddToCursorIgnore(keyFilePath, state.ReaderWriter())
+
+	account.Key = accounts.NewFileKey(
+		keyFilePath,
+		account.Key.Index(),
+		account.Key.SigAlgo(),
+		account.Key.HashAlgo(),
+		state.ReaderWriter(),
+	)
+
+	state.Accounts().AddOrUpdate(account)
+
+	return keyFilePath, nil
+}

--- a/internal/config/extract-key_test.go
+++ b/internal/config/extract-key_test.go
@@ -1,0 +1,269 @@
+/*
+ * Flow CLI
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flowkit/v2/accounts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-cli/internal/command"
+	"github.com/onflow/flow-cli/internal/util"
+)
+
+func Test_ExtractKey(t *testing.T) {
+	t.Run("Success extracting key for specific account", func(t *testing.T) {
+		srv, state, rw := util.TestMocks(t)
+
+		testAddr := flow.HexToAddress("0x01cf0e2f2f715450")
+		testAccount := &accounts.Account{
+			Name:    "test-account",
+			Address: testAddr,
+			Key:     accounts.NewHexKeyFromPrivateKey(0, crypto.SHA3_256, util.GenerateTestPrivateKey()),
+		}
+		state.Accounts().AddOrUpdate(testAccount)
+
+		extractKeyFlags = flagsExtractKey{}
+
+		result, err := extractKey(
+			[]string{"test-account"},
+			command.GlobalFlags{ConfigPaths: []string{"flow.json"}},
+			util.NoLogger,
+			srv.Mock,
+			state,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result.String(), "Successfully extracted keys for 1 account(s)")
+
+		keyFilePath := accounts.PrivateKeyFile("test-account", "")
+		keyData, err := rw.ReadFile(keyFilePath)
+		require.NoError(t, err)
+		assert.NotEmpty(t, keyData)
+
+		updatedAccount, err := state.Accounts().ByName("test-account")
+		require.NoError(t, err)
+		assert.NotNil(t, updatedAccount)
+	})
+
+	t.Run("Success extracting keys for all accounts with --all flag", func(t *testing.T) {
+		srv, state, rw := util.TestMocks(t)
+
+		testAddr1 := flow.HexToAddress("0x01cf0e2f2f715450")
+		testAccount1 := &accounts.Account{
+			Name:    "test-account-1",
+			Address: testAddr1,
+			Key:     accounts.NewHexKeyFromPrivateKey(0, crypto.SHA3_256, util.GenerateTestPrivateKey()),
+		}
+		state.Accounts().AddOrUpdate(testAccount1)
+
+		testAddr2 := flow.HexToAddress("0x179b6b1cb6755e31")
+		testAccount2 := &accounts.Account{
+			Name:    "test-account-2",
+			Address: testAddr2,
+			Key:     accounts.NewHexKeyFromPrivateKey(0, crypto.SHA3_256, util.GenerateTestPrivateKey()),
+		}
+		state.Accounts().AddOrUpdate(testAccount2)
+
+		extractKeyFlags = flagsExtractKey{All: true}
+
+		result, err := extractKey(
+			[]string{},
+			command.GlobalFlags{ConfigPaths: []string{"flow.json"}},
+			util.NoLogger,
+			srv.Mock,
+			state,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result.String(), "Successfully extracted keys for")
+
+		keyFilePath1 := accounts.PrivateKeyFile("test-account-1", "")
+		keyData1, err := rw.ReadFile(keyFilePath1)
+		require.NoError(t, err)
+		assert.NotEmpty(t, keyData1)
+
+		keyFilePath2 := accounts.PrivateKeyFile("test-account-2", "")
+		keyData2, err := rw.ReadFile(keyFilePath2)
+		require.NoError(t, err)
+		assert.NotEmpty(t, keyData2)
+
+		extractKeyFlags = flagsExtractKey{}
+	})
+
+	t.Run("Fail when account not found", func(t *testing.T) {
+		srv, state, _ := util.TestMocks(t)
+
+		extractKeyFlags = flagsExtractKey{}
+
+		result, err := extractKey(
+			[]string{"nonexistent-account"},
+			command.GlobalFlags{ConfigPaths: []string{"flow.json"}},
+			util.NoLogger,
+			srv.Mock,
+			state,
+		)
+
+		assert.Nil(t, result)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("No accounts with inline keys", func(t *testing.T) {
+		srv, state, rw := util.TestMocks(t)
+
+		emulatorKeyFilePath := accounts.PrivateKeyFile("emulator-account", "")
+		emulatorPrivateKey := util.GenerateTestPrivateKey()
+		err := rw.WriteFile(emulatorKeyFilePath, []byte(emulatorPrivateKey.String()), 0600)
+		require.NoError(t, err)
+
+		testAddr := flow.HexToAddress("0x01cf0e2f2f715450")
+		keyFilePath := accounts.PrivateKeyFile("file-key-account", "")
+
+		privateKey := util.GenerateTestPrivateKey()
+		err = rw.WriteFile(keyFilePath, []byte(privateKey.String()), 0600)
+		require.NoError(t, err)
+
+		testAccount := &accounts.Account{
+			Name:    "file-key-account",
+			Address: testAddr,
+			Key:     accounts.NewFileKey(keyFilePath, 0, crypto.ECDSA_P256, crypto.SHA3_256, rw),
+		}
+		state.Accounts().AddOrUpdate(testAccount)
+
+		extractKeyFlags = flagsExtractKey{All: true}
+
+		result, err := extractKey(
+			[]string{},
+			command.GlobalFlags{ConfigPaths: []string{"flow.json"}},
+			util.NoLogger,
+			srv.Mock,
+			state,
+		)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result.String(), "No accounts with inline keys found")
+
+		extractKeyFlags = flagsExtractKey{}
+	})
+}
+
+func Test_FindAccountsWithHexKeys(t *testing.T) {
+	t.Run("Find accounts with hex keys", func(t *testing.T) {
+		_, state, _ := util.TestMocks(t)
+
+		testAddr := flow.HexToAddress("0x01cf0e2f2f715450")
+		testAccount := &accounts.Account{
+			Name:    "test-hex-account",
+			Address: testAddr,
+			Key:     accounts.NewHexKeyFromPrivateKey(0, crypto.SHA3_256, util.GenerateTestPrivateKey()),
+		}
+		state.Accounts().AddOrUpdate(testAccount)
+
+		hexKeyAccounts := findAccountsWithHexKeys(state)
+
+		assert.GreaterOrEqual(t, len(hexKeyAccounts), 1)
+		assert.Contains(t, hexKeyAccounts, "test-hex-account")
+	})
+
+	t.Run("Skip accounts with file keys", func(t *testing.T) {
+		_, state, rw := util.TestMocks(t)
+
+		testAddr := flow.HexToAddress("0x01cf0e2f2f715450")
+		keyFilePath := accounts.PrivateKeyFile("file-key-test", "")
+
+		privateKey := util.GenerateTestPrivateKey()
+		err := rw.WriteFile(keyFilePath, []byte(privateKey.String()), 0600)
+		require.NoError(t, err)
+
+		testAccount := &accounts.Account{
+			Name:    "file-key-test",
+			Address: testAddr,
+			Key:     accounts.NewFileKey(keyFilePath, 0, crypto.ECDSA_P256, crypto.SHA3_256, rw),
+		}
+		state.Accounts().AddOrUpdate(testAccount)
+
+		hexKeyAccounts := findAccountsWithHexKeys(state)
+
+		assert.NotContains(t, hexKeyAccounts, "file-key-test")
+	})
+}
+
+func Test_ExtractKeyForAccount(t *testing.T) {
+	t.Run("Successfully extract key for account", func(t *testing.T) {
+		_, state, rw := util.TestMocks(t)
+
+		testAddr := flow.HexToAddress("0x01cf0e2f2f715450")
+		privateKey := util.GenerateTestPrivateKey()
+		testAccount := &accounts.Account{
+			Name:    "extract-test",
+			Address: testAddr,
+			Key:     accounts.NewHexKeyFromPrivateKey(0, crypto.SHA3_256, privateKey),
+		}
+		state.Accounts().AddOrUpdate(testAccount)
+
+		keyFilePath, err := extractKeyForAccount(state, "extract-test")
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, keyFilePath)
+
+		keyData, err := rw.ReadFile(keyFilePath)
+		require.NoError(t, err)
+		assert.Equal(t, privateKey.String(), string(keyData))
+
+		updatedAccount, err := state.Accounts().ByName("extract-test")
+		require.NoError(t, err)
+		assert.NotNil(t, updatedAccount)
+	})
+
+	t.Run("Fail when account not found", func(t *testing.T) {
+		_, state, _ := util.TestMocks(t)
+
+		_, err := extractKeyForAccount(state, "nonexistent")
+
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("Fail when key file already exists", func(t *testing.T) {
+		_, state, rw := util.TestMocks(t)
+
+		testAddr := flow.HexToAddress("0x01cf0e2f2f715450")
+		testAccount := &accounts.Account{
+			Name:    "existing-file-test",
+			Address: testAddr,
+			Key:     accounts.NewHexKeyFromPrivateKey(0, crypto.SHA3_256, util.GenerateTestPrivateKey()),
+		}
+		state.Accounts().AddOrUpdate(testAccount)
+
+		keyFilePath := accounts.PrivateKeyFile("existing-file-test", "")
+		err := rw.WriteFile(keyFilePath, []byte("existing content"), 0600)
+		require.NoError(t, err)
+
+		_, err = extractKeyForAccount(state, "existing-file-test")
+
+		assert.ErrorContains(t, err, "already exists")
+	})
+}


### PR DESCRIPTION
Adds a new command to extract inline private keys from `flow.json` into separate
`.pkey` files for improved security.

### Usage

```sh
flow config extract-key <account-name>  # Extract a specific account
flow config extract-key --all           # Extract all accounts with inline keys
flow config extract-key                 # Interactive selection
````

### What it does

- Converts accounts from inline hex key format
  (`"key": "0xdeadbeef..."`)
  to file-based format
  (`"key": { "type": "file", "location": "./account.pkey" }`)

- Automatically adds key files to `.gitignore` and `.cursorignore`
- Prevents accidental overwrites if a key file already exists

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
