### PR TITLE
Fall back to project root when file resolver cannot find file

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -550,11 +550,17 @@ func fileResolver(scriptPath string, state *flowkit.State) cdcTests.FileResolver
 		importFilePath := util.AbsolutePath(scriptPath, path)
 
 		content, err := state.ReadFile(importFilePath)
-		if err != nil {
+		if err == nil {
+			return string(content), nil
+		}
+
+		// Fall back to resolving relative to the project root (CWD, where flow.json lives).
+		projectContent, projectErr := state.ReadFile(filepath.Clean(path))
+		if projectErr != nil {
 			return "", err
 		}
 
-		return string(content), nil
+		return string(projectContent), nil
 	}
 }
 

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -255,6 +255,29 @@ func TestExecutingTests(t *testing.T) {
 		assert.NoError(t, result.Results[script.Filename][0].Error)
 	})
 
+	t.Run("with file read from project root when not found relative to test file", func(t *testing.T) {
+		_, state, rw := util.TestMocks(t)
+		_ = rw.WriteFile(
+			tests.SomeFile.Filename,
+			tests.SomeFile.Source,
+			os.ModeTemporary,
+		)
+		t.Parallel()
+
+		// Place the test script in a subdirectory. SomeFile only exists at the
+		// project root, so the first lookup (relative to the script) will fail
+		// and the resolver must fall back to the project root.
+		script := tests.TestScriptWithFileRead
+		testFiles := map[string][]byte{
+			"subdir/" + script.Filename: script.Source,
+		}
+		result, err := testCode(testFiles, state, flagsTests{})
+
+		require.NoError(t, err)
+		require.Len(t, result.Results, 1)
+		assert.NoError(t, result.Results["subdir/"+script.Filename][0].Error)
+	})
+
 	t.Run("with code coverage", func(t *testing.T) {
 		// Setup
 		_, state, _ := util.TestMocks(t)


### PR DESCRIPTION
The `fileResolver` always resolved file paths relative to the test file that triggered the import. This breaks when a helper script is shared across test files in different directories.

For example, given this layout: 
``` 
tests/some_test.cdc -> imports "test_helpers" -> reads some_contract.cdc -> resolves to tests/some_contract.cdc
tests/mocks/some_test.cdc -> imports "../test_helpers" -> reads some_contract.cdc -> resolves to tests/mocks/some_contract.cdc
``` 

This essentially forces having all test files in a single directory.

The fix adds a fallback: if a file isn't found at the path relative to the test file, it retries the path relative to the project root (the working directory where `flow.json` lives).
The original error is returned only if both lookups fail, so existing behavior is fully preserved. 
Any test that already works continues to work unchanged.
