### PR TITLE
Fix unused import detection in Cadence linter

### DIFF
--- a/internal/cadence/lint_test.go
+++ b/internal/cadence/lint_test.go
@@ -89,6 +89,65 @@ func Test_Lint(t *testing.T) {
 		)
 	})
 
+	t.Run("detects unused import", func(t *testing.T) {
+		t.Parallel()
+
+		state := setupMockState(t)
+
+		results, err := lintFiles(state, false, "UnusedImport.cdc")
+		require.NoError(t, err)
+
+		require.Len(t, results.Results, 1)
+		require.Len(t, results.Results[0].Diagnostics, 1)
+
+		diagnostic := results.Results[0].Diagnostics[0]
+		require.Equal(t, "unused-import-hint", diagnostic.Category)
+		require.Equal(t, "unused import", diagnostic.Message)
+		require.Equal(t, 0, results.exitCode)
+	})
+
+	t.Run("detects unused contract-name import", func(t *testing.T) {
+		t.Parallel()
+
+		state := setupMockState(t)
+
+		results, err := lintFiles(state, false, "UnusedContractNameImport.cdc")
+		require.NoError(t, err)
+
+		require.Len(t, results.Results, 1)
+		require.Len(t, results.Results[0].Diagnostics, 1)
+
+		diagnostic := results.Results[0].Diagnostics[0]
+		require.Equal(t, "unused-import-hint", diagnostic.Category)
+		require.Equal(t, 0, results.exitCode)
+	})
+
+	t.Run("does not flag import used only in resource conformance", func(t *testing.T) {
+		t.Parallel()
+
+		state := setupMockState(t)
+
+		results, err := lintFiles(state, false, "ConformanceUser.cdc")
+		require.NoError(t, err)
+
+		require.Len(t, results.Results, 1)
+		require.Empty(t, results.Results[0].Diagnostics)
+		require.Equal(t, 0, results.exitCode)
+	})
+
+	t.Run("does not flag import used only in entitlement access specifier", func(t *testing.T) {
+		t.Parallel()
+
+		state := setupMockState(t)
+
+		results, err := lintFiles(state, false, "EntitlementUser.cdc")
+		require.NoError(t, err)
+
+		require.Len(t, results.Results, 1)
+		require.Empty(t, results.Results[0].Diagnostics)
+		require.Equal(t, 0, results.exitCode)
+	})
+
 	t.Run("lints multiple files", func(t *testing.T) {
 		t.Parallel()
 
@@ -503,6 +562,20 @@ func setupMockState(t *testing.T) *flowkit.State {
 	_ = afero.WriteFile(mockFs, "foo/WithImports.cdc", []byte(`
 	import "../NoError.cdc"
 	access(all) contract WithImports {
+		init() {
+			let _ = NoError.getType()
+		}
+	}
+	`), 0644)
+	_ = afero.WriteFile(mockFs, "UnusedImport.cdc", []byte(`
+	import "NoError.cdc"
+	access(all) contract UnusedImport {
+		init() {}
+	}
+	`), 0644)
+	_ = afero.WriteFile(mockFs, "UnusedContractNameImport.cdc", []byte(`
+	import "NoError"
+	access(all) contract UnusedContractNameImport {
 		init() {}
 	}
 	`), 0644)
@@ -635,6 +708,10 @@ func setupMockState(t *testing.T) *flowkit.State {
 	state.Contracts().AddOrUpdate(config.Contract{
 		Name:     "ContractWithNestedImports",
 		Location: "ContractWithNestedImports.cdc",
+	})
+	state.Contracts().AddOrUpdate(config.Contract{
+		Name:     "Scheduler",
+		Location: "Scheduler.cdc",
 	})
 
 	return state

--- a/internal/cadence/lint_test.go
+++ b/internal/cadence/lint_test.go
@@ -682,6 +682,42 @@ func setupMockState(t *testing.T) *flowkit.State {
 	}
 	`), 0644)
 
+	_ = afero.WriteFile(mockFs, "ConformanceProvider.cdc", []byte(`
+	access(all) contract ConformanceProvider {
+		access(all) resource interface Greeter {
+			access(all) fun greet(): String
+		}
+		init() {}
+	}
+	`), 0644)
+
+	_ = afero.WriteFile(mockFs, "ConformanceUser.cdc", []byte(`
+	import "ConformanceProvider"
+	access(all) contract ConformanceUser {
+		access(all) resource MyGreeter: ConformanceProvider.Greeter {
+			access(all) fun greet(): String { return "hi" }
+		}
+		init() {}
+	}
+	`), 0644)
+
+	_ = afero.WriteFile(mockFs, "EntitlementProvider.cdc", []byte(`
+	access(all) contract EntitlementProvider {
+		access(all) entitlement Admin
+		init() {}
+	}
+	`), 0644)
+
+	_ = afero.WriteFile(mockFs, "EntitlementUser.cdc", []byte(`
+	import "EntitlementProvider"
+	access(all) contract EntitlementUser {
+		access(all) resource Admin {
+			access(EntitlementProvider.Admin) fun doAdminStuff() {}
+		}
+		init() {}
+	}
+	`), 0644)
+
 	_ = afero.WriteFile(mockFs, "TransactionImportingContractWithNestedImports.cdc", []byte(`
 	import ContractWithNestedImports from "ContractWithNestedImports"
 	
@@ -712,6 +748,22 @@ func setupMockState(t *testing.T) *flowkit.State {
 	state.Contracts().AddOrUpdate(config.Contract{
 		Name:     "Scheduler",
 		Location: "Scheduler.cdc",
+	})
+	state.Contracts().AddOrUpdate(config.Contract{
+		Name:     "ConformanceProvider",
+		Location: "ConformanceProvider.cdc",
+	})
+	state.Contracts().AddOrUpdate(config.Contract{
+		Name:     "ConformanceUser",
+		Location: "ConformanceUser.cdc",
+	})
+	state.Contracts().AddOrUpdate(config.Contract{
+		Name:     "EntitlementProvider",
+		Location: "EntitlementProvider.cdc",
+	})
+	state.Contracts().AddOrUpdate(config.Contract{
+		Name:     "EntitlementUser",
+		Location: "EntitlementUser.cdc",
 	})
 
 	return state

--- a/internal/cadence/linter.go
+++ b/internal/cadence/linter.go
@@ -42,12 +42,12 @@ import (
 )
 
 type linter struct {
-	checkers                map[string]*sema.Checker
-	exportedIdentifiers     map[string][]ast.Identifier
-	state                   *flowkit.State
-	checkerStandardConfig   *sema.Config
-	checkerScriptConfig     *sema.Config
-	currentLocation         common.Location
+	checkers              map[string]*sema.Checker
+	exportedIdentifiers   map[string][]ast.Identifier
+	state                 *flowkit.State
+	checkerStandardConfig *sema.Config
+	checkerScriptConfig   *sema.Config
+	currentLocation       common.Location
 }
 
 type positionedError interface {

--- a/internal/cadence/linter.go
+++ b/internal/cadence/linter.go
@@ -42,10 +42,12 @@ import (
 )
 
 type linter struct {
-	checkers              map[string]*sema.Checker
-	state                 *flowkit.State
-	checkerStandardConfig *sema.Config
-	checkerScriptConfig   *sema.Config
+	checkers                map[string]*sema.Checker
+	exportedIdentifiers     map[string][]ast.Identifier
+	state                   *flowkit.State
+	checkerStandardConfig   *sema.Config
+	checkerScriptConfig     *sema.Config
+	currentLocation         common.Location
 }
 
 type positionedError interface {
@@ -64,8 +66,9 @@ var analyzers = maps.Values(cdclint.Analyzers)
 
 func newLinter(state *flowkit.State) *linter {
 	l := &linter{
-		checkers: make(map[string]*sema.Checker),
-		state:    state,
+		checkers:            make(map[string]*sema.Checker),
+		exportedIdentifiers: make(map[string][]ast.Identifier),
+		state:               state,
 	}
 
 	// Create checker configs for both standard and script
@@ -101,6 +104,8 @@ func (l *linter) lintCode(
 
 	diagnostics = make([]analysis.Diagnostic, 0)
 	codeStr := string(code)
+
+	l.currentLocation = location
 
 	// Parse program & convert any parsing errors to diagnostics
 	program, parseProgramErr := parser.ParseProgram(nil, code, parser.Config{})
@@ -332,6 +337,7 @@ func (l *linter) newCheckerConfig(standardLibrary *util.StandardLibrary) *sema.C
 		PositionInfoEnabled:        true, // Must be enabled for linters
 		ExtendedElaborationEnabled: true, // Must be enabled for linters
 		ImportHandler:              l.handleImport,
+		LocationHandler:            l.resolveLocation,
 		SuggestionsEnabled:         true, // Must be enabled to offer semantic suggestions
 	}
 }
@@ -437,7 +443,13 @@ func (l *linter) handleImport(
 			}
 
 			l.checkers[filepath] = importedChecker
+			// Pre-populate so resolveLocation doesn't re-parse during sub-checking
+			l.exportedIdentifiers[filepath] = exportedIdentifiersFromProgram(importedProgram)
+
+			prevLocation := l.currentLocation
+			l.currentLocation = fileLocation
 			err = importedChecker.Check()
+			l.currentLocation = prevLocation
 			if err != nil {
 				return nil, err
 			}
@@ -472,6 +484,82 @@ func (l *linter) resolveImportFilepath(
 	default:
 		return "", fmt.Errorf("unsupported location: %T", location)
 	}
+}
+
+// resolveLocation is the LocationHandler for the sema.Checker config.
+// For implicit imports (no explicit identifiers), it resolves the exported names
+// from the imported file so the unused-import analyzer can track usage.
+func (l *linter) resolveLocation(
+	identifiers []ast.Identifier,
+	location common.Location,
+) ([]sema.ResolvedLocation, error) {
+	defaultResolution := []sema.ResolvedLocation{{
+		Location:    location,
+		Identifiers: identifiers,
+	}}
+
+	// Explicit imports already carry their identifiers — nothing to add
+	if len(identifiers) > 0 {
+		return defaultResolution, nil
+	}
+
+	// Only handle string locations (path-based or contract-name imports)
+	if _, ok := location.(common.StringLocation); !ok {
+		return defaultResolution, nil
+	}
+
+	// Normalize relative path imports against the current file's location,
+	// then resolve to a file path (handles both .cdc paths and contract names)
+	resolvedLoc := location
+	if l.currentLocation != nil && util.IsPathLocation(location) {
+		resolvedLoc = util.NormalizePathLocation(l.currentLocation, location)
+	}
+
+	filePath, err := l.resolveImportFilepath(resolvedLoc, l.currentLocation)
+	if err != nil {
+		return defaultResolution, nil
+	}
+
+	exportedIdents := l.getExportedIdentifiers(filePath)
+	if len(exportedIdents) == 0 {
+		return defaultResolution, nil
+	}
+
+	return []sema.ResolvedLocation{{
+		Location:    location,
+		Identifiers: exportedIdents,
+	}}, nil
+}
+
+func (l *linter) getExportedIdentifiers(filePath string) []ast.Identifier {
+	if cached, ok := l.exportedIdentifiers[filePath]; ok {
+		return cached
+	}
+
+	code, err := l.state.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+
+	program, err := parser.ParseProgram(nil, code, parser.Config{})
+	if err != nil || program == nil {
+		return nil
+	}
+
+	identifiers := exportedIdentifiersFromProgram(program)
+	l.exportedIdentifiers[filePath] = identifiers
+	return identifiers
+}
+
+func exportedIdentifiersFromProgram(program *ast.Program) []ast.Identifier {
+	var identifiers []ast.Identifier
+	for _, decl := range program.CompositeDeclarations() {
+		identifiers = append(identifiers, decl.Identifier)
+	}
+	for _, decl := range program.InterfaceDeclarations() {
+		identifiers = append(identifiers, decl.Identifier)
+	}
+	return identifiers
 }
 
 // helpers

--- a/internal/cadence/linter.go
+++ b/internal/cadence/linter.go
@@ -553,11 +553,15 @@ func (l *linter) getExportedIdentifiers(filePath string) []ast.Identifier {
 
 func exportedIdentifiersFromProgram(program *ast.Program) []ast.Identifier {
 	var identifiers []ast.Identifier
-	for _, decl := range program.CompositeDeclarations() {
-		identifiers = append(identifiers, decl.Identifier)
-	}
-	for _, decl := range program.InterfaceDeclarations() {
-		identifiers = append(identifiers, decl.Identifier)
+	for _, decl := range program.Declarations() {
+		identifier := decl.DeclarationIdentifier()
+		if identifier == nil {
+			continue
+		}
+		if decl.DeclarationAccess() != ast.AccessAll {
+			continue
+		}
+		identifiers = append(identifiers, *identifier)
 	}
 	return identifiers
 }


### PR DESCRIPTION
## Problem

`flow cadence lint` never reported `unused-import-hint` diagnostics despite the `UnusedImportAnalyzer` being registered and running.

The Cadence sema checker populates `ImportDeclarationResolvedLocations` in its elaboration during type checking. Without a `LocationHandler`, implicit imports (`import "Foo"` or `import "./Foo.cdc"`) get an empty `Identifiers` slice in the resolved location. The `UnusedImportAnalyzer` iterates those identifiers to know what was imported — finding nothing, it never flags anything.

## Fix

Added `resolveLocation` as a `LocationHandler` in the sema checker config. For implicit imports it resolves the imported file and returns its exported declaration names as the resolved identifiers, giving the analyzer the data it needs.

- A `currentLocation` field on the linter tracks the file being checked, saved/restored around sub-checker calls in `handleImport` so nested imports resolve correctly.
- An `exportedIdentifiers` cache avoids re-parsing: `handleImport` pre-populates it from the already-parsed program before sub-checking.

## Known limitation

See: https://github.com/onflow/cadence-tools/pull/628

Imports used *only* in conformances (`resource Foo: Bar.Interface`) or entitlement access specifiers (`access(Bar.Entitlement)`) are false-positively flagged. Root cause: `UnusedImportAnalyzer` tracks usage via `ast.Inspector`, which relies on `Walk` — and `CompositeDeclaration.Walk` does not traverse `Conformances` or `Access`. Fix belongs in `onflow/cadence-tools` (`lint/unused_import_analyzer.go:98`). Tests for correct behavior are included and currently failing.
