### PR TITLE
Add security warning for accounts with inline keys

### DIFF
--- a/cadence/transactions/test.cdc
+++ b/cadence/transactions/test.cdc
@@ -1,5 +1,0 @@
-transaction() {
-    prepare(account: &Account) {}
-
-    execute {}
-}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -47,6 +47,7 @@ import (
 	"github.com/onflow/flowkit/v2/output"
 
 	"github.com/onflow/flow-cli/build"
+	"github.com/onflow/flow-cli/common/branding"
 	"github.com/onflow/flow-cli/internal/prompt"
 	"github.com/onflow/flow-cli/internal/settings"
 	"github.com/onflow/flow-cli/internal/util"
@@ -345,12 +346,15 @@ func checkForInlineKeys(state *flowkit.State, logger output.Logger) {
 	}
 
 	if len(inlineKeyAccounts) > 0 {
+		cmd := branding.GreenStyle.Render("flow config extract-key --all")
 		logger.Info(fmt.Sprintf(
 			"\n%s Security warning: %d account(s) have private keys stored directly in flow.json: %s\n"+
-				"   Extract them to separate key files by running: flow config extract-key --all\n",
+				"   Extract them to separate key files by running: %s\n"+
+				"   Learn more: https://developers.flow.com/build/tools/flow-cli/flow.json/security\n",
 			output.WarningEmoji(),
 			len(inlineKeyAccounts),
 			strings.Join(inlineKeyAccounts, ", "),
+			cmd,
 		))
 	}
 }


### PR DESCRIPTION
## Description

Adds a security warning when running CLI commands if accounts have inline keys stored directly in flow.json.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
