### PR TITLE
Auto-enable TLS for access nodes on port 443

### DIFF
--- a/internal/accounts/create-interactive.go
+++ b/internal/accounts/create-interactive.go
@@ -59,7 +59,7 @@ func createInteractive(
 	privateFile := accounts.PrivateKeyFile(name, "")
 
 	// create new gateway based on chosen network
-	gw, err := gateway.NewGrpcGateway(selectedNetwork)
+	gw, err := gateway.NewGrpcGateway(selectedNetwork, util.GRPCDialOptionForHost(selectedNetwork.Host))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/accounts/list.go
+++ b/internal/accounts/list.go
@@ -213,7 +213,7 @@ func validateAccountOnNetwork(account *accounts.Account, network *config.Network
 	var gw gateway.Gateway
 	var err error
 
-	gw, err = gateway.NewGrpcGateway(*network)
+	gw, err = gateway.NewGrpcGateway(*network, util.GRPCDialOptionForHost(network.Host))
 
 	if err != nil {
 		result.Error = fmt.Sprintf("Failed to create gateway: %v", err)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -193,7 +193,7 @@ func createGateway(network config.Network) (gateway.Gateway, error) {
 		return gateway.NewSecureGrpcGateway(network)
 	}
 
-	return gateway.NewGrpcGateway(network)
+	return gateway.NewGrpcGateway(network, util.GRPCDialOptionForHost(network.Host))
 }
 
 // resolveHost from the flags provided.

--- a/internal/dependencymanager/dependencyinstaller.go
+++ b/internal/dependencymanager/dependencyinstaller.go
@@ -167,17 +167,17 @@ func NewDependencyInstaller(logger output.Logger, state *flowkit.State, saveStat
 		return nil, fmt.Errorf("cannot use both --update and --skip-update-prompts flags together")
 	}
 
-	emulatorGateway, err := gateway.NewGrpcGateway(config.EmulatorNetwork)
+	emulatorGateway, err := gateway.NewGrpcGateway(config.EmulatorNetwork, util.GRPCDialOptionForHost(config.EmulatorNetwork.Host))
 	if err != nil {
 		return nil, fmt.Errorf("error creating emulator gateway: %v", err)
 	}
 
-	testnetGateway, err := gateway.NewGrpcGateway(config.TestnetNetwork)
+	testnetGateway, err := gateway.NewGrpcGateway(config.TestnetNetwork, util.GRPCDialOptionForHost(config.TestnetNetwork.Host))
 	if err != nil {
 		return nil, fmt.Errorf("error creating testnet gateway: %v", err)
 	}
 
-	mainnetGateway, err := gateway.NewGrpcGateway(config.MainnetNetwork)
+	mainnetGateway, err := gateway.NewGrpcGateway(config.MainnetNetwork, util.GRPCDialOptionForHost(config.MainnetNetwork.Host))
 	if err != nil {
 		return nil, fmt.Errorf("error creating mainnet gateway: %v", err)
 	}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -30,6 +30,8 @@ import (
 	"github.com/onflow/flowkit/v2"
 	"github.com/onflow/flowkit/v2/config"
 	"github.com/onflow/flowkit/v2/gateway"
+
+	"github.com/onflow/flow-cli/internal/util"
 )
 
 var Cmd = &cobra.Command{
@@ -128,5 +130,5 @@ func createGateway(state *flowkit.State, network string) (gateway.Gateway, error
 	if net.Key != "" {
 		return gateway.NewSecureGrpcGateway(*net)
 	}
-	return gateway.NewGrpcGateway(*net)
+	return gateway.NewGrpcGateway(*net, util.GRPCDialOptionForHost(net.Host))
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -21,6 +21,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -38,6 +39,7 @@ import (
 	flowGo "github.com/onflow/flow-go/model/flow"
 	flowaccess "github.com/onflow/flow/protobuf/go/flow/access"
 	grpcOpts "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	emulatorUtils "github.com/onflow/flow-emulator/utils"
@@ -74,7 +76,7 @@ func IsAddressValidForNetwork(address flow.Address, networkName string) bool {
 // by querying the access node to get the actual chain ID
 func ValidateAddressForNetwork(address flow.Address, network *config.Network) error {
 	// Create a grpc client to query the network
-	client, err := grpc.NewBaseClient(network.Host, grpcOpts.WithTransportCredentials(insecure.NewCredentials()))
+	client, err := grpc.NewBaseClient(network.Host, TransportCredentialForHost(network.Host))
 	if err != nil {
 		return fmt.Errorf("failed to connect to access node: %w", err)
 	}
@@ -244,6 +246,22 @@ func AddFlowEntriesToCursorIgnore(targetDir string, loader flowkit.ReaderWriter)
 	return addEntriesToIgnoreFile(cursorIgnorePath, flowEntries, loader)
 }
 
+// TransportCredentialForHost returns TLS credentials using system CA certificates
+// if the host uses port 443, or insecure credentials otherwise.
+func TransportCredentialForHost(host string) grpcOpts.DialOption {
+	_, port, err := net.SplitHostPort(host)
+	if err == nil && port == "443" {
+		return grpcOpts.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12}))
+	}
+	return grpcOpts.WithTransportCredentials(insecure.NewCredentials())
+}
+
+// GRPCDialOptionForHost returns a grpcAccess.ClientOption that configures
+// TLS using system CA certificates for port 443 hosts, or insecure credentials otherwise.
+func GRPCDialOptionForHost(host string) grpc.ClientOption {
+	return grpc.WithGRPCDialOptions(TransportCredentialForHost(host))
+}
+
 // GetAddressNetwork returns the chain ID for an address.
 func GetAddressNetwork(address flow.Address) (flow.ChainID, error) {
 	networks := []flow.ChainID{
@@ -282,7 +300,7 @@ func GetChainIDFromHost(host string) (flowGo.ChainID, error) {
 
 	conn, err := grpcOpts.NewClient(
 		host,
-		grpcOpts.WithTransportCredentials(insecure.NewCredentials()),
+		TransportCredentialForHost(host),
 		emulatorUtils.DefaultGRPCRetryInterceptor(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

- When an access node host uses port 443, automatically configure TLS with system CA certificate verification instead of insecure credentials
- Adds `TransportCredentialForHost` and `GRPCDialOptionForHost` helpers in `internal/util/` for consistent behavior across all gRPC connection points
- Updates all `NewGrpcGateway`, `NewBaseClient`, and `grpc.NewClient` call sites to use the new helpers

this can be used when connecting to QuickNode, or other ANs with a standard CA signed certificate

## Context

Access nodes behind TLS-terminating proxies (e.g. on port 443) require proper CA-based certificate verification. Previously, all non-key-authenticated connections used insecure credentials regardless of port. This change makes the CLI automatically do the right thing when connecting to port 443 endpoints.

Non-443 ports (emulator on 3569, mainnet/testnet on 9000, etc.) retain existing insecure transport behavior.

## Test plan

- [ ] Verify CLI commands work against access nodes on port 443 with valid TLS certs
- [ ] Verify existing behavior unchanged for default networks (emulator:3569, testnet:9000, mainnet:9000)
- [ ] Verify `--host` flag with `:443` suffix enables TLS automatically