### PR TITLE
Add ENV variable to skip network test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,14 @@ We try to follow the coding guidelines from the Go community.
 - Code should be commented
 - Code should pass all tests: `make test`
 
+#### Skipping Network-Dependent Tests
+
+Some tests require network access to connect to Flow mainnet/testnet nodes. To skip these tests (e.g., in sandboxed build environments like Nix), set the `SKIP_NETWORK_TESTS` environment variable:
+
+```
+SKIP_NETWORK_TESTS=1 make test
+```
+
 ## Releasing
 
 Releasing is automated by Github actions. Release action is triggered by creating a release on Github and publishing it.

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -757,6 +757,9 @@ Seed: 1521
 }
 
 func TestForkMode_UsesMainnetAliases(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)
@@ -822,6 +825,9 @@ func TestForkMode_UsesMainnetAliases(t *testing.T) {
 }
 
 func TestForkMode_UsesTestnetAliasesExplicit(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)
@@ -902,6 +908,9 @@ func TestForkMode_AutodetectFailureRequiresExplicitNetwork(t *testing.T) {
 }
 
 func TestNetworkForkResolution_Success(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)
@@ -1011,6 +1020,9 @@ access(all) fun testSimple() {
 }
 
 func TestNetworkForkResolution_WithOwnHost(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)
@@ -1052,6 +1064,9 @@ access(all) fun testSimple() {
 }
 
 func TestContractAddressForkResolution_UsesMainnetForkFirst(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)
@@ -1116,6 +1131,9 @@ access(all) fun testUsesMainnetForkAddress() {
 }
 
 func TestContractAddressForkResolution_FallbackToMainnet(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)
@@ -1180,6 +1198,9 @@ access(all) fun testFallbackToMainnetAddress() {
 }
 
 func TestContractAddressForkResolution_PrioritizesForkOverParent(t *testing.T) {
+	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
+		t.Skip("skipping network-dependent test")
+	}
 	t.Parallel()
 
 	_, state, _ := util.TestMocks(t)


### PR DESCRIPTION
## Description

When making a nix derivation for flow-cli I noticed that some tests use networking. This fails in sandboxed environments. I added a `SKIP_NETWORK_TESTS` env variable to optionally skip them.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
