### PR TITLE
add script path to failed tests

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -421,7 +421,7 @@ func testCode(
 
 	for r := range resultCh {
 		if r.err != nil && firstErr == nil {
-			firstErr = r.err
+			firstErr = fmt.Errorf("error in test file %q: %w", r.scriptPath, r.err)
 		}
 		if r.results != nil {
 			testResults[r.scriptPath] = r.results


### PR DESCRIPTION
Add the cdc file path in the error message when tests fails, make it easier to find out which test is failing. 

Before:
```
❌ Command Error: Checking failed:
error: too few arguments
  --> 7465737400000000000000000000000000000000000000000000000000000000:81:4

  See documentation at: https://cadence-lang.org/docs/language/functions

error: mismatched types
  --> 7465737400000000000000000000000000000000000000000000000000000000:81:106

```

After:
```
❌ Command Error: error in test file "/Users/leozhang/FlowALP/cadence/tests/withdraw_and_pull_deposit_and_push_test.cdc": Checking failed:
error: too few arguments
  --> 7465737400000000000000000000000000000000000000000000000000000000:81:4

  See documentation at: https://cadence-lang.org/docs/language/functions

error: mismatched types
  --> 7465737400000000000000000000000000000000000000000000000000000000:81:106

```