### PR TITLE
fix: nil pointer panic in getDefaultInstallDir on containerized Linux

### DIFF
--- a/internal/settings/defaults.go
+++ b/internal/settings/defaults.go
@@ -20,7 +20,7 @@ package settings
 
 import (
 	"fmt"
-	"os/user"
+	"os"
 	"runtime"
 )
 
@@ -48,13 +48,19 @@ func getDefaultInstallDir() string {
 		return "/Applications"
 	case Windows:
 		// https://superuser.com/questions/1327037/what-choices-do-i-have-about-where-to-install-software-on-windows-10
-		usr, _ := user.Current() // safe to ignore cache errors
-		return fmt.Sprintf(`%s\AppData\Local\Programs`, usr.HomeDir)
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf(`%s\AppData\Local\Programs`, homeDir)
 	case Linux:
 		// https://unix.stackexchange.com/questions/127076/into-which-directory-should-i-install-programs-in-linux
-		usr, _ := user.Current() // safe to ignore cache errors
 		// Use path in users home folder to not require sudo permissions for installation
-		return fmt.Sprintf(`%s/.local/bin`, usr.HomeDir)
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf(`%s/.local/bin`, homeDir)
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

`flow` CLI panics immediately on startup with a nil pointer dereference in containerized Linux environments (Docker, CI runners, Kubernetes pods, etc.) where the running UID is not present in `/etc/passwd`.

## Root Cause

In `internal/settings/defaults.go`, `getDefaultInstallDir()` calls `user.Current()` from Go's `os/user` package to resolve the home directory:

```go
// Before (Linux branch)
usr, _ := user.Current() // safe to ignore cache errors
return fmt.Sprintf(`%s/.local/bin`, usr.HomeDir)
```

The comment "safe to ignore cache errors" is misleading and incorrect in this context. `user.Current()` can fail in two distinct ways:

1. **Cache/NSS errors** — a transient lookup failure where `usr` may still be partially populated. Ignoring these *might* be tolerable.
2. **UID not in `/etc/passwd`** — the process UID has no corresponding entry in the user database. In this case `user.Current()` returns `nil, err`. Ignoring the error and then accessing `usr.HomeDir` dereferences a nil pointer.

Because `getDefaultInstallDir()` is called during package `init()` (it's used as a map literal value in `defaults`), the panic fires before `main()` runs. There is no way to recover from it — `flow version`, `flow help`, and every other subcommand all crash identically.

### Why this is common

Containerized environments routinely run processes under UIDs that are not registered in `/etc/passwd`:

- Docker images built `FROM scratch` or minimal base images (`alpine`, `distroless`) often omit `/etc/passwd` entries for dynamically assigned UIDs
- Kubernetes `runAsUser` / `runAsNonRoot` security contexts frequently assign arbitrary UIDs
- CI systems (GitHub Actions, GitLab CI, BuildKit) sometimes run steps under UIDs injected at runtime that don't exist in the image's `/etc/passwd`
- The same issue applies to any `chroot` environment without a fully populated `/etc/passwd`

### Reproduction

```dockerfile
FROM ubuntu:22.04
COPY flow /usr/local/bin/flow
# Run as a UID that has no /etc/passwd entry
USER 12345
CMD ["flow", "version"]
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x1da23f0]

goroutine 1 [running]:
github.com/onflow/flow-cli/internal/settings.getDefaultInstallDir()
	/go/src/github.com/onflow/flow-cli/internal/settings/defaults.go:57 +0x20
github.com/onflow/flow-cli/internal/settings.init()
	/go/src/github.com/onflow/flow-cli/internal/settings/defaults.go:35 +0x70
```

## Fix

Replace `user.Current()` with `os.UserHomeDir()`, which is the idiomatic Go way to resolve the home directory. `os.UserHomeDir()` uses the following resolution order:

1. Calls `user.Current()` internally on most platforms
2. **Falls back to the `$HOME` environment variable** if the syscall lookup fails

This means it works correctly in all the environments where `user.Current()` panics, as long as `$HOME` is set (which it almost always is, even in minimal containers). If `$HOME` is also absent, it returns an error, which we handle gracefully by returning an empty string — a safe no-op rather than a crash.

The fix also removes the `os/user` import (now unused) and applies the same correction to the Windows branch, which has the identical vulnerability.

```go
// After (Linux branch)
homeDir, err := os.UserHomeDir()
if err != nil {
    return ""
}
return fmt.Sprintf(`%s/.local/bin`, homeDir)
```

## Impact

- **Before:** `flow` CLI is completely unusable in any containerized Linux environment where the process UID is not in `/etc/passwd`. Every command panics at startup.
- **After:** `flow` CLI starts correctly in all environments where `$HOME` is set, and fails gracefully (returns an empty default path) in the rare case where neither `/etc/passwd` nor `$HOME` is available.

## Testing

To verify the fix, build the CLI and run it inside a container with a synthetic UID:

```bash
docker run --rm -u 99999 -v $(which flow):/usr/local/bin/flow ubuntu:22.04 flow version
```

Before this fix: immediate panic. After: normal output.
