### PR TITLE
refactor: use strings.builder

### DIFF
--- a/internal/dependencymanager/dependencyinstaller.go
+++ b/internal/dependencymanager/dependencyinstaller.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/psiemens/sconfig"
 
@@ -585,19 +586,19 @@ func (di *DependencyInstaller) fetchDependenciesWithDepth(dependency config.Depe
 	}
 
 	// Log installation with visual hierarchy and branding colors
-	indent := ""
+	var indent strings.Builder
 	prefix := ""
 
 	if depth > 0 {
 		// Create indentation with proper tree characters
 		for i := 0; i < depth; i++ {
-			indent += "  "
+			indent.WriteString("  ")
 		}
 		prefix = "├─ "
 
 		// Add depth limit warning for very deep chains
 		if depth >= 5 {
-			di.Logger.Info(fmt.Sprintf("%s⚠️  Deep dependency chain (depth %d)", indent, depth))
+			di.Logger.Info(fmt.Sprintf("%s⚠️  Deep dependency chain (depth %d)", indent.String(), depth))
 		}
 	}
 
@@ -606,7 +607,7 @@ func (di *DependencyInstaller) fetchDependenciesWithDepth(dependency config.Depe
 	shortAddress := "0x..." + fullAddress[len(fullAddress)-4:]
 	addressStyled := branding.GreenStyle.Render(shortAddress)
 	networkStyled := branding.GrayStyle.Render(networkName)
-	di.Logger.Info(fmt.Sprintf("%s%s%s @ %s (%s)", indent, prefix, contractNameStyled, addressStyled, networkStyled))
+	di.Logger.Info(fmt.Sprintf("%s%s%s @ %s (%s)", indent.String(), prefix, contractNameStyled, addressStyled, networkStyled))
 	di.installCount++
 
 	err := di.addDependency(dependency)


### PR DESCRIPTION
Closes #???

## Description

The modernize has added an analyzer for using strings.Builder for string construction. strings.Builder has fewer memory allocations and better performance.

More info: https://github.com/golang/go/issues/75190


Inspired by https://github.com/onflow/flow-cli/pull/2036

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
